### PR TITLE
Restrict config and source commands to server admins

### DIFF
--- a/src/intelstream/discord/cogs/config_management.py
+++ b/src/intelstream/discord/cogs/config_management.py
@@ -15,7 +15,11 @@ class ConfigManagement(commands.Cog):
     def __init__(self, bot: "IntelStreamBot") -> None:
         self.bot = bot
 
-    config_group = app_commands.Group(name="config", description="Configure bot settings")
+    config_group = app_commands.Group(
+        name="config",
+        description="Configure bot settings",
+        default_permissions=discord.Permissions(manage_guild=True),
+    )
 
     @config_group.command(name="channel", description="Set the channel for content posts")
     @app_commands.describe(channel="The channel where content summaries will be posted")

--- a/src/intelstream/discord/cogs/source_management.py
+++ b/src/intelstream/discord/cogs/source_management.py
@@ -51,7 +51,11 @@ class SourceManagement(commands.Cog):
     def __init__(self, bot: "IntelStreamBot") -> None:
         self.bot = bot
 
-    source_group = app_commands.Group(name="source", description="Manage content sources")
+    source_group = app_commands.Group(
+        name="source",
+        description="Manage content sources",
+        default_permissions=discord.Permissions(manage_guild=True),
+    )
 
     @source_group.command(name="add", description="Add a new content source")
     @app_commands.describe(


### PR DESCRIPTION
Add default_permissions(manage_guild=True) to the /config and /source command groups. This restricts these commands to users with the "Manage Server" permission by default.

Server admins can further customize permissions in Server Settings > Integrations > IntelStream.