### PR TITLE
Use Haiku for background summarization, Sonnet for /summarize

### DIFF
--- a/src/intelstream/config.py
+++ b/src/intelstream/config.py
@@ -65,7 +65,12 @@ class Settings(BaseSettings):
 
     summary_model: str = Field(
         default="claude-3-5-haiku-20241022",
-        description="Model to use for summarization",
+        description="Model to use for background summarization",
+    )
+
+    summary_model_interactive: str = Field(
+        default="claude-sonnet-4-20250514",
+        description="Model to use for interactive /summarize command",
     )
 
     discord_max_message_length: int = Field(

--- a/src/intelstream/discord/cogs/summarize.py
+++ b/src/intelstream/discord/cogs/summarize.py
@@ -62,7 +62,7 @@ class Summarize(commands.Cog):
         )
         self._summarizer = SummarizationService(
             api_key=self.bot.settings.anthropic_api_key,
-            model=self.bot.settings.summary_model,
+            model=self.bot.settings.summary_model_interactive,
             max_tokens=self.bot.settings.summary_max_tokens,
             max_input_length=self.bot.settings.summary_max_input_length,
         )
@@ -305,7 +305,7 @@ class Summarize(commands.Cog):
             if not self._summarizer:
                 self._summarizer = SummarizationService(
                     api_key=self.bot.settings.anthropic_api_key,
-                    model=self.bot.settings.summary_model,
+                    model=self.bot.settings.summary_model_interactive,
                     max_tokens=self.bot.settings.summary_max_tokens,
                     max_input_length=self.bot.settings.summary_max_input_length,
                 )


### PR DESCRIPTION
## Summary
- Background summarization (automated pipeline) uses Haiku by default (cheaper, faster)
- Interactive `/summarize` command uses Sonnet by default (higher quality for user-initiated requests)

## Changes
- Added `summary_model_interactive` config setting (defaults to `claude-sonnet-4-20250514`)
- Updated `/summarize` cog to use the interactive model setting
- Background summarization continues to use `summary_model` (defaults to `claude-3-5-haiku-20241022`)

## Test plan
- [x] All 264 tests pass
- [x] Linter passes

@greptile