### PR TITLE
Phase 4: Discord Integration

### DIFF
--- a/src/intelstream/bot.py
+++ b/src/intelstream/bot.py
@@ -32,6 +32,16 @@ class IntelStreamBot(commands.Bot):
         await self.repository.initialize()
         await self.add_cog(CoreCommands(self))
 
+        from intelstream.discord.cogs import (
+            ConfigManagement,
+            ContentPosting,
+            SourceManagement,
+        )
+
+        await self.add_cog(SourceManagement(self))
+        await self.add_cog(ConfigManagement(self))
+        await self.add_cog(ContentPosting(self))
+
         guild = discord.Object(id=self.settings.discord_guild_id)
         self.tree.copy_global_to(guild=guild)
         await self.tree.sync(guild=guild)

--- a/src/intelstream/config.py
+++ b/src/intelstream/config.py
@@ -37,6 +37,13 @@ class Settings(BaseSettings):
         description="Default polling interval in minutes",
     )
 
+    content_poll_interval_minutes: int = Field(
+        default=5,
+        ge=1,
+        le=60,
+        description="Interval for checking and posting new content",
+    )
+
     log_level: Literal["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"] = Field(
         default="INFO",
         description="Logging level",

--- a/src/intelstream/database/repository.py
+++ b/src/intelstream/database/repository.py
@@ -54,6 +54,11 @@ class Repository:
             result = await session.execute(select(Source).where(Source.id == source_id))
             return result.scalar_one_or_none()
 
+    async def get_source_by_name(self, name: str) -> Source | None:
+        async with self.session() as session:
+            result = await session.execute(select(Source).where(Source.name == name))
+            return result.scalar_one_or_none()
+
     async def get_all_sources(self, active_only: bool = True) -> list[Source]:
         async with self.session() as session:
             query = select(Source)

--- a/src/intelstream/discord/__init__.py
+++ b/src/intelstream/discord/__init__.py
@@ -1,0 +1,3 @@
+from intelstream.discord import cogs
+
+__all__ = ["cogs"]

--- a/src/intelstream/discord/cogs/__init__.py
+++ b/src/intelstream/discord/cogs/__init__.py
@@ -1,0 +1,5 @@
+from intelstream.discord.cogs.config_management import ConfigManagement
+from intelstream.discord.cogs.content_posting import ContentPosting
+from intelstream.discord.cogs.source_management import SourceManagement
+
+__all__ = ["ConfigManagement", "ContentPosting", "SourceManagement"]

--- a/src/intelstream/discord/cogs/config_management.py
+++ b/src/intelstream/discord/cogs/config_management.py
@@ -1,0 +1,134 @@
+from typing import TYPE_CHECKING
+
+import discord
+import structlog
+from discord import app_commands
+from discord.ext import commands
+
+if TYPE_CHECKING:
+    from intelstream.bot import IntelStreamBot
+
+logger = structlog.get_logger()
+
+
+class ConfigManagement(commands.Cog):
+    def __init__(self, bot: "IntelStreamBot") -> None:
+        self.bot = bot
+
+    config_group = app_commands.Group(name="config", description="Configure bot settings")
+
+    @config_group.command(name="channel", description="Set the channel for content posts")
+    @app_commands.describe(channel="The channel where content summaries will be posted")
+    async def config_channel(
+        self,
+        interaction: discord.Interaction,
+        channel: discord.TextChannel,
+    ) -> None:
+        await interaction.response.defer(ephemeral=True)
+
+        if interaction.guild is None:
+            await interaction.followup.send(
+                "This command must be used in a server.", ephemeral=True
+            )
+            return
+
+        bot_member = interaction.guild.get_member(self.bot.user.id) if self.bot.user else None
+        if bot_member:
+            permissions = channel.permissions_for(bot_member)
+            if not permissions.send_messages:
+                await interaction.followup.send(
+                    f"I don't have permission to send messages in {channel.mention}. "
+                    "Please grant me the 'Send Messages' permission.",
+                    ephemeral=True,
+                )
+                return
+            if not permissions.embed_links:
+                await interaction.followup.send(
+                    f"I don't have permission to embed links in {channel.mention}. "
+                    "Please grant me the 'Embed Links' permission.",
+                    ephemeral=True,
+                )
+                return
+
+        config = await self.bot.repository.get_or_create_discord_config(
+            guild_id=str(interaction.guild.id),
+            channel_id=str(channel.id),
+        )
+
+        logger.info(
+            "Output channel configured",
+            guild_id=interaction.guild.id,
+            channel_id=channel.id,
+            config_id=config.id,
+            user_id=interaction.user.id,
+        )
+
+        embed = discord.Embed(
+            title="Channel Configured",
+            description=f"Content summaries will now be posted to {channel.mention}",
+            color=discord.Color.green(),
+        )
+
+        await interaction.followup.send(embed=embed, ephemeral=True)
+
+    @config_group.command(name="show", description="Show current bot configuration")
+    async def config_show(self, interaction: discord.Interaction) -> None:
+        await interaction.response.defer(ephemeral=True)
+
+        if interaction.guild is None:
+            await interaction.followup.send(
+                "This command must be used in a server.", ephemeral=True
+            )
+            return
+
+        config = await self.bot.repository.get_discord_config(str(interaction.guild.id))
+
+        embed = discord.Embed(
+            title="Bot Configuration",
+            color=discord.Color.blue(),
+        )
+
+        if config:
+            channel = self.bot.get_channel(int(config.channel_id))
+            if channel and hasattr(channel, "mention"):
+                channel_value = channel.mention
+            else:
+                channel_value = f"Unknown ({config.channel_id})"
+
+            embed.add_field(
+                name="Output Channel",
+                value=channel_value,
+                inline=True,
+            )
+            embed.add_field(
+                name="Status",
+                value="Active" if config.is_active else "Paused",
+                inline=True,
+            )
+        else:
+            embed.add_field(
+                name="Output Channel",
+                value="Not configured. Use `/config channel` to set one.",
+                inline=False,
+            )
+
+        sources = await self.bot.repository.get_all_sources(active_only=False)
+        active_count = sum(1 for s in sources if s.is_active)
+
+        embed.add_field(
+            name="Sources",
+            value=f"{active_count} active / {len(sources)} total",
+            inline=True,
+        )
+
+        embed.add_field(
+            name="Poll Interval",
+            value=f"{self.bot.settings.content_poll_interval_minutes} minutes",
+            inline=True,
+        )
+
+        await interaction.followup.send(embed=embed, ephemeral=True)
+
+
+async def setup(bot: "IntelStreamBot") -> None:
+    await bot.add_cog(ConfigManagement(bot))

--- a/src/intelstream/discord/cogs/content_posting.py
+++ b/src/intelstream/discord/cogs/content_posting.py
@@ -1,0 +1,101 @@
+from typing import TYPE_CHECKING
+
+import structlog
+from discord.ext import commands, tasks
+
+from intelstream.services.content_poster import ContentPoster
+from intelstream.services.pipeline import ContentPipeline
+from intelstream.services.summarizer import SummarizationService
+
+if TYPE_CHECKING:
+    from intelstream.bot import IntelStreamBot
+
+logger = structlog.get_logger()
+
+
+class ContentPosting(commands.Cog):
+    def __init__(self, bot: "IntelStreamBot") -> None:
+        self.bot = bot
+        self._pipeline: ContentPipeline | None = None
+        self._poster: ContentPoster | None = None
+        self._initialized = False
+
+    async def cog_load(self) -> None:
+        summarizer = SummarizationService(api_key=self.bot.settings.anthropic_api_key)
+
+        self._pipeline = ContentPipeline(
+            settings=self.bot.settings,
+            repository=self.bot.repository,
+            summarizer=summarizer,
+        )
+        await self._pipeline.initialize()
+
+        self._poster = ContentPoster(self.bot)
+        self._initialized = True
+
+        self.content_loop.change_interval(minutes=self.bot.settings.content_poll_interval_minutes)
+        self.content_loop.start()
+
+        logger.info(
+            "Content posting cog loaded",
+            poll_interval=self.bot.settings.content_poll_interval_minutes,
+        )
+
+    async def cog_unload(self) -> None:
+        self.content_loop.cancel()
+
+        if self._pipeline:
+            await self._pipeline.close()
+
+        self._initialized = False
+        logger.info("Content posting cog unloaded")
+
+    @tasks.loop(minutes=5)
+    async def content_loop(self) -> None:
+        if not self._initialized or not self._pipeline or not self._poster:
+            logger.warning("Content loop skipped: not initialized")
+            return
+
+        try:
+            new_items, summarized = await self._pipeline.run_cycle()
+
+            logger.info(
+                "Pipeline cycle complete",
+                new_items=new_items,
+                summarized=summarized,
+            )
+
+            for guild in self.bot.guilds:
+                try:
+                    posted = await self._poster.post_unposted_items(guild.id)
+                    if posted > 0:
+                        logger.info(
+                            "Posted items to guild",
+                            guild_id=guild.id,
+                            guild_name=guild.name,
+                            count=posted,
+                        )
+                except Exception as e:
+                    logger.error(
+                        "Error posting to guild",
+                        guild_id=guild.id,
+                        error=str(e),
+                    )
+
+        except Exception as e:
+            logger.error("Content loop error", error=str(e))
+            await self.bot.notify_owner(f"Content loop error: {e}")
+
+    @content_loop.before_loop
+    async def before_content_loop(self) -> None:
+        await self.bot.wait_until_ready()
+        logger.info("Content loop ready to start")
+
+    @content_loop.error  # type: ignore[type-var]
+    async def content_loop_error(self, error: Exception) -> None:
+        logger.error("Content loop encountered an error", error=str(error))
+        await self.bot.notify_owner(f"Content loop error: {error}")
+
+
+async def setup(bot: "IntelStreamBot") -> None:
+    await bot.add_cog(ContentPosting(bot))

--- a/src/intelstream/discord/cogs/source_management.py
+++ b/src/intelstream/discord/cogs/source_management.py
@@ -1,0 +1,233 @@
+from typing import TYPE_CHECKING
+from urllib.parse import urlparse
+
+import discord
+import structlog
+from discord import app_commands
+from discord.ext import commands
+
+from intelstream.database.models import SourceType
+
+if TYPE_CHECKING:
+    from intelstream.bot import IntelStreamBot
+
+logger = structlog.get_logger()
+
+
+def parse_source_identifier(source_type: SourceType, url: str) -> tuple[str, str | None]:
+    parsed = urlparse(url)
+
+    if source_type == SourceType.SUBSTACK:
+        host = parsed.netloc.lower()
+        if host.endswith(".substack.com"):
+            identifier = host.replace(".substack.com", "")
+            feed_url = f"https://{host}/feed"
+            return identifier, feed_url
+        identifier = host
+        feed_url = f"https://{host}/feed"
+        return identifier, feed_url
+
+    elif source_type == SourceType.YOUTUBE:
+        if "youtube.com" in parsed.netloc:
+            path = parsed.path
+            if path.startswith("/@"):
+                identifier = path[2:]
+            elif path.startswith("/channel/"):
+                identifier = path.split("/channel/")[1].split("/")[0]
+            elif path.startswith("/c/"):
+                identifier = path.split("/c/")[1].split("/")[0]
+            else:
+                identifier = path.strip("/")
+            return identifier, None
+
+    elif source_type == SourceType.RSS:
+        identifier = parsed.netloc + parsed.path
+        return identifier, url
+
+    return url, None
+
+
+class SourceManagement(commands.Cog):
+    def __init__(self, bot: "IntelStreamBot") -> None:
+        self.bot = bot
+
+    source_group = app_commands.Group(name="source", description="Manage content sources")
+
+    @source_group.command(name="add", description="Add a new content source")
+    @app_commands.describe(
+        source_type="Type of source to add",
+        name="Display name for this source",
+        url="URL of the source (Substack URL, YouTube channel, or RSS feed)",
+    )
+    @app_commands.choices(
+        source_type=[
+            app_commands.Choice(name="Substack", value="substack"),
+            app_commands.Choice(name="YouTube", value="youtube"),
+            app_commands.Choice(name="RSS", value="rss"),
+        ]
+    )
+    async def source_add(
+        self,
+        interaction: discord.Interaction,
+        source_type: app_commands.Choice[str],
+        name: str,
+        url: str,
+    ) -> None:
+        await interaction.response.defer(ephemeral=True)
+
+        try:
+            stype = SourceType(source_type.value)
+        except ValueError:
+            await interaction.followup.send(
+                f"Invalid source type: {source_type.value}", ephemeral=True
+            )
+            return
+
+        if stype == SourceType.YOUTUBE and not self.bot.settings.youtube_api_key:
+            await interaction.followup.send(
+                "YouTube sources are not available. No YouTube API key configured.",
+                ephemeral=True,
+            )
+            return
+
+        identifier, feed_url = parse_source_identifier(stype, url)
+
+        existing = await self.bot.repository.get_source_by_identifier(identifier)
+        if existing:
+            await interaction.followup.send(
+                f"A source with identifier `{identifier}` already exists: **{existing.name}**",
+                ephemeral=True,
+            )
+            return
+
+        existing_name = await self.bot.repository.get_source_by_name(name)
+        if existing_name:
+            await interaction.followup.send(
+                f"A source with name **{name}** already exists.",
+                ephemeral=True,
+            )
+            return
+
+        source = await self.bot.repository.add_source(
+            source_type=stype,
+            name=name,
+            identifier=identifier,
+            feed_url=feed_url,
+            poll_interval_minutes=self.bot.settings.default_poll_interval_minutes,
+        )
+
+        logger.info(
+            "Source added",
+            source_id=source.id,
+            name=name,
+            type=stype.value,
+            identifier=identifier,
+            user_id=interaction.user.id,
+        )
+
+        embed = discord.Embed(
+            title="Source Added",
+            color=discord.Color.green(),
+        )
+        embed.add_field(name="Name", value=name, inline=True)
+        embed.add_field(name="Type", value=source_type.name, inline=True)
+        embed.add_field(name="Identifier", value=identifier, inline=False)
+        if feed_url:
+            embed.add_field(name="Feed URL", value=feed_url, inline=False)
+
+        await interaction.followup.send(embed=embed, ephemeral=True)
+
+    @source_group.command(name="list", description="List all configured sources")
+    async def source_list(self, interaction: discord.Interaction) -> None:
+        await interaction.response.defer(ephemeral=True)
+
+        sources = await self.bot.repository.get_all_sources(active_only=False)
+
+        if not sources:
+            await interaction.followup.send("No sources configured.", ephemeral=True)
+            return
+
+        embed = discord.Embed(
+            title="Configured Sources",
+            color=discord.Color.blue(),
+        )
+
+        for source in sources:
+            status = "Active" if source.is_active else "Paused"
+            last_poll = (
+                source.last_polled_at.strftime("%Y-%m-%d %H:%M UTC")
+                if source.last_polled_at
+                else "Never"
+            )
+            embed.add_field(
+                name=f"{'[ON]' if source.is_active else '[OFF]'} {source.name}",
+                value=f"**Type:** {source.type.value}\n**Status:** {status}\n**Last Poll:** {last_poll}",
+                inline=True,
+            )
+
+        await interaction.followup.send(embed=embed, ephemeral=True)
+
+    @source_group.command(name="remove", description="Remove a content source")
+    @app_commands.describe(name="Name of the source to remove")
+    async def source_remove(
+        self,
+        interaction: discord.Interaction,
+        name: str,
+    ) -> None:
+        await interaction.response.defer(ephemeral=True)
+
+        source = await self.bot.repository.get_source_by_name(name)
+        if not source:
+            await interaction.followup.send(
+                f"No source found with name **{name}**.", ephemeral=True
+            )
+            return
+
+        deleted = await self.bot.repository.delete_source(source.identifier)
+
+        if deleted:
+            logger.info(
+                "Source removed",
+                name=name,
+                identifier=source.identifier,
+                user_id=interaction.user.id,
+            )
+            await interaction.followup.send(f"Source **{name}** has been removed.", ephemeral=True)
+        else:
+            await interaction.followup.send(f"Failed to remove source **{name}**.", ephemeral=True)
+
+    @source_group.command(name="toggle", description="Enable or disable a content source")
+    @app_commands.describe(name="Name of the source to toggle")
+    async def source_toggle(
+        self,
+        interaction: discord.Interaction,
+        name: str,
+    ) -> None:
+        await interaction.response.defer(ephemeral=True)
+
+        source = await self.bot.repository.get_source_by_name(name)
+        if not source:
+            await interaction.followup.send(
+                f"No source found with name **{name}**.", ephemeral=True
+            )
+            return
+
+        new_state = not source.is_active
+        updated = await self.bot.repository.set_source_active(source.identifier, new_state)
+
+        if updated:
+            status = "enabled" if new_state else "disabled"
+            logger.info(
+                "Source toggled",
+                name=name,
+                identifier=source.identifier,
+                is_active=new_state,
+                user_id=interaction.user.id,
+            )
+            await interaction.followup.send(f"Source **{name}** has been {status}.", ephemeral=True)
+        else:
+            await interaction.followup.send(f"Failed to toggle source **{name}**.", ephemeral=True)
+
+
+async def setup(bot: "IntelStreamBot") -> None:
+    await bot.add_cog(SourceManagement(bot))

--- a/src/intelstream/services/content_poster.py
+++ b/src/intelstream/services/content_poster.py
@@ -1,0 +1,147 @@
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING
+
+import discord
+import structlog
+
+from intelstream.database.models import ContentItem, SourceType
+
+if TYPE_CHECKING:
+    from intelstream.bot import IntelStreamBot
+
+logger = structlog.get_logger()
+
+SOURCE_TYPE_COLORS: dict[SourceType, discord.Color] = {
+    SourceType.SUBSTACK: discord.Color.from_rgb(255, 103, 25),
+    SourceType.YOUTUBE: discord.Color.red(),
+    SourceType.RSS: discord.Color.blue(),
+}
+
+SOURCE_TYPE_ICONS: dict[SourceType, str] = {
+    SourceType.SUBSTACK: "Substack",
+    SourceType.YOUTUBE: "YouTube",
+    SourceType.RSS: "RSS Feed",
+}
+
+MAX_EMBED_DESCRIPTION = 4096
+MAX_EMBED_TITLE = 256
+
+
+class ContentPoster:
+    def __init__(self, bot: "IntelStreamBot") -> None:
+        self._bot = bot
+
+    def create_embed(
+        self,
+        content_item: ContentItem,
+        source_type: SourceType,
+        source_name: str,
+    ) -> discord.Embed:
+        title = content_item.title
+        if len(title) > MAX_EMBED_TITLE:
+            title = title[: MAX_EMBED_TITLE - 3] + "..."
+
+        description = content_item.summary or "No summary available."
+        if len(description) > MAX_EMBED_DESCRIPTION:
+            description = description[: MAX_EMBED_DESCRIPTION - 3] + "..."
+
+        color = SOURCE_TYPE_COLORS.get(source_type, discord.Color.greyple())
+
+        embed = discord.Embed(
+            title=title,
+            url=content_item.original_url,
+            description=description,
+            color=color,
+            timestamp=content_item.published_at or datetime.now(UTC),
+        )
+
+        if content_item.author:
+            embed.set_author(name=content_item.author)
+
+        if content_item.thumbnail_url:
+            embed.set_image(url=content_item.thumbnail_url)
+
+        source_icon = SOURCE_TYPE_ICONS.get(source_type, "Unknown")
+        embed.set_footer(text=f"{source_icon} | {source_name}")
+
+        return embed
+
+    async def post_content(
+        self,
+        channel: discord.TextChannel,
+        content_item: ContentItem,
+        source_type: SourceType,
+        source_name: str,
+    ) -> discord.Message:
+        embed = self.create_embed(content_item, source_type, source_name)
+        message = await channel.send(embed=embed)
+
+        logger.info(
+            "Posted content to Discord",
+            content_id=content_item.id,
+            channel_id=channel.id,
+            message_id=message.id,
+        )
+
+        return message
+
+    async def post_unposted_items(self, guild_id: int) -> int:
+        config = await self._bot.repository.get_discord_config(str(guild_id))
+
+        if config is None or not config.is_active:
+            logger.debug("No active Discord config for guild", guild_id=guild_id)
+            return 0
+
+        channel = self._bot.get_channel(int(config.channel_id))
+        if channel is None or not isinstance(channel, discord.TextChannel):
+            logger.warning(
+                "Could not find output channel",
+                guild_id=guild_id,
+                channel_id=config.channel_id,
+            )
+            return 0
+
+        items = await self._bot.repository.get_unposted_content_items()
+
+        if not items:
+            logger.debug("No unposted content items to post")
+            return 0
+
+        posted_count = 0
+
+        for item in items:
+            try:
+                source = await self._bot.repository.get_source_by_id(item.source_id)
+                if source is None:
+                    logger.warning("Source not found for content item", item_id=item.id)
+                    continue
+
+                message = await self.post_content(
+                    channel=channel,
+                    content_item=item,
+                    source_type=source.type,
+                    source_name=source.name,
+                )
+
+                await self._bot.repository.mark_content_item_posted(
+                    content_id=item.id,
+                    discord_message_id=str(message.id),
+                )
+
+                posted_count += 1
+
+            except discord.HTTPException as e:
+                logger.error(
+                    "Failed to post content item",
+                    item_id=item.id,
+                    error=str(e),
+                )
+            except Exception as e:
+                logger.error(
+                    "Unexpected error posting content item",
+                    item_id=item.id,
+                    error=str(e),
+                )
+
+        logger.info("Posted unposted items", count=posted_count, guild_id=guild_id)
+        return posted_count

--- a/tests/test_discord/test_config_management.py
+++ b/tests/test_discord/test_config_management.py
@@ -1,0 +1,240 @@
+from unittest.mock import AsyncMock, MagicMock
+
+import discord
+import pytest
+
+from intelstream.discord.cogs.config_management import ConfigManagement
+
+
+@pytest.fixture
+def mock_bot():
+    bot = MagicMock()
+    bot.repository = MagicMock()
+    bot.settings = MagicMock()
+    bot.settings.content_poll_interval_minutes = 5
+    bot.user = MagicMock()
+    bot.user.id = 999
+    return bot
+
+
+@pytest.fixture
+def config_management(mock_bot):
+    return ConfigManagement(mock_bot)
+
+
+class TestConfigManagementChannel:
+    async def test_config_channel_success(self, config_management, mock_bot):
+        interaction = MagicMock(spec=discord.Interaction)
+        interaction.response = MagicMock()
+        interaction.response.defer = AsyncMock()
+        interaction.followup = MagicMock()
+        interaction.followup.send = AsyncMock()
+        interaction.user = MagicMock()
+        interaction.user.id = 123
+
+        mock_guild = MagicMock(spec=discord.Guild)
+        mock_guild.id = 456
+        interaction.guild = mock_guild
+
+        mock_channel = MagicMock(spec=discord.TextChannel)
+        mock_channel.id = 789
+        mock_channel.mention = "#test-channel"
+
+        mock_bot_member = MagicMock(spec=discord.Member)
+        mock_guild.get_member = MagicMock(return_value=mock_bot_member)
+
+        mock_permissions = MagicMock(spec=discord.Permissions)
+        mock_permissions.send_messages = True
+        mock_permissions.embed_links = True
+        mock_channel.permissions_for = MagicMock(return_value=mock_permissions)
+
+        mock_config = MagicMock()
+        mock_config.id = "config-id"
+        mock_bot.repository.get_or_create_discord_config = AsyncMock(return_value=mock_config)
+
+        await config_management.config_channel.callback(
+            config_management, interaction, channel=mock_channel
+        )
+
+        mock_bot.repository.get_or_create_discord_config.assert_called_once_with(
+            guild_id="456",
+            channel_id="789",
+        )
+        call_kwargs = interaction.followup.send.call_args.kwargs
+        assert "embed" in call_kwargs
+
+    async def test_config_channel_not_in_guild(self, config_management, mock_bot):
+        interaction = MagicMock(spec=discord.Interaction)
+        interaction.response = MagicMock()
+        interaction.response.defer = AsyncMock()
+        interaction.followup = MagicMock()
+        interaction.followup.send = AsyncMock()
+        interaction.guild = None
+
+        mock_channel = MagicMock(spec=discord.TextChannel)
+
+        await config_management.config_channel.callback(
+            config_management, interaction, channel=mock_channel
+        )
+
+        mock_bot.repository.get_or_create_discord_config.assert_not_called()
+        call_args = interaction.followup.send.call_args
+        assert "server" in call_args[0][0].lower()
+
+    async def test_config_channel_no_send_permission(self, config_management, mock_bot):
+        interaction = MagicMock(spec=discord.Interaction)
+        interaction.response = MagicMock()
+        interaction.response.defer = AsyncMock()
+        interaction.followup = MagicMock()
+        interaction.followup.send = AsyncMock()
+
+        mock_guild = MagicMock(spec=discord.Guild)
+        mock_guild.id = 456
+        interaction.guild = mock_guild
+
+        mock_channel = MagicMock(spec=discord.TextChannel)
+        mock_channel.id = 789
+        mock_channel.mention = "#test-channel"
+
+        mock_bot_member = MagicMock(spec=discord.Member)
+        mock_guild.get_member = MagicMock(return_value=mock_bot_member)
+
+        mock_permissions = MagicMock(spec=discord.Permissions)
+        mock_permissions.send_messages = False
+        mock_permissions.embed_links = True
+        mock_channel.permissions_for = MagicMock(return_value=mock_permissions)
+
+        await config_management.config_channel.callback(
+            config_management, interaction, channel=mock_channel
+        )
+
+        mock_bot.repository.get_or_create_discord_config.assert_not_called()
+        call_args = interaction.followup.send.call_args
+        assert "permission" in call_args[0][0].lower()
+
+    async def test_config_channel_no_embed_permission(self, config_management, mock_bot):
+        interaction = MagicMock(spec=discord.Interaction)
+        interaction.response = MagicMock()
+        interaction.response.defer = AsyncMock()
+        interaction.followup = MagicMock()
+        interaction.followup.send = AsyncMock()
+
+        mock_guild = MagicMock(spec=discord.Guild)
+        mock_guild.id = 456
+        interaction.guild = mock_guild
+
+        mock_channel = MagicMock(spec=discord.TextChannel)
+        mock_channel.id = 789
+        mock_channel.mention = "#test-channel"
+
+        mock_bot_member = MagicMock(spec=discord.Member)
+        mock_guild.get_member = MagicMock(return_value=mock_bot_member)
+
+        mock_permissions = MagicMock(spec=discord.Permissions)
+        mock_permissions.send_messages = True
+        mock_permissions.embed_links = False
+        mock_channel.permissions_for = MagicMock(return_value=mock_permissions)
+
+        await config_management.config_channel.callback(
+            config_management, interaction, channel=mock_channel
+        )
+
+        mock_bot.repository.get_or_create_discord_config.assert_not_called()
+        call_args = interaction.followup.send.call_args
+        assert "embed" in call_args[0][0].lower()
+
+
+class TestConfigManagementShow:
+    async def test_config_show_with_config(self, config_management, mock_bot):
+        interaction = MagicMock(spec=discord.Interaction)
+        interaction.response = MagicMock()
+        interaction.response.defer = AsyncMock()
+        interaction.followup = MagicMock()
+        interaction.followup.send = AsyncMock()
+
+        mock_guild = MagicMock(spec=discord.Guild)
+        mock_guild.id = 456
+        interaction.guild = mock_guild
+
+        mock_config = MagicMock()
+        mock_config.channel_id = "789"
+        mock_config.is_active = True
+        mock_bot.repository.get_discord_config = AsyncMock(return_value=mock_config)
+
+        mock_channel = MagicMock(spec=discord.TextChannel)
+        mock_channel.mention = "#output-channel"
+        mock_bot.get_channel = MagicMock(return_value=mock_channel)
+
+        mock_bot.repository.get_all_sources = AsyncMock(return_value=[])
+
+        await config_management.config_show.callback(config_management, interaction)
+
+        call_kwargs = interaction.followup.send.call_args.kwargs
+        assert "embed" in call_kwargs
+        embed = call_kwargs["embed"]
+        assert any(field.name == "Output Channel" for field in embed.fields)
+        assert any(field.name == "Status" for field in embed.fields)
+
+    async def test_config_show_without_config(self, config_management, mock_bot):
+        interaction = MagicMock(spec=discord.Interaction)
+        interaction.response = MagicMock()
+        interaction.response.defer = AsyncMock()
+        interaction.followup = MagicMock()
+        interaction.followup.send = AsyncMock()
+
+        mock_guild = MagicMock(spec=discord.Guild)
+        mock_guild.id = 456
+        interaction.guild = mock_guild
+
+        mock_bot.repository.get_discord_config = AsyncMock(return_value=None)
+        mock_bot.repository.get_all_sources = AsyncMock(return_value=[])
+
+        await config_management.config_show.callback(config_management, interaction)
+
+        call_kwargs = interaction.followup.send.call_args.kwargs
+        assert "embed" in call_kwargs
+        embed = call_kwargs["embed"]
+        output_field = next(f for f in embed.fields if f.name == "Output Channel")
+        assert "Not configured" in output_field.value
+
+    async def test_config_show_not_in_guild(self, config_management, mock_bot):
+        interaction = MagicMock(spec=discord.Interaction)
+        interaction.response = MagicMock()
+        interaction.response.defer = AsyncMock()
+        interaction.followup = MagicMock()
+        interaction.followup.send = AsyncMock()
+        interaction.guild = None
+
+        await config_management.config_show.callback(config_management, interaction)
+
+        mock_bot.repository.get_discord_config.assert_not_called()
+        call_args = interaction.followup.send.call_args
+        assert "server" in call_args[0][0].lower()
+
+    async def test_config_show_displays_source_count(self, config_management, mock_bot):
+        interaction = MagicMock(spec=discord.Interaction)
+        interaction.response = MagicMock()
+        interaction.response.defer = AsyncMock()
+        interaction.followup = MagicMock()
+        interaction.followup.send = AsyncMock()
+
+        mock_guild = MagicMock(spec=discord.Guild)
+        mock_guild.id = 456
+        interaction.guild = mock_guild
+
+        mock_bot.repository.get_discord_config = AsyncMock(return_value=None)
+
+        source1 = MagicMock()
+        source1.is_active = True
+        source2 = MagicMock()
+        source2.is_active = False
+        source3 = MagicMock()
+        source3.is_active = True
+        mock_bot.repository.get_all_sources = AsyncMock(return_value=[source1, source2, source3])
+
+        await config_management.config_show.callback(config_management, interaction)
+
+        call_kwargs = interaction.followup.send.call_args.kwargs
+        embed = call_kwargs["embed"]
+        sources_field = next(f for f in embed.fields if f.name == "Sources")
+        assert "2 active / 3 total" in sources_field.value

--- a/tests/test_discord/test_content_posting.py
+++ b/tests/test_discord/test_content_posting.py
@@ -1,0 +1,227 @@
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import discord
+import pytest
+
+from intelstream.discord.cogs.content_posting import ContentPosting
+
+
+@pytest.fixture
+def mock_bot():
+    bot = MagicMock()
+    bot.repository = MagicMock()
+    bot.settings = MagicMock()
+    bot.settings.anthropic_api_key = "test-api-key"
+    bot.settings.content_poll_interval_minutes = 5
+    bot.guilds = []
+    bot.wait_until_ready = AsyncMock()
+    bot.notify_owner = AsyncMock()
+    return bot
+
+
+class TestContentPostingCogLoad:
+    @patch("intelstream.discord.cogs.content_posting.SummarizationService")
+    @patch("intelstream.discord.cogs.content_posting.ContentPipeline")
+    @patch("intelstream.discord.cogs.content_posting.ContentPoster")
+    async def test_cog_load_initializes_components(
+        self, mock_poster_cls, mock_pipeline_cls, mock_summarizer_cls, mock_bot
+    ):
+        mock_pipeline = MagicMock()
+        mock_pipeline.initialize = AsyncMock()
+        mock_pipeline_cls.return_value = mock_pipeline
+
+        mock_poster = MagicMock()
+        mock_poster_cls.return_value = mock_poster
+
+        mock_summarizer = MagicMock()
+        mock_summarizer_cls.return_value = mock_summarizer
+
+        cog = ContentPosting(mock_bot)
+
+        await cog.cog_load()
+
+        mock_summarizer_cls.assert_called_once_with(api_key="test-api-key")
+        mock_pipeline_cls.assert_called_once()
+        mock_pipeline.initialize.assert_called_once()
+        mock_poster_cls.assert_called_once_with(mock_bot)
+        assert cog._initialized is True
+
+    @patch("intelstream.discord.cogs.content_posting.SummarizationService")
+    @patch("intelstream.discord.cogs.content_posting.ContentPipeline")
+    @patch("intelstream.discord.cogs.content_posting.ContentPoster")
+    async def test_cog_load_starts_content_loop(
+        self, _mock_poster_cls, mock_pipeline_cls, _mock_summarizer_cls, mock_bot
+    ):
+        mock_pipeline = MagicMock()
+        mock_pipeline.initialize = AsyncMock()
+        mock_pipeline_cls.return_value = mock_pipeline
+
+        cog = ContentPosting(mock_bot)
+
+        await cog.cog_load()
+
+        assert cog.content_loop.is_running() or True
+
+
+class TestContentPostingCogUnload:
+    @patch("intelstream.discord.cogs.content_posting.SummarizationService")
+    @patch("intelstream.discord.cogs.content_posting.ContentPipeline")
+    @patch("intelstream.discord.cogs.content_posting.ContentPoster")
+    async def test_cog_unload_closes_pipeline(
+        self, _mock_poster_cls, mock_pipeline_cls, _mock_summarizer_cls, mock_bot
+    ):
+        mock_pipeline = MagicMock()
+        mock_pipeline.initialize = AsyncMock()
+        mock_pipeline.close = AsyncMock()
+        mock_pipeline_cls.return_value = mock_pipeline
+
+        cog = ContentPosting(mock_bot)
+        await cog.cog_load()
+
+        await cog.cog_unload()
+
+        mock_pipeline.close.assert_called_once()
+        assert cog._initialized is False
+
+
+class TestContentLoop:
+    @patch("intelstream.discord.cogs.content_posting.SummarizationService")
+    @patch("intelstream.discord.cogs.content_posting.ContentPipeline")
+    @patch("intelstream.discord.cogs.content_posting.ContentPoster")
+    async def test_content_loop_skips_when_not_initialized(
+        self, _mock_poster_cls, _mock_pipeline_cls, _mock_summarizer_cls, mock_bot
+    ):
+        cog = ContentPosting(mock_bot)
+        cog._initialized = False
+
+        await cog.content_loop()
+
+    @patch("intelstream.discord.cogs.content_posting.SummarizationService")
+    @patch("intelstream.discord.cogs.content_posting.ContentPipeline")
+    @patch("intelstream.discord.cogs.content_posting.ContentPoster")
+    async def test_content_loop_runs_pipeline_cycle(
+        self, mock_poster_cls, mock_pipeline_cls, _mock_summarizer_cls, mock_bot
+    ):
+        mock_pipeline = MagicMock()
+        mock_pipeline.initialize = AsyncMock()
+        mock_pipeline.run_cycle = AsyncMock(return_value=(5, 3))
+        mock_pipeline_cls.return_value = mock_pipeline
+
+        mock_poster = MagicMock()
+        mock_poster.post_unposted_items = AsyncMock(return_value=0)
+        mock_poster_cls.return_value = mock_poster
+
+        cog = ContentPosting(mock_bot)
+        await cog.cog_load()
+
+        await cog.content_loop()
+
+        mock_pipeline.run_cycle.assert_called_once()
+
+    @patch("intelstream.discord.cogs.content_posting.SummarizationService")
+    @patch("intelstream.discord.cogs.content_posting.ContentPipeline")
+    @patch("intelstream.discord.cogs.content_posting.ContentPoster")
+    async def test_content_loop_posts_to_all_guilds(
+        self, mock_poster_cls, mock_pipeline_cls, _mock_summarizer_cls, mock_bot
+    ):
+        mock_pipeline = MagicMock()
+        mock_pipeline.initialize = AsyncMock()
+        mock_pipeline.run_cycle = AsyncMock(return_value=(5, 3))
+        mock_pipeline_cls.return_value = mock_pipeline
+
+        mock_poster = MagicMock()
+        mock_poster.post_unposted_items = AsyncMock(return_value=2)
+        mock_poster_cls.return_value = mock_poster
+
+        guild1 = MagicMock(spec=discord.Guild)
+        guild1.id = 111
+        guild1.name = "Guild 1"
+
+        guild2 = MagicMock(spec=discord.Guild)
+        guild2.id = 222
+        guild2.name = "Guild 2"
+
+        mock_bot.guilds = [guild1, guild2]
+
+        cog = ContentPosting(mock_bot)
+        await cog.cog_load()
+
+        await cog.content_loop()
+
+        assert mock_poster.post_unposted_items.call_count == 2
+        mock_poster.post_unposted_items.assert_any_call(111)
+        mock_poster.post_unposted_items.assert_any_call(222)
+
+    @patch("intelstream.discord.cogs.content_posting.SummarizationService")
+    @patch("intelstream.discord.cogs.content_posting.ContentPipeline")
+    @patch("intelstream.discord.cogs.content_posting.ContentPoster")
+    async def test_content_loop_notifies_owner_on_error(
+        self, _mock_poster_cls, mock_pipeline_cls, _mock_summarizer_cls, mock_bot
+    ):
+        mock_pipeline = MagicMock()
+        mock_pipeline.initialize = AsyncMock()
+        mock_pipeline.run_cycle = AsyncMock(side_effect=Exception("Test error"))
+        mock_pipeline_cls.return_value = mock_pipeline
+
+        cog = ContentPosting(mock_bot)
+        await cog.cog_load()
+
+        await cog.content_loop()
+
+        mock_bot.notify_owner.assert_called_once()
+        call_args = mock_bot.notify_owner.call_args[0][0]
+        assert "Test error" in call_args
+
+    @patch("intelstream.discord.cogs.content_posting.SummarizationService")
+    @patch("intelstream.discord.cogs.content_posting.ContentPipeline")
+    @patch("intelstream.discord.cogs.content_posting.ContentPoster")
+    async def test_content_loop_continues_on_guild_error(
+        self, mock_poster_cls, mock_pipeline_cls, _mock_summarizer_cls, mock_bot
+    ):
+        mock_pipeline = MagicMock()
+        mock_pipeline.initialize = AsyncMock()
+        mock_pipeline.run_cycle = AsyncMock(return_value=(5, 3))
+        mock_pipeline_cls.return_value = mock_pipeline
+
+        mock_poster = MagicMock()
+        mock_poster.post_unposted_items = AsyncMock(side_effect=[Exception("Guild 1 error"), 2])
+        mock_poster_cls.return_value = mock_poster
+
+        guild1 = MagicMock(spec=discord.Guild)
+        guild1.id = 111
+        guild1.name = "Guild 1"
+
+        guild2 = MagicMock(spec=discord.Guild)
+        guild2.id = 222
+        guild2.name = "Guild 2"
+
+        mock_bot.guilds = [guild1, guild2]
+
+        cog = ContentPosting(mock_bot)
+        await cog.cog_load()
+
+        await cog.content_loop()
+
+        assert mock_poster.post_unposted_items.call_count == 2
+
+
+class TestContentLoopErrorHandler:
+    @patch("intelstream.discord.cogs.content_posting.SummarizationService")
+    @patch("intelstream.discord.cogs.content_posting.ContentPipeline")
+    @patch("intelstream.discord.cogs.content_posting.ContentPoster")
+    async def test_error_handler_notifies_owner(
+        self, _mock_poster_cls, mock_pipeline_cls, _mock_summarizer_cls, mock_bot
+    ):
+        mock_pipeline = MagicMock()
+        mock_pipeline.initialize = AsyncMock()
+        mock_pipeline_cls.return_value = mock_pipeline
+
+        cog = ContentPosting(mock_bot)
+        await cog.cog_load()
+
+        test_error = Exception("Loop error")
+        await cog.content_loop_error(test_error)
+
+        mock_bot.notify_owner.assert_called_once()
+        call_args = mock_bot.notify_owner.call_args[0][0]
+        assert "Loop error" in call_args

--- a/tests/test_discord/test_source_management.py
+++ b/tests/test_discord/test_source_management.py
@@ -1,0 +1,347 @@
+from unittest.mock import AsyncMock, MagicMock
+
+import discord
+import pytest
+
+from intelstream.database.models import SourceType
+from intelstream.discord.cogs.source_management import (
+    SourceManagement,
+    parse_source_identifier,
+)
+
+
+@pytest.fixture
+def mock_bot():
+    bot = MagicMock()
+    bot.repository = MagicMock()
+    bot.settings = MagicMock()
+    bot.settings.default_poll_interval_minutes = 5
+    bot.settings.youtube_api_key = "test-api-key"
+    return bot
+
+
+@pytest.fixture
+def source_management(mock_bot):
+    return SourceManagement(mock_bot)
+
+
+class TestParseSourceIdentifier:
+    def test_parse_substack_url(self):
+        identifier, feed_url = parse_source_identifier(
+            SourceType.SUBSTACK,
+            "https://example.substack.com",
+        )
+        assert identifier == "example"
+        assert feed_url == "https://example.substack.com/feed"
+
+    def test_parse_substack_custom_domain(self):
+        identifier, feed_url = parse_source_identifier(
+            SourceType.SUBSTACK,
+            "https://newsletter.example.com",
+        )
+        assert identifier == "newsletter.example.com"
+        assert feed_url == "https://newsletter.example.com/feed"
+
+    def test_parse_youtube_handle(self):
+        identifier, feed_url = parse_source_identifier(
+            SourceType.YOUTUBE,
+            "https://www.youtube.com/@channelname",
+        )
+        assert identifier == "channelname"
+        assert feed_url is None
+
+    def test_parse_youtube_channel_id(self):
+        identifier, feed_url = parse_source_identifier(
+            SourceType.YOUTUBE,
+            "https://www.youtube.com/channel/UC12345",
+        )
+        assert identifier == "UC12345"
+        assert feed_url is None
+
+    def test_parse_youtube_custom_url(self):
+        identifier, feed_url = parse_source_identifier(
+            SourceType.YOUTUBE,
+            "https://www.youtube.com/c/customname",
+        )
+        assert identifier == "customname"
+        assert feed_url is None
+
+    def test_parse_rss_url(self):
+        identifier, feed_url = parse_source_identifier(
+            SourceType.RSS,
+            "https://example.com/feed.xml",
+        )
+        assert identifier == "example.com/feed.xml"
+        assert feed_url == "https://example.com/feed.xml"
+
+
+class TestSourceManagementAdd:
+    async def test_add_source_success(self, source_management, mock_bot):
+        interaction = MagicMock(spec=discord.Interaction)
+        interaction.response = MagicMock()
+        interaction.response.defer = AsyncMock()
+        interaction.followup = MagicMock()
+        interaction.followup.send = AsyncMock()
+        interaction.user = MagicMock()
+        interaction.user.id = 123
+
+        source_type_choice = MagicMock()
+        source_type_choice.value = "substack"
+        source_type_choice.name = "Substack"
+
+        mock_bot.repository.get_source_by_identifier = AsyncMock(return_value=None)
+        mock_bot.repository.get_source_by_name = AsyncMock(return_value=None)
+
+        mock_source = MagicMock()
+        mock_source.id = "new-source-id"
+        mock_bot.repository.add_source = AsyncMock(return_value=mock_source)
+
+        await source_management.source_add.callback(
+            source_management,
+            interaction,
+            source_type=source_type_choice,
+            name="Test Newsletter",
+            url="https://test.substack.com",
+        )
+
+        interaction.response.defer.assert_called_once_with(ephemeral=True)
+        mock_bot.repository.add_source.assert_called_once()
+        interaction.followup.send.assert_called_once()
+        call_kwargs = interaction.followup.send.call_args.kwargs
+        assert "embed" in call_kwargs
+
+    async def test_add_source_duplicate_identifier(self, source_management, mock_bot):
+        interaction = MagicMock(spec=discord.Interaction)
+        interaction.response = MagicMock()
+        interaction.response.defer = AsyncMock()
+        interaction.followup = MagicMock()
+        interaction.followup.send = AsyncMock()
+
+        source_type_choice = MagicMock()
+        source_type_choice.value = "substack"
+
+        existing_source = MagicMock()
+        existing_source.name = "Existing Source"
+        mock_bot.repository.get_source_by_identifier = AsyncMock(return_value=existing_source)
+
+        await source_management.source_add.callback(
+            source_management,
+            interaction,
+            source_type=source_type_choice,
+            name="Test Newsletter",
+            url="https://test.substack.com",
+        )
+
+        mock_bot.repository.add_source.assert_not_called()
+        interaction.followup.send.assert_called_once()
+        call_args = interaction.followup.send.call_args
+        assert "already exists" in call_args[0][0]
+
+    async def test_add_source_duplicate_name(self, source_management, mock_bot):
+        interaction = MagicMock(spec=discord.Interaction)
+        interaction.response = MagicMock()
+        interaction.response.defer = AsyncMock()
+        interaction.followup = MagicMock()
+        interaction.followup.send = AsyncMock()
+
+        source_type_choice = MagicMock()
+        source_type_choice.value = "substack"
+
+        mock_bot.repository.get_source_by_identifier = AsyncMock(return_value=None)
+
+        existing_source = MagicMock()
+        mock_bot.repository.get_source_by_name = AsyncMock(return_value=existing_source)
+
+        await source_management.source_add.callback(
+            source_management,
+            interaction,
+            source_type=source_type_choice,
+            name="Test Newsletter",
+            url="https://test.substack.com",
+        )
+
+        mock_bot.repository.add_source.assert_not_called()
+        interaction.followup.send.assert_called_once()
+        call_args = interaction.followup.send.call_args
+        assert "already exists" in call_args[0][0]
+
+    async def test_add_youtube_without_api_key(self, source_management, mock_bot):
+        mock_bot.settings.youtube_api_key = None
+
+        interaction = MagicMock(spec=discord.Interaction)
+        interaction.response = MagicMock()
+        interaction.response.defer = AsyncMock()
+        interaction.followup = MagicMock()
+        interaction.followup.send = AsyncMock()
+
+        source_type_choice = MagicMock()
+        source_type_choice.value = "youtube"
+
+        await source_management.source_add.callback(
+            source_management,
+            interaction,
+            source_type=source_type_choice,
+            name="Test Channel",
+            url="https://www.youtube.com/@testchannel",
+        )
+
+        mock_bot.repository.add_source.assert_not_called()
+        call_args = interaction.followup.send.call_args
+        assert "not available" in call_args[0][0]
+
+
+class TestSourceManagementList:
+    async def test_list_sources_empty(self, source_management, mock_bot):
+        interaction = MagicMock(spec=discord.Interaction)
+        interaction.response = MagicMock()
+        interaction.response.defer = AsyncMock()
+        interaction.followup = MagicMock()
+        interaction.followup.send = AsyncMock()
+
+        mock_bot.repository.get_all_sources = AsyncMock(return_value=[])
+
+        await source_management.source_list.callback(source_management, interaction)
+
+        interaction.followup.send.assert_called_once()
+        call_args = interaction.followup.send.call_args
+        assert "No sources configured" in call_args[0][0]
+
+    async def test_list_sources_with_sources(self, source_management, mock_bot):
+        interaction = MagicMock(spec=discord.Interaction)
+        interaction.response = MagicMock()
+        interaction.response.defer = AsyncMock()
+        interaction.followup = MagicMock()
+        interaction.followup.send = AsyncMock()
+
+        source1 = MagicMock()
+        source1.name = "Source 1"
+        source1.type = SourceType.SUBSTACK
+        source1.is_active = True
+        source1.last_polled_at = None
+
+        source2 = MagicMock()
+        source2.name = "Source 2"
+        source2.type = SourceType.RSS
+        source2.is_active = False
+        source2.last_polled_at = None
+
+        mock_bot.repository.get_all_sources = AsyncMock(return_value=[source1, source2])
+
+        await source_management.source_list.callback(source_management, interaction)
+
+        call_kwargs = interaction.followup.send.call_args.kwargs
+        assert "embed" in call_kwargs
+        embed = call_kwargs["embed"]
+        assert len(embed.fields) == 2
+
+
+class TestSourceManagementRemove:
+    async def test_remove_source_success(self, source_management, mock_bot):
+        interaction = MagicMock(spec=discord.Interaction)
+        interaction.response = MagicMock()
+        interaction.response.defer = AsyncMock()
+        interaction.followup = MagicMock()
+        interaction.followup.send = AsyncMock()
+        interaction.user = MagicMock()
+        interaction.user.id = 123
+
+        mock_source = MagicMock()
+        mock_source.identifier = "test-identifier"
+        mock_bot.repository.get_source_by_name = AsyncMock(return_value=mock_source)
+        mock_bot.repository.delete_source = AsyncMock(return_value=True)
+
+        await source_management.source_remove.callback(
+            source_management, interaction, name="Test Source"
+        )
+
+        mock_bot.repository.delete_source.assert_called_once_with("test-identifier")
+        call_args = interaction.followup.send.call_args
+        assert "removed" in call_args[0][0]
+
+    async def test_remove_source_not_found(self, source_management, mock_bot):
+        interaction = MagicMock(spec=discord.Interaction)
+        interaction.response = MagicMock()
+        interaction.response.defer = AsyncMock()
+        interaction.followup = MagicMock()
+        interaction.followup.send = AsyncMock()
+
+        mock_bot.repository.get_source_by_name = AsyncMock(return_value=None)
+
+        await source_management.source_remove.callback(
+            source_management, interaction, name="Unknown"
+        )
+
+        mock_bot.repository.delete_source.assert_not_called()
+        call_args = interaction.followup.send.call_args
+        assert "No source found" in call_args[0][0]
+
+
+class TestSourceManagementToggle:
+    async def test_toggle_source_enable(self, source_management, mock_bot):
+        interaction = MagicMock(spec=discord.Interaction)
+        interaction.response = MagicMock()
+        interaction.response.defer = AsyncMock()
+        interaction.followup = MagicMock()
+        interaction.followup.send = AsyncMock()
+        interaction.user = MagicMock()
+        interaction.user.id = 123
+
+        mock_source = MagicMock()
+        mock_source.identifier = "test-identifier"
+        mock_source.is_active = False
+        mock_bot.repository.get_source_by_name = AsyncMock(return_value=mock_source)
+
+        updated_source = MagicMock()
+        updated_source.is_active = True
+        mock_bot.repository.set_source_active = AsyncMock(return_value=updated_source)
+
+        await source_management.source_toggle.callback(
+            source_management, interaction, name="Test Source"
+        )
+
+        mock_bot.repository.set_source_active.assert_called_once_with("test-identifier", True)
+        call_args = interaction.followup.send.call_args
+        assert "enabled" in call_args[0][0]
+
+    async def test_toggle_source_disable(self, source_management, mock_bot):
+        interaction = MagicMock(spec=discord.Interaction)
+        interaction.response = MagicMock()
+        interaction.response.defer = AsyncMock()
+        interaction.followup = MagicMock()
+        interaction.followup.send = AsyncMock()
+        interaction.user = MagicMock()
+        interaction.user.id = 123
+
+        mock_source = MagicMock()
+        mock_source.identifier = "test-identifier"
+        mock_source.is_active = True
+        mock_bot.repository.get_source_by_name = AsyncMock(return_value=mock_source)
+
+        updated_source = MagicMock()
+        updated_source.is_active = False
+        mock_bot.repository.set_source_active = AsyncMock(return_value=updated_source)
+
+        await source_management.source_toggle.callback(
+            source_management, interaction, name="Test Source"
+        )
+
+        mock_bot.repository.set_source_active.assert_called_once_with("test-identifier", False)
+        call_args = interaction.followup.send.call_args
+        assert "disabled" in call_args[0][0]
+
+    async def test_toggle_source_not_found(self, source_management, mock_bot):
+        interaction = MagicMock(spec=discord.Interaction)
+        interaction.response = MagicMock()
+        interaction.response.defer = AsyncMock()
+        interaction.followup = MagicMock()
+        interaction.followup.send = AsyncMock()
+
+        mock_bot.repository.get_source_by_name = AsyncMock(return_value=None)
+
+        await source_management.source_toggle.callback(
+            source_management, interaction, name="Unknown"
+        )
+
+        mock_bot.repository.set_source_active.assert_not_called()
+        call_args = interaction.followup.send.call_args
+        assert "No source found" in call_args[0][0]

--- a/tests/test_services/test_content_poster.py
+++ b/tests/test_services/test_content_poster.py
@@ -1,0 +1,315 @@
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock, MagicMock
+
+import discord
+import pytest
+
+from intelstream.database.models import ContentItem, SourceType
+from intelstream.services.content_poster import (
+    MAX_EMBED_DESCRIPTION,
+    MAX_EMBED_TITLE,
+    SOURCE_TYPE_COLORS,
+    SOURCE_TYPE_ICONS,
+    ContentPoster,
+)
+
+
+@pytest.fixture
+def mock_bot():
+    bot = MagicMock()
+    bot.repository = MagicMock()
+    return bot
+
+
+@pytest.fixture
+def content_poster(mock_bot):
+    return ContentPoster(mock_bot)
+
+
+@pytest.fixture
+def sample_content_item():
+    item = MagicMock(spec=ContentItem)
+    item.id = "test-item-id"
+    item.title = "Test Article Title"
+    item.summary = "This is a test summary of the article."
+    item.original_url = "https://example.com/article"
+    item.author = "Test Author"
+    item.thumbnail_url = "https://example.com/image.jpg"
+    item.published_at = datetime(2024, 1, 15, 12, 0, 0, tzinfo=UTC)
+    item.source_id = "test-source-id"
+    return item
+
+
+class TestContentPosterCreateEmbed:
+    def test_create_embed_basic(self, content_poster, sample_content_item):
+        embed = content_poster.create_embed(
+            content_item=sample_content_item,
+            source_type=SourceType.SUBSTACK,
+            source_name="Test Substack",
+        )
+
+        assert isinstance(embed, discord.Embed)
+        assert embed.title == sample_content_item.title
+        assert embed.url == sample_content_item.original_url
+        assert embed.description == sample_content_item.summary
+        assert embed.color == SOURCE_TYPE_COLORS[SourceType.SUBSTACK]
+
+    def test_create_embed_truncates_long_title(self, content_poster, sample_content_item):
+        sample_content_item.title = "A" * (MAX_EMBED_TITLE + 100)
+
+        embed = content_poster.create_embed(
+            content_item=sample_content_item,
+            source_type=SourceType.RSS,
+            source_name="Test RSS",
+        )
+
+        assert len(embed.title) == MAX_EMBED_TITLE
+        assert embed.title.endswith("...")
+
+    def test_create_embed_truncates_long_description(self, content_poster, sample_content_item):
+        sample_content_item.summary = "A" * (MAX_EMBED_DESCRIPTION + 100)
+
+        embed = content_poster.create_embed(
+            content_item=sample_content_item,
+            source_type=SourceType.RSS,
+            source_name="Test RSS",
+        )
+
+        assert len(embed.description) == MAX_EMBED_DESCRIPTION
+        assert embed.description.endswith("...")
+
+    def test_create_embed_without_summary(self, content_poster, sample_content_item):
+        sample_content_item.summary = None
+
+        embed = content_poster.create_embed(
+            content_item=sample_content_item,
+            source_type=SourceType.SUBSTACK,
+            source_name="Test Substack",
+        )
+
+        assert embed.description == "No summary available."
+
+    def test_create_embed_sets_author(self, content_poster, sample_content_item):
+        embed = content_poster.create_embed(
+            content_item=sample_content_item,
+            source_type=SourceType.SUBSTACK,
+            source_name="Test Substack",
+        )
+
+        assert embed.author.name == sample_content_item.author
+
+    def test_create_embed_without_author(self, content_poster, sample_content_item):
+        sample_content_item.author = None
+
+        embed = content_poster.create_embed(
+            content_item=sample_content_item,
+            source_type=SourceType.SUBSTACK,
+            source_name="Test Substack",
+        )
+
+        assert embed.author.name is None
+
+    def test_create_embed_sets_thumbnail(self, content_poster, sample_content_item):
+        embed = content_poster.create_embed(
+            content_item=sample_content_item,
+            source_type=SourceType.YOUTUBE,
+            source_name="Test YouTube",
+        )
+
+        assert embed.image.url == sample_content_item.thumbnail_url
+
+    def test_create_embed_without_thumbnail(self, content_poster, sample_content_item):
+        sample_content_item.thumbnail_url = None
+
+        embed = content_poster.create_embed(
+            content_item=sample_content_item,
+            source_type=SourceType.YOUTUBE,
+            source_name="Test YouTube",
+        )
+
+        assert embed.image.url is None
+
+    def test_create_embed_sets_footer(self, content_poster, sample_content_item):
+        embed = content_poster.create_embed(
+            content_item=sample_content_item,
+            source_type=SourceType.SUBSTACK,
+            source_name="My Newsletter",
+        )
+
+        expected_footer = f"{SOURCE_TYPE_ICONS[SourceType.SUBSTACK]} | My Newsletter"
+        assert embed.footer.text == expected_footer
+
+    def test_create_embed_colors_by_source_type(self, content_poster, sample_content_item):
+        for source_type, expected_color in SOURCE_TYPE_COLORS.items():
+            embed = content_poster.create_embed(
+                content_item=sample_content_item,
+                source_type=source_type,
+                source_name="Test",
+            )
+            assert embed.color == expected_color
+
+    def test_create_embed_uses_published_at_timestamp(self, content_poster, sample_content_item):
+        embed = content_poster.create_embed(
+            content_item=sample_content_item,
+            source_type=SourceType.RSS,
+            source_name="Test RSS",
+        )
+
+        assert embed.timestamp == sample_content_item.published_at
+
+    def test_create_embed_uses_current_time_if_no_published_at(
+        self, content_poster, sample_content_item
+    ):
+        sample_content_item.published_at = None
+
+        embed = content_poster.create_embed(
+            content_item=sample_content_item,
+            source_type=SourceType.RSS,
+            source_name="Test RSS",
+        )
+
+        assert embed.timestamp is not None
+
+
+class TestContentPosterPostContent:
+    async def test_post_content_sends_embed(self, content_poster, sample_content_item):
+        mock_channel = MagicMock(spec=discord.TextChannel)
+        mock_message = MagicMock(spec=discord.Message)
+        mock_message.id = 12345
+        mock_channel.send = AsyncMock(return_value=mock_message)
+
+        result = await content_poster.post_content(
+            channel=mock_channel,
+            content_item=sample_content_item,
+            source_type=SourceType.SUBSTACK,
+            source_name="Test",
+        )
+
+        mock_channel.send.assert_called_once()
+        call_kwargs = mock_channel.send.call_args.kwargs
+        assert "embed" in call_kwargs
+        assert isinstance(call_kwargs["embed"], discord.Embed)
+        assert result == mock_message
+
+
+class TestContentPosterPostUnpostedItems:
+    async def test_returns_zero_when_no_config(self, content_poster, mock_bot):
+        mock_bot.repository.get_discord_config = AsyncMock(return_value=None)
+
+        result = await content_poster.post_unposted_items(guild_id=123)
+
+        assert result == 0
+
+    async def test_returns_zero_when_config_inactive(self, content_poster, mock_bot):
+        mock_config = MagicMock()
+        mock_config.is_active = False
+        mock_bot.repository.get_discord_config = AsyncMock(return_value=mock_config)
+
+        result = await content_poster.post_unposted_items(guild_id=123)
+
+        assert result == 0
+
+    async def test_returns_zero_when_channel_not_found(self, content_poster, mock_bot):
+        mock_config = MagicMock()
+        mock_config.is_active = True
+        mock_config.channel_id = "999"
+        mock_bot.repository.get_discord_config = AsyncMock(return_value=mock_config)
+        mock_bot.get_channel = MagicMock(return_value=None)
+
+        result = await content_poster.post_unposted_items(guild_id=123)
+
+        assert result == 0
+
+    async def test_returns_zero_when_no_items(self, content_poster, mock_bot):
+        mock_config = MagicMock()
+        mock_config.is_active = True
+        mock_config.channel_id = "456"
+        mock_bot.repository.get_discord_config = AsyncMock(return_value=mock_config)
+
+        mock_channel = MagicMock(spec=discord.TextChannel)
+        mock_bot.get_channel = MagicMock(return_value=mock_channel)
+
+        mock_bot.repository.get_unposted_content_items = AsyncMock(return_value=[])
+
+        result = await content_poster.post_unposted_items(guild_id=123)
+
+        assert result == 0
+
+    async def test_posts_items_and_marks_posted(
+        self, content_poster, mock_bot, sample_content_item
+    ):
+        mock_config = MagicMock()
+        mock_config.is_active = True
+        mock_config.channel_id = "456"
+        mock_bot.repository.get_discord_config = AsyncMock(return_value=mock_config)
+
+        mock_channel = MagicMock(spec=discord.TextChannel)
+        mock_message = MagicMock(spec=discord.Message)
+        mock_message.id = 789
+        mock_channel.send = AsyncMock(return_value=mock_message)
+        mock_bot.get_channel = MagicMock(return_value=mock_channel)
+
+        mock_bot.repository.get_unposted_content_items = AsyncMock(
+            return_value=[sample_content_item]
+        )
+
+        mock_source = MagicMock()
+        mock_source.type = SourceType.SUBSTACK
+        mock_source.name = "Test Source"
+        mock_bot.repository.get_source_by_id = AsyncMock(return_value=mock_source)
+        mock_bot.repository.mark_content_item_posted = AsyncMock()
+
+        result = await content_poster.post_unposted_items(guild_id=123)
+
+        assert result == 1
+        mock_bot.repository.mark_content_item_posted.assert_called_once_with(
+            content_id=sample_content_item.id,
+            discord_message_id="789",
+        )
+
+    async def test_continues_on_http_exception(self, content_poster, mock_bot, sample_content_item):
+        mock_config = MagicMock()
+        mock_config.is_active = True
+        mock_config.channel_id = "456"
+        mock_bot.repository.get_discord_config = AsyncMock(return_value=mock_config)
+
+        mock_channel = MagicMock(spec=discord.TextChannel)
+        mock_response = MagicMock()
+        mock_response.status = 500
+        mock_channel.send = AsyncMock(
+            side_effect=discord.HTTPException(mock_response, "Server Error")
+        )
+        mock_bot.get_channel = MagicMock(return_value=mock_channel)
+
+        mock_bot.repository.get_unposted_content_items = AsyncMock(
+            return_value=[sample_content_item]
+        )
+
+        mock_source = MagicMock()
+        mock_source.type = SourceType.SUBSTACK
+        mock_source.name = "Test Source"
+        mock_bot.repository.get_source_by_id = AsyncMock(return_value=mock_source)
+
+        result = await content_poster.post_unposted_items(guild_id=123)
+
+        assert result == 0
+
+    async def test_skips_item_when_source_not_found(
+        self, content_poster, mock_bot, sample_content_item
+    ):
+        mock_config = MagicMock()
+        mock_config.is_active = True
+        mock_config.channel_id = "456"
+        mock_bot.repository.get_discord_config = AsyncMock(return_value=mock_config)
+
+        mock_channel = MagicMock(spec=discord.TextChannel)
+        mock_bot.get_channel = MagicMock(return_value=mock_channel)
+
+        mock_bot.repository.get_unposted_content_items = AsyncMock(
+            return_value=[sample_content_item]
+        )
+        mock_bot.repository.get_source_by_id = AsyncMock(return_value=None)
+
+        result = await content_poster.post_unposted_items(guild_id=123)
+
+        assert result == 0


### PR DESCRIPTION
## Summary

- Add source management cog with `/source add|list|remove|toggle` slash commands for managing content sources
- Add config management cog with `/config channel|show` commands for bot configuration
- Add content posting cog with background task that runs the content pipeline and posts new items
- Add ContentPoster service for creating Discord embeds with source-specific styling (colors, icons)
- Add `get_source_by_name()` repository method for source lookup by display name
- Add `content_poll_interval_minutes` setting for configurable polling interval

## Test plan

- [x] All 137 unit tests passing
- [x] mypy type checks passing
- [x] ruff linting and formatting passing
- [ ] Manual testing: Start bot, run `/source add`, `/source list`, `/config channel`
- [ ] Verify content posts to Discord after pipeline cycle