### PR TITLE
Limit initial source fetch to most recent item

### DIFF
--- a/src/intelstream/services/pipeline.py
+++ b/src/intelstream/services/pipeline.py
@@ -108,11 +108,20 @@ class ContentPipeline:
 
         items = await adapter.fetch_latest(source.identifier, feed_url=source.feed_url)
 
+        is_first_poll = source.last_polled_at is None
+
         new_count = 0
         for item in items:
             if not await self._repository.content_item_exists(item.external_id):
                 await self._store_content_item(source, item)
                 new_count += 1
+
+                if is_first_poll:
+                    logger.info(
+                        "First poll for source, limiting to most recent item",
+                        source_name=source.name,
+                    )
+                    break
 
         await self._repository.update_source_last_polled(source.id)
 


### PR DESCRIPTION
## Summary
- When a new source is added, only the most recent item is fetched and stored on the first poll
- Subsequent polls fetch and store all new items as before
- This prevents flooding the summarization queue with old articles when adding a new source

## Changes
- Modified `_fetch_source()` in `pipeline.py` to check if `source.last_polled_at is None` (first poll)
- On first poll, breaks after storing the first item (most recent)
- Added tests for both first-poll and subsequent-poll behavior

## Test plan
- [x] Existing pipeline tests pass
- [x] New test `test_first_poll_limits_to_one_item` verifies only 1 item stored on first poll
- [x] New test `test_subsequent_poll_stores_all_new_items` verifies all items stored on subsequent polls