### PR TITLE
Add Smart Page Adapter for non-RSS blog sites

### DIFF
--- a/src/intelstream/adapters/__init__.py
+++ b/src/intelstream/adapters/__init__.py
@@ -1,4 +1,5 @@
 from intelstream.adapters.base import BaseAdapter, ContentData
+from intelstream.adapters.page import PageAdapter
 from intelstream.adapters.rss import RSSAdapter
 from intelstream.adapters.substack import SubstackAdapter
 from intelstream.adapters.youtube import YouTubeAdapter
@@ -6,6 +7,7 @@ from intelstream.adapters.youtube import YouTubeAdapter
 __all__ = [
     "BaseAdapter",
     "ContentData",
+    "PageAdapter",
     "RSSAdapter",
     "SubstackAdapter",
     "YouTubeAdapter",

--- a/src/intelstream/adapters/page.py
+++ b/src/intelstream/adapters/page.py
@@ -1,0 +1,204 @@
+import contextlib
+import re
+from datetime import UTC, datetime
+from urllib.parse import urljoin
+
+import httpx
+import structlog
+from bs4 import BeautifulSoup, Tag
+
+from intelstream.adapters.base import BaseAdapter, ContentData
+from intelstream.services.page_analyzer import ExtractionProfile
+
+logger = structlog.get_logger()
+
+
+class PageAdapter(BaseAdapter):
+    def __init__(
+        self,
+        extraction_profile: ExtractionProfile,
+        http_client: httpx.AsyncClient | None = None,
+    ) -> None:
+        self._profile = extraction_profile
+        self._client = http_client
+
+    @property
+    def source_type(self) -> str:
+        return "page"
+
+    async def get_feed_url(self, identifier: str) -> str:
+        return identifier
+
+    async def fetch_latest(
+        self,
+        identifier: str,
+        feed_url: str | None = None,
+        max_results: int = 20,
+    ) -> list[ContentData]:
+        url = feed_url or identifier
+
+        logger.debug(
+            "Fetching page content",
+            url=url,
+            site_name=self._profile.site_name,
+        )
+
+        try:
+            html = await self._fetch_html(url)
+            items = self._extract_posts(html, url)
+
+            if max_results:
+                items = items[:max_results]
+
+            logger.info(
+                "Fetched page content",
+                url=url,
+                site_name=self._profile.site_name,
+                count=len(items),
+            )
+
+            return items
+
+        except httpx.HTTPStatusError as e:
+            logger.error(
+                "HTTP error fetching page",
+                url=url,
+                status_code=e.response.status_code,
+            )
+            raise
+        except httpx.RequestError as e:
+            logger.error("Request error fetching page", url=url, error=str(e))
+            raise
+
+    async def _fetch_html(self, url: str) -> str:
+        headers = {
+            "User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36"
+        }
+
+        if self._client:
+            response = await self._client.get(url, headers=headers, follow_redirects=True)
+        else:
+            async with httpx.AsyncClient(timeout=30.0) as client:
+                response = await client.get(url, headers=headers, follow_redirects=True)
+
+        response.raise_for_status()
+        return response.text
+
+    def _extract_posts(self, html: str, page_url: str) -> list[ContentData]:
+        soup = BeautifulSoup(html, "lxml")
+        posts = soup.select(self._profile.post_selector)
+
+        items: list[ContentData] = []
+        base_url = self._profile.base_url or page_url
+
+        for post in posts:
+            try:
+                item = self._parse_post(post, base_url)
+                if item:
+                    items.append(item)
+            except Exception as e:
+                logger.warning(
+                    "Failed to parse post element",
+                    site_name=self._profile.site_name,
+                    error=str(e),
+                )
+                continue
+
+        return items
+
+    def _parse_post(self, post: Tag, base_url: str) -> ContentData | None:
+        title_elem = post.select_one(self._profile.title_selector)
+        if not title_elem:
+            return None
+
+        title = title_elem.get_text(strip=True)
+        if not title:
+            return None
+
+        url_elem = post.select_one(self._profile.url_selector)
+        if not url_elem:
+            return None
+
+        url_value = url_elem.get(self._profile.url_attribute)
+        if not url_value:
+            return None
+
+        original_url = str(url_value)
+        if not original_url.startswith(("http://", "https://")):
+            original_url = urljoin(base_url, original_url)
+
+        external_id = original_url
+
+        published_at = self._extract_date(post)
+        author = self._extract_author(post)
+
+        return ContentData(
+            external_id=external_id,
+            title=title,
+            original_url=original_url,
+            author=author or self._profile.site_name,
+            published_at=published_at,
+            raw_content=None,
+            thumbnail_url=None,
+        )
+
+    def _extract_date(self, post: Tag) -> datetime:
+        if not self._profile.date_selector:
+            return datetime.now(UTC)
+
+        date_elem = post.select_one(self._profile.date_selector)
+        if not date_elem:
+            return datetime.now(UTC)
+
+        date_str: str | None = None
+        if self._profile.date_attribute:
+            attr_value = date_elem.get(self._profile.date_attribute)
+            if attr_value:
+                date_str = str(attr_value)
+        else:
+            date_str = date_elem.get_text(strip=True)
+
+        if not date_str:
+            return datetime.now(UTC)
+
+        return self._parse_date_string(date_str)
+
+    def _parse_date_string(self, date_str: str) -> datetime:
+        date_str = date_str.replace("Z", "+00:00")
+
+        with contextlib.suppress(ValueError):
+            return datetime.fromisoformat(date_str)
+
+        date_formats = [
+            "%Y-%m-%d",
+            "%B %d, %Y",
+            "%b %d, %Y",
+            "%d %B %Y",
+            "%d %b %Y",
+            "%m/%d/%Y",
+            "%d/%m/%Y",
+        ]
+
+        for fmt in date_formats:
+            with contextlib.suppress(ValueError):
+                dt = datetime.strptime(date_str, fmt)
+                return dt.replace(tzinfo=UTC)
+
+        date_match = re.search(r"(\w+)\s+(\d{1,2}),?\s+(\d{4})", date_str)
+        if date_match:
+            with contextlib.suppress(ValueError):
+                month_str, day, year = date_match.groups()
+                parsed = datetime.strptime(f"{month_str} {day}, {year}", "%B %d, %Y")
+                return parsed.replace(tzinfo=UTC)
+
+        return datetime.now(UTC)
+
+    def _extract_author(self, post: Tag) -> str | None:
+        if not self._profile.author_selector:
+            return None
+
+        author_elem = post.select_one(self._profile.author_selector)
+        if not author_elem:
+            return None
+
+        return author_elem.get_text(strip=True) or None

--- a/src/intelstream/services/__init__.py
+++ b/src/intelstream/services/__init__.py
@@ -1,4 +1,16 @@
+from intelstream.services.page_analyzer import (
+    ExtractionProfile,
+    PageAnalysisError,
+    PageAnalyzer,
+)
 from intelstream.services.pipeline import ContentPipeline
 from intelstream.services.summarizer import SummarizationError, SummarizationService
 
-__all__ = ["ContentPipeline", "SummarizationError", "SummarizationService"]
+__all__ = [
+    "ContentPipeline",
+    "ExtractionProfile",
+    "PageAnalysisError",
+    "PageAnalyzer",
+    "SummarizationError",
+    "SummarizationService",
+]

--- a/src/intelstream/services/page_analyzer.py
+++ b/src/intelstream/services/page_analyzer.py
@@ -1,0 +1,264 @@
+import json
+import re
+from dataclasses import dataclass
+from typing import Any
+
+import anthropic
+import httpx
+import structlog
+from bs4 import BeautifulSoup
+from tenacity import (
+    retry,
+    retry_if_exception_type,
+    stop_after_attempt,
+    wait_exponential,
+)
+
+logger = structlog.get_logger()
+
+DEFAULT_MODEL = "claude-sonnet-4-20250514"
+MAX_HTML_LENGTH = 50000
+
+
+@dataclass
+class ExtractionProfile:
+    site_name: str
+    post_selector: str
+    title_selector: str
+    url_selector: str
+    url_attribute: str
+    date_selector: str | None = None
+    date_attribute: str | None = None
+    author_selector: str | None = None
+    base_url: str | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "site_name": self.site_name,
+            "post_selector": self.post_selector,
+            "title_selector": self.title_selector,
+            "url_selector": self.url_selector,
+            "url_attribute": self.url_attribute,
+            "date_selector": self.date_selector,
+            "date_attribute": self.date_attribute,
+            "author_selector": self.author_selector,
+            "base_url": self.base_url,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> "ExtractionProfile":
+        return cls(
+            site_name=data["site_name"],
+            post_selector=data["post_selector"],
+            title_selector=data["title_selector"],
+            url_selector=data["url_selector"],
+            url_attribute=data["url_attribute"],
+            date_selector=data.get("date_selector"),
+            date_attribute=data.get("date_attribute"),
+            author_selector=data.get("author_selector"),
+            base_url=data.get("base_url"),
+        )
+
+
+class PageAnalysisError(Exception):
+    pass
+
+
+ANALYSIS_SYSTEM_PROMPT = """You are an expert web scraper that analyzes HTML to identify blog post/article listing patterns.
+
+Your task is to examine the provided HTML and determine CSS selectors that can be used to extract blog posts or articles from the page.
+
+You must respond with ONLY a valid JSON object (no markdown, no explanation) with these fields:
+- site_name: A human-readable name for the site
+- post_selector: CSS selector for the container element of each post/article
+- title_selector: CSS selector for the title WITHIN each post container (relative to post_selector)
+- url_selector: CSS selector for the link element WITHIN each post container (relative to post_selector)
+- url_attribute: The attribute containing the URL (usually "href")
+- date_selector: CSS selector for the date element (relative to post_selector), or null if not found
+- date_attribute: The attribute containing the date (e.g., "datetime"), or null if date is in text content
+- author_selector: CSS selector for the author (relative to post_selector), or null if not found
+- base_url: The base URL for resolving relative links
+
+Example response:
+{"site_name": "Anthropic Research", "post_selector": "article.post-card", "title_selector": "h3.title", "url_selector": "a.post-link", "url_attribute": "href", "date_selector": "time", "date_attribute": "datetime", "author_selector": null, "base_url": "https://www.anthropic.com"}
+
+IMPORTANT:
+- The selectors for title, url, date, and author should be RELATIVE to the post container (not absolute from document root)
+- Look for repeating patterns that represent individual posts/articles
+- Common patterns: article tags, divs with "post", "card", "entry" classes
+- If you cannot identify a clear post listing pattern, respond with: {"error": "Could not identify post listing pattern"}"""
+
+
+class PageAnalyzer:
+    def __init__(
+        self,
+        api_key: str,
+        http_client: httpx.AsyncClient | None = None,
+        model: str = DEFAULT_MODEL,
+    ) -> None:
+        self._client = anthropic.AsyncAnthropic(api_key=api_key)
+        self._http_client = http_client
+        self._model = model
+
+    async def analyze(self, url: str) -> ExtractionProfile:
+        logger.info("Analyzing page structure", url=url)
+
+        html = await self._fetch_html(url)
+        cleaned_html = self._clean_html(html)
+
+        profile_data = await self._extract_profile_with_llm(url, cleaned_html)
+
+        profile = ExtractionProfile.from_dict(profile_data)
+
+        validation_result = self._validate_profile(html, profile)
+        if not validation_result["valid"]:
+            raise PageAnalysisError(f"Profile validation failed: {validation_result['reason']}")
+
+        logger.info(
+            "Page analysis complete",
+            url=url,
+            site_name=profile.site_name,
+            posts_found=validation_result["post_count"],
+        )
+
+        return profile
+
+    async def _fetch_html(self, url: str) -> str:
+        headers = {
+            "User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36"
+        }
+
+        try:
+            if self._http_client:
+                response = await self._http_client.get(url, headers=headers, follow_redirects=True)
+            else:
+                async with httpx.AsyncClient(timeout=30.0) as client:
+                    response = await client.get(url, headers=headers, follow_redirects=True)
+
+            response.raise_for_status()
+            return response.text
+
+        except httpx.HTTPStatusError as e:
+            raise PageAnalysisError(f"Failed to fetch page: HTTP {e.response.status_code}") from e
+        except httpx.RequestError as e:
+            raise PageAnalysisError(f"Failed to fetch page: {e}") from e
+
+    def _clean_html(self, html: str) -> str:
+        soup = BeautifulSoup(html, "lxml")
+
+        for tag in soup.find_all(["script", "style", "noscript", "svg", "path"]):
+            tag.decompose()
+
+        for tag in soup.find_all(True):
+            attrs_to_remove = []
+            for attr in tag.attrs:
+                if attr not in ["class", "id", "href", "datetime", "data-date", "rel"]:
+                    attrs_to_remove.append(attr)
+            for attr in attrs_to_remove:
+                del tag[attr]
+
+        cleaned = str(soup)
+
+        if len(cleaned) > MAX_HTML_LENGTH:
+            cleaned = cleaned[:MAX_HTML_LENGTH]
+            logger.warning(
+                "HTML truncated for analysis",
+                original_length=len(html),
+                truncated_length=MAX_HTML_LENGTH,
+            )
+
+        return cleaned
+
+    @retry(
+        retry=retry_if_exception_type(anthropic.RateLimitError),
+        wait=wait_exponential(multiplier=1, min=4, max=60),
+        stop=stop_after_attempt(3),
+    )
+    async def _extract_profile_with_llm(self, url: str, html: str) -> dict[str, Any]:
+        user_prompt = f"""Analyze this page and provide CSS selectors to extract blog posts/articles.
+
+URL: {url}
+
+HTML:
+{html}
+
+Respond with ONLY a JSON object, no markdown formatting."""
+
+        try:
+            message = await self._client.messages.create(
+                model=self._model,
+                max_tokens=1024,
+                system=ANALYSIS_SYSTEM_PROMPT,
+                messages=[{"role": "user", "content": user_prompt}],
+            )
+
+            response_text = ""
+            for block in message.content:
+                if hasattr(block, "text"):
+                    response_text += block.text
+
+            response_text = response_text.strip()
+
+            json_match = re.search(r"\{.*\}", response_text, re.DOTALL)
+            if json_match:
+                response_text = json_match.group()
+
+            try:
+                data: dict[str, Any] = json.loads(response_text)
+            except json.JSONDecodeError as e:
+                logger.error(
+                    "Failed to parse LLM response as JSON",
+                    response=response_text[:500],
+                    error=str(e),
+                )
+                raise PageAnalysisError("LLM returned invalid JSON response") from e
+
+            if "error" in data:
+                raise PageAnalysisError(data["error"])
+
+            required_fields = [
+                "site_name",
+                "post_selector",
+                "title_selector",
+                "url_selector",
+                "url_attribute",
+            ]
+            for field in required_fields:
+                if field not in data:
+                    raise PageAnalysisError(f"Missing required field: {field}")
+
+            return data
+
+        except anthropic.APIError as e:
+            logger.error("Anthropic API error during page analysis", error=str(e))
+            raise PageAnalysisError(f"LLM API error: {e}") from e
+
+    def _validate_profile(self, html: str, profile: ExtractionProfile) -> dict[str, Any]:
+        soup = BeautifulSoup(html, "lxml")
+
+        posts = soup.select(profile.post_selector)
+        if not posts:
+            return {
+                "valid": False,
+                "reason": f"No elements found with selector: {profile.post_selector}",
+                "post_count": 0,
+            }
+
+        valid_posts = 0
+        for post in posts[:10]:
+            title_elem = post.select_one(profile.title_selector)
+            url_elem = post.select_one(profile.url_selector)
+
+            if title_elem and url_elem:
+                url_value = url_elem.get(profile.url_attribute)
+                if url_value:
+                    valid_posts += 1
+
+        if valid_posts == 0:
+            return {
+                "valid": False,
+                "reason": "Could not extract title and URL from any post",
+                "post_count": 0,
+            }
+
+        return {"valid": True, "reason": None, "post_count": valid_posts}

--- a/tests/test_adapters/test_page.py
+++ b/tests/test_adapters/test_page.py
@@ -1,0 +1,279 @@
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import httpx
+import pytest
+
+from intelstream.adapters.page import PageAdapter
+from intelstream.services.page_analyzer import ExtractionProfile
+
+
+@pytest.fixture
+def sample_profile() -> ExtractionProfile:
+    return ExtractionProfile(
+        site_name="Test Blog",
+        post_selector="article.post",
+        title_selector="h2.title",
+        url_selector="a.link",
+        url_attribute="href",
+        date_selector="time",
+        date_attribute="datetime",
+        author_selector="span.author",
+        base_url="https://example.com",
+    )
+
+
+@pytest.fixture
+def sample_html() -> str:
+    return """
+    <html>
+    <body>
+        <article class="post">
+            <h2 class="title">First Post Title</h2>
+            <a class="link" href="/posts/first-post">Read more</a>
+            <time datetime="2024-01-15T12:00:00Z">January 15, 2024</time>
+            <span class="author">John Doe</span>
+        </article>
+        <article class="post">
+            <h2 class="title">Second Post Title</h2>
+            <a class="link" href="https://example.com/posts/second-post">Read more</a>
+            <time datetime="2024-01-10T10:00:00Z">January 10, 2024</time>
+            <span class="author">Jane Smith</span>
+        </article>
+        <article class="post">
+            <h2 class="title">Third Post Title</h2>
+            <a class="link" href="/posts/third-post">Read more</a>
+        </article>
+    </body>
+    </html>
+    """
+
+
+class TestPageAdapter:
+    async def test_source_type(self, sample_profile: ExtractionProfile) -> None:
+        adapter = PageAdapter(extraction_profile=sample_profile)
+        assert adapter.source_type == "page"
+
+    async def test_get_feed_url_returns_identifier(self, sample_profile: ExtractionProfile) -> None:
+        adapter = PageAdapter(extraction_profile=sample_profile)
+        url = await adapter.get_feed_url("https://example.com/blog")
+        assert url == "https://example.com/blog"
+
+    async def test_fetch_latest_extracts_posts(
+        self, sample_profile: ExtractionProfile, sample_html: str
+    ) -> None:
+        mock_client = MagicMock(spec=httpx.AsyncClient)
+        mock_response = MagicMock()
+        mock_response.text = sample_html
+        mock_response.raise_for_status = MagicMock()
+        mock_client.get = AsyncMock(return_value=mock_response)
+
+        adapter = PageAdapter(extraction_profile=sample_profile, http_client=mock_client)
+        items = await adapter.fetch_latest("https://example.com/blog")
+
+        assert len(items) == 3
+        assert items[0].title == "First Post Title"
+        assert items[0].original_url == "https://example.com/posts/first-post"
+        assert items[0].author == "John Doe"
+        assert items[0].published_at == datetime(2024, 1, 15, 12, 0, 0, tzinfo=UTC)
+
+    async def test_fetch_latest_resolves_relative_urls(
+        self, sample_profile: ExtractionProfile, sample_html: str
+    ) -> None:
+        mock_client = MagicMock(spec=httpx.AsyncClient)
+        mock_response = MagicMock()
+        mock_response.text = sample_html
+        mock_response.raise_for_status = MagicMock()
+        mock_client.get = AsyncMock(return_value=mock_response)
+
+        adapter = PageAdapter(extraction_profile=sample_profile, http_client=mock_client)
+        items = await adapter.fetch_latest("https://example.com/blog")
+
+        assert items[0].original_url == "https://example.com/posts/first-post"
+        assert items[1].original_url == "https://example.com/posts/second-post"
+
+    async def test_fetch_latest_handles_missing_author(
+        self, sample_profile: ExtractionProfile, sample_html: str
+    ) -> None:
+        mock_client = MagicMock(spec=httpx.AsyncClient)
+        mock_response = MagicMock()
+        mock_response.text = sample_html
+        mock_response.raise_for_status = MagicMock()
+        mock_client.get = AsyncMock(return_value=mock_response)
+
+        adapter = PageAdapter(extraction_profile=sample_profile, http_client=mock_client)
+        items = await adapter.fetch_latest("https://example.com/blog")
+
+        assert items[2].author == "Test Blog"
+
+    async def test_fetch_latest_handles_missing_date(
+        self, sample_profile: ExtractionProfile, sample_html: str
+    ) -> None:
+        mock_client = MagicMock(spec=httpx.AsyncClient)
+        mock_response = MagicMock()
+        mock_response.text = sample_html
+        mock_response.raise_for_status = MagicMock()
+        mock_client.get = AsyncMock(return_value=mock_response)
+
+        adapter = PageAdapter(extraction_profile=sample_profile, http_client=mock_client)
+        items = await adapter.fetch_latest("https://example.com/blog")
+
+        assert items[2].published_at.tzinfo == UTC
+        assert (datetime.now(UTC) - items[2].published_at).total_seconds() < 5
+
+    async def test_fetch_latest_respects_max_results(
+        self, sample_profile: ExtractionProfile, sample_html: str
+    ) -> None:
+        mock_client = MagicMock(spec=httpx.AsyncClient)
+        mock_response = MagicMock()
+        mock_response.text = sample_html
+        mock_response.raise_for_status = MagicMock()
+        mock_client.get = AsyncMock(return_value=mock_response)
+
+        adapter = PageAdapter(extraction_profile=sample_profile, http_client=mock_client)
+        items = await adapter.fetch_latest("https://example.com/blog", max_results=2)
+
+        assert len(items) == 2
+
+    async def test_fetch_latest_handles_http_error(self, sample_profile: ExtractionProfile) -> None:
+        mock_client = MagicMock(spec=httpx.AsyncClient)
+        mock_response = MagicMock()
+        mock_response.status_code = 404
+        mock_response.raise_for_status = MagicMock(
+            side_effect=httpx.HTTPStatusError(
+                "Not found", request=MagicMock(), response=mock_response
+            )
+        )
+        mock_client.get = AsyncMock(return_value=mock_response)
+
+        adapter = PageAdapter(extraction_profile=sample_profile, http_client=mock_client)
+
+        with pytest.raises(httpx.HTTPStatusError):
+            await adapter.fetch_latest("https://example.com/blog")
+
+    async def test_fetch_latest_without_http_client(
+        self, sample_profile: ExtractionProfile, sample_html: str
+    ) -> None:
+        with patch("intelstream.adapters.page.httpx.AsyncClient") as mock_client_class:
+            mock_client = MagicMock()
+            mock_response = MagicMock()
+            mock_response.text = sample_html
+            mock_response.raise_for_status = MagicMock()
+            mock_client.get = AsyncMock(return_value=mock_response)
+            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client.__aexit__ = AsyncMock(return_value=None)
+            mock_client_class.return_value = mock_client
+
+            adapter = PageAdapter(extraction_profile=sample_profile)
+            items = await adapter.fetch_latest("https://example.com/blog")
+
+            assert len(items) == 3
+
+    async def test_fetch_latest_with_no_matching_posts(
+        self, sample_profile: ExtractionProfile
+    ) -> None:
+        html = "<html><body><div>No posts here</div></body></html>"
+
+        mock_client = MagicMock(spec=httpx.AsyncClient)
+        mock_response = MagicMock()
+        mock_response.text = html
+        mock_response.raise_for_status = MagicMock()
+        mock_client.get = AsyncMock(return_value=mock_response)
+
+        adapter = PageAdapter(extraction_profile=sample_profile, http_client=mock_client)
+        items = await adapter.fetch_latest("https://example.com/blog")
+
+        assert len(items) == 0
+
+    async def test_fetch_latest_skips_posts_without_title(
+        self, sample_profile: ExtractionProfile
+    ) -> None:
+        html = """
+        <html>
+        <body>
+            <article class="post">
+                <h2 class="title"></h2>
+                <a class="link" href="/posts/empty-title">Read more</a>
+            </article>
+            <article class="post">
+                <h2 class="title">Valid Title</h2>
+                <a class="link" href="/posts/valid">Read more</a>
+            </article>
+        </body>
+        </html>
+        """
+
+        mock_client = MagicMock(spec=httpx.AsyncClient)
+        mock_response = MagicMock()
+        mock_response.text = html
+        mock_response.raise_for_status = MagicMock()
+        mock_client.get = AsyncMock(return_value=mock_response)
+
+        adapter = PageAdapter(extraction_profile=sample_profile, http_client=mock_client)
+        items = await adapter.fetch_latest("https://example.com/blog")
+
+        assert len(items) == 1
+        assert items[0].title == "Valid Title"
+
+    def test_parse_date_string_iso_format(self, sample_profile: ExtractionProfile) -> None:
+        adapter = PageAdapter(extraction_profile=sample_profile)
+        result = adapter._parse_date_string("2024-01-15T12:00:00Z")
+        assert result == datetime(2024, 1, 15, 12, 0, 0, tzinfo=UTC)
+
+    def test_parse_date_string_simple_date(self, sample_profile: ExtractionProfile) -> None:
+        adapter = PageAdapter(extraction_profile=sample_profile)
+        result = adapter._parse_date_string("2024-01-15")
+        assert result.year == 2024
+        assert result.month == 1
+        assert result.day == 15
+
+    def test_parse_date_string_month_name(self, sample_profile: ExtractionProfile) -> None:
+        adapter = PageAdapter(extraction_profile=sample_profile)
+        result = adapter._parse_date_string("January 15, 2024")
+        assert result.year == 2024
+        assert result.month == 1
+        assert result.day == 15
+
+    def test_parse_date_string_invalid_returns_now(self, sample_profile: ExtractionProfile) -> None:
+        adapter = PageAdapter(extraction_profile=sample_profile)
+        result = adapter._parse_date_string("not a date")
+        assert (datetime.now(UTC) - result).total_seconds() < 5
+
+
+class TestExtractionProfile:
+    def test_to_dict(self, sample_profile: ExtractionProfile) -> None:
+        data = sample_profile.to_dict()
+        assert data["site_name"] == "Test Blog"
+        assert data["post_selector"] == "article.post"
+        assert data["title_selector"] == "h2.title"
+        assert data["url_selector"] == "a.link"
+        assert data["url_attribute"] == "href"
+
+    def test_from_dict(self) -> None:
+        data = {
+            "site_name": "Test Blog",
+            "post_selector": "article.post",
+            "title_selector": "h2.title",
+            "url_selector": "a.link",
+            "url_attribute": "href",
+            "date_selector": "time",
+            "date_attribute": "datetime",
+            "author_selector": None,
+            "base_url": "https://example.com",
+        }
+        profile = ExtractionProfile.from_dict(data)
+        assert profile.site_name == "Test Blog"
+        assert profile.post_selector == "article.post"
+
+    def test_from_dict_minimal(self) -> None:
+        data = {
+            "site_name": "Minimal Blog",
+            "post_selector": "div.post",
+            "title_selector": "h1",
+            "url_selector": "a",
+            "url_attribute": "href",
+        }
+        profile = ExtractionProfile.from_dict(data)
+        assert profile.site_name == "Minimal Blog"
+        assert profile.date_selector is None
+        assert profile.author_selector is None

--- a/tests/test_services/test_page_analyzer.py
+++ b/tests/test_services/test_page_analyzer.py
@@ -1,0 +1,337 @@
+import json
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import anthropic
+import httpx
+import pytest
+
+from intelstream.services.page_analyzer import (
+    ExtractionProfile,
+    PageAnalysisError,
+    PageAnalyzer,
+)
+
+
+@pytest.fixture
+def sample_html() -> str:
+    return """
+    <html>
+    <head>
+        <title>Test Blog</title>
+        <script>console.log('test');</script>
+        <style>.hidden { display: none; }</style>
+    </head>
+    <body>
+        <nav>Navigation</nav>
+        <main>
+            <article class="post-card">
+                <h3 class="post-title">First Article</h3>
+                <a class="post-link" href="/articles/first">Read more</a>
+                <time class="post-date" datetime="2024-01-15">Jan 15, 2024</time>
+            </article>
+            <article class="post-card">
+                <h3 class="post-title">Second Article</h3>
+                <a class="post-link" href="/articles/second">Read more</a>
+                <time class="post-date" datetime="2024-01-10">Jan 10, 2024</time>
+            </article>
+        </main>
+    </body>
+    </html>
+    """
+
+
+@pytest.fixture
+def valid_llm_response() -> dict:
+    return {
+        "site_name": "Test Blog",
+        "post_selector": "article.post-card",
+        "title_selector": "h3.post-title",
+        "url_selector": "a.post-link",
+        "url_attribute": "href",
+        "date_selector": "time.post-date",
+        "date_attribute": "datetime",
+        "author_selector": None,
+        "base_url": "https://example.com",
+    }
+
+
+class TestPageAnalyzer:
+    async def test_analyze_success(self, sample_html: str, valid_llm_response: dict) -> None:
+        mock_http_client = MagicMock(spec=httpx.AsyncClient)
+        mock_response = MagicMock()
+        mock_response.text = sample_html
+        mock_response.raise_for_status = MagicMock()
+        mock_http_client.get = AsyncMock(return_value=mock_response)
+
+        mock_anthropic_response = MagicMock()
+        mock_text_block = MagicMock()
+        mock_text_block.text = json.dumps(valid_llm_response)
+        mock_anthropic_response.content = [mock_text_block]
+
+        analyzer = PageAnalyzer(api_key="test-key", http_client=mock_http_client)
+        analyzer._client.messages.create = AsyncMock(return_value=mock_anthropic_response)
+
+        profile = await analyzer.analyze("https://example.com/blog")
+
+        assert profile.site_name == "Test Blog"
+        assert profile.post_selector == "article.post-card"
+        assert profile.title_selector == "h3.post-title"
+
+    async def test_analyze_http_error(self) -> None:
+        mock_http_client = MagicMock(spec=httpx.AsyncClient)
+        mock_response = MagicMock()
+        mock_response.status_code = 404
+        mock_response.raise_for_status = MagicMock(
+            side_effect=httpx.HTTPStatusError(
+                "Not found", request=MagicMock(), response=mock_response
+            )
+        )
+        mock_http_client.get = AsyncMock(return_value=mock_response)
+
+        analyzer = PageAnalyzer(api_key="test-key", http_client=mock_http_client)
+
+        with pytest.raises(PageAnalysisError, match="Failed to fetch page"):
+            await analyzer.analyze("https://example.com/blog")
+
+    async def test_analyze_llm_returns_error(self, sample_html: str) -> None:
+        mock_http_client = MagicMock(spec=httpx.AsyncClient)
+        mock_response = MagicMock()
+        mock_response.text = sample_html
+        mock_response.raise_for_status = MagicMock()
+        mock_http_client.get = AsyncMock(return_value=mock_response)
+
+        mock_anthropic_response = MagicMock()
+        mock_text_block = MagicMock()
+        mock_text_block.text = json.dumps({"error": "Could not identify post listing pattern"})
+        mock_anthropic_response.content = [mock_text_block]
+
+        analyzer = PageAnalyzer(api_key="test-key", http_client=mock_http_client)
+        analyzer._client.messages.create = AsyncMock(return_value=mock_anthropic_response)
+
+        with pytest.raises(PageAnalysisError, match="Could not identify"):
+            await analyzer.analyze("https://example.com/blog")
+
+    async def test_analyze_llm_invalid_json(self, sample_html: str) -> None:
+        mock_http_client = MagicMock(spec=httpx.AsyncClient)
+        mock_response = MagicMock()
+        mock_response.text = sample_html
+        mock_response.raise_for_status = MagicMock()
+        mock_http_client.get = AsyncMock(return_value=mock_response)
+
+        mock_anthropic_response = MagicMock()
+        mock_text_block = MagicMock()
+        mock_text_block.text = "This is not valid JSON"
+        mock_anthropic_response.content = [mock_text_block]
+
+        analyzer = PageAnalyzer(api_key="test-key", http_client=mock_http_client)
+        analyzer._client.messages.create = AsyncMock(return_value=mock_anthropic_response)
+
+        with pytest.raises(PageAnalysisError, match="invalid JSON"):
+            await analyzer.analyze("https://example.com/blog")
+
+    async def test_analyze_llm_missing_required_field(self, sample_html: str) -> None:
+        mock_http_client = MagicMock(spec=httpx.AsyncClient)
+        mock_response = MagicMock()
+        mock_response.text = sample_html
+        mock_response.raise_for_status = MagicMock()
+        mock_http_client.get = AsyncMock(return_value=mock_response)
+
+        incomplete_response = {
+            "site_name": "Test Blog",
+            "post_selector": "article.post-card",
+        }
+        mock_anthropic_response = MagicMock()
+        mock_text_block = MagicMock()
+        mock_text_block.text = json.dumps(incomplete_response)
+        mock_anthropic_response.content = [mock_text_block]
+
+        analyzer = PageAnalyzer(api_key="test-key", http_client=mock_http_client)
+        analyzer._client.messages.create = AsyncMock(return_value=mock_anthropic_response)
+
+        with pytest.raises(PageAnalysisError, match="Missing required field"):
+            await analyzer.analyze("https://example.com/blog")
+
+    async def test_analyze_validation_fails_no_posts(self, valid_llm_response: dict) -> None:
+        html = "<html><body><div>No matching posts</div></body></html>"
+
+        mock_http_client = MagicMock(spec=httpx.AsyncClient)
+        mock_response = MagicMock()
+        mock_response.text = html
+        mock_response.raise_for_status = MagicMock()
+        mock_http_client.get = AsyncMock(return_value=mock_response)
+
+        mock_anthropic_response = MagicMock()
+        mock_text_block = MagicMock()
+        mock_text_block.text = json.dumps(valid_llm_response)
+        mock_anthropic_response.content = [mock_text_block]
+
+        analyzer = PageAnalyzer(api_key="test-key", http_client=mock_http_client)
+        analyzer._client.messages.create = AsyncMock(return_value=mock_anthropic_response)
+
+        with pytest.raises(PageAnalysisError, match="Profile validation failed"):
+            await analyzer.analyze("https://example.com/blog")
+
+    async def test_analyze_api_error(self, sample_html: str) -> None:
+        mock_http_client = MagicMock(spec=httpx.AsyncClient)
+        mock_response = MagicMock()
+        mock_response.text = sample_html
+        mock_response.raise_for_status = MagicMock()
+        mock_http_client.get = AsyncMock(return_value=mock_response)
+
+        analyzer = PageAnalyzer(api_key="test-key", http_client=mock_http_client)
+        analyzer._client.messages.create = AsyncMock(
+            side_effect=anthropic.APIError(message="API Error", request=MagicMock(), body=None)
+        )
+
+        with pytest.raises(PageAnalysisError, match="LLM API error"):
+            await analyzer.analyze("https://example.com/blog")
+
+    async def test_analyze_without_http_client(
+        self, sample_html: str, valid_llm_response: dict
+    ) -> None:
+        with patch("intelstream.services.page_analyzer.httpx.AsyncClient") as mock_client_class:
+            mock_client = MagicMock()
+            mock_response = MagicMock()
+            mock_response.text = sample_html
+            mock_response.raise_for_status = MagicMock()
+            mock_client.get = AsyncMock(return_value=mock_response)
+            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client.__aexit__ = AsyncMock(return_value=None)
+            mock_client_class.return_value = mock_client
+
+            mock_anthropic_response = MagicMock()
+            mock_text_block = MagicMock()
+            mock_text_block.text = json.dumps(valid_llm_response)
+            mock_anthropic_response.content = [mock_text_block]
+
+            analyzer = PageAnalyzer(api_key="test-key")
+            analyzer._client.messages.create = AsyncMock(return_value=mock_anthropic_response)
+
+            profile = await analyzer.analyze("https://example.com/blog")
+            assert profile.site_name == "Test Blog"
+
+    def test_clean_html_removes_scripts(self) -> None:
+        html = """
+        <html>
+        <head><script>alert('xss')</script></head>
+        <body>
+            <article class="post">
+                <h1>Title</h1>
+                <script>console.log('test');</script>
+            </article>
+        </body>
+        </html>
+        """
+        analyzer = PageAnalyzer(api_key="test-key")
+        cleaned = analyzer._clean_html(html)
+
+        assert "<script>" not in cleaned
+        assert "alert" not in cleaned
+        assert "console.log" not in cleaned
+
+    def test_clean_html_removes_styles(self) -> None:
+        html = """
+        <html>
+        <head><style>.hidden { display: none; }</style></head>
+        <body>
+            <article class="post">Content</article>
+        </body>
+        </html>
+        """
+        analyzer = PageAnalyzer(api_key="test-key")
+        cleaned = analyzer._clean_html(html)
+
+        assert "<style>" not in cleaned
+        assert "display: none" not in cleaned
+
+    def test_clean_html_preserves_important_attributes(self) -> None:
+        html = """
+        <html>
+        <body>
+            <article class="post" id="post-1" data-tracking="abc">
+                <a href="/link" class="link">Click</a>
+                <time datetime="2024-01-15">Jan 15</time>
+            </article>
+        </body>
+        </html>
+        """
+        analyzer = PageAnalyzer(api_key="test-key")
+        cleaned = analyzer._clean_html(html)
+
+        assert 'class="post"' in cleaned
+        assert 'id="post-1"' in cleaned
+        assert 'href="/link"' in cleaned
+        assert 'datetime="2024-01-15"' in cleaned
+        assert "data-tracking" not in cleaned
+
+    def test_validate_profile_valid(self, sample_html: str) -> None:
+        profile = ExtractionProfile(
+            site_name="Test",
+            post_selector="article.post-card",
+            title_selector="h3.post-title",
+            url_selector="a.post-link",
+            url_attribute="href",
+        )
+        analyzer = PageAnalyzer(api_key="test-key")
+        result = analyzer._validate_profile(sample_html, profile)
+
+        assert result["valid"] is True
+        assert result["post_count"] == 2
+
+    def test_validate_profile_no_matching_posts(self, sample_html: str) -> None:
+        profile = ExtractionProfile(
+            site_name="Test",
+            post_selector="div.nonexistent",
+            title_selector="h1",
+            url_selector="a",
+            url_attribute="href",
+        )
+        analyzer = PageAnalyzer(api_key="test-key")
+        result = analyzer._validate_profile(sample_html, profile)
+
+        assert result["valid"] is False
+        assert "No elements found" in result["reason"]
+
+    def test_validate_profile_cannot_extract_data(self) -> None:
+        html = """
+        <html>
+        <body>
+            <article class="post">
+                <span>No title or link here</span>
+            </article>
+        </body>
+        </html>
+        """
+        profile = ExtractionProfile(
+            site_name="Test",
+            post_selector="article.post",
+            title_selector="h2.title",
+            url_selector="a.link",
+            url_attribute="href",
+        )
+        analyzer = PageAnalyzer(api_key="test-key")
+        result = analyzer._validate_profile(html, profile)
+
+        assert result["valid"] is False
+        assert "Could not extract" in result["reason"]
+
+    async def test_analyze_extracts_json_from_markdown(
+        self, sample_html: str, valid_llm_response: dict
+    ) -> None:
+        mock_http_client = MagicMock(spec=httpx.AsyncClient)
+        mock_response = MagicMock()
+        mock_response.text = sample_html
+        mock_response.raise_for_status = MagicMock()
+        mock_http_client.get = AsyncMock(return_value=mock_response)
+
+        mock_anthropic_response = MagicMock()
+        mock_text_block = MagicMock()
+        mock_text_block.text = f"```json\n{json.dumps(valid_llm_response)}\n```"
+        mock_anthropic_response.content = [mock_text_block]
+
+        analyzer = PageAnalyzer(api_key="test-key", http_client=mock_http_client)
+        analyzer._client.messages.create = AsyncMock(return_value=mock_anthropic_response)
+
+        profile = await analyzer.analyze("https://example.com/blog")
+
+        assert profile.site_name == "Test Blog"


### PR DESCRIPTION
## Summary

Implements the "Smart Page Adapter" feature from IMPLEMENTATION_PLAN.md for monitoring non-standard blog sites that don't have RSS feeds, such as:
- https://www.darioamodei.com/ (Dario Amodei's personal blog)
- https://www.anthropic.com/research (Anthropic research page)

### Two-Phase LLM-Assisted Detection

**Phase 1 - Discovery (One-time)**
- `PageAnalyzer` uses Claude to analyze HTML structure and generate CSS selectors
- Validates generated selectors actually work on the current page before storing
- Cleans HTML before LLM analysis (removes scripts, styles, tracking attributes)
- Returns an `ExtractionProfile` with selectors for posts, titles, URLs, dates, authors

**Phase 2 - Monitoring (Regular polling)**
- `PageAdapter` uses stored `ExtractionProfile` with BeautifulSoup
- No LLM calls during regular polling (cost-effective)
- Handles relative URL resolution, multiple date formats, missing optional fields

### Components Added

| File | Description |
|------|-------------|
| `services/page_analyzer.py` | LLM-based page structure analyzer |
| `adapters/page.py` | Page adapter using extraction profiles |
| `tests/test_services/test_page_analyzer.py` | 15 tests for analyzer |
| `tests/test_adapters/test_page.py` | 18 tests for adapter |

### ExtractionProfile Schema

```python
@dataclass
class ExtractionProfile:
    site_name: str
    post_selector: str      # CSS selector for post containers
    title_selector: str     # Relative to post container
    url_selector: str       # Relative to post container
    url_attribute: str      # Usually "href"
    date_selector: str | None
    date_attribute: str | None
    author_selector: str | None
    base_url: str | None
```

## Test plan

- [x] All 33 new tests pass
- [x] Full test suite passes (215 passed, 2 pre-existing failures unrelated to this PR)
- [x] Linting passes (`ruff check`)
- [x] Type checking passes (`mypy`)
- [ ] Manual test: Add darioamodei.com as a source and verify extraction
- [ ] Manual test: Add anthropic.com/research and verify extraction