### PR TITLE
Filter /source list by current channel

### DIFF
--- a/src/intelstream/database/repository.py
+++ b/src/intelstream/database/repository.py
@@ -115,11 +115,15 @@ class Repository:
             result = await session.execute(select(Source).where(Source.name == name))
             return result.scalar_one_or_none()
 
-    async def get_all_sources(self, active_only: bool = True) -> list[Source]:
+    async def get_all_sources(
+        self, active_only: bool = True, channel_id: str | None = None
+    ) -> list[Source]:
         async with self.session() as session:
             query = select(Source)
             if active_only:
                 query = query.where(Source.is_active == True)  # noqa: E712
+            if channel_id is not None:
+                query = query.where(Source.channel_id == channel_id)
             result = await session.execute(query)
             return list(result.scalars().all())
 

--- a/src/intelstream/discord/cogs/source_management.py
+++ b/src/intelstream/discord/cogs/source_management.py
@@ -227,18 +227,21 @@ class SourceManagement(commands.Cog):
 
         await interaction.followup.send(embed=embed, ephemeral=True)
 
-    @source_group.command(name="list", description="List all configured sources")
+    @source_group.command(name="list", description="List sources for this channel")
     async def source_list(self, interaction: discord.Interaction) -> None:
         await interaction.response.defer()
 
-        sources = await self.bot.repository.get_all_sources(active_only=False)
+        channel_id = str(interaction.channel_id)
+        sources = await self.bot.repository.get_all_sources(
+            active_only=False, channel_id=channel_id
+        )
 
         if not sources:
-            await interaction.followup.send("No sources configured.")
+            await interaction.followup.send("No sources configured for this channel.")
             return
 
         embed = discord.Embed(
-            title="Configured Sources",
+            title="Sources for This Channel",
             color=discord.Color.blue(),
         )
 
@@ -249,10 +252,9 @@ class SourceManagement(commands.Cog):
                 if source.last_polled_at
                 else "Never"
             )
-            channel_info = f"<#{source.channel_id}>" if source.channel_id else "Not set"
             embed.add_field(
                 name=f"{'[ON]' if source.is_active else '[OFF]'} {source.name}",
-                value=f"**Type:** {source.type.value}\n**Channel:** {channel_info}\n**Status:** {status}\n**Last Poll:** {last_poll}",
+                value=f"**Type:** {source.type.value}\n**Status:** {status}\n**Last Poll:** {last_poll}",
                 inline=True,
             )
 

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -77,6 +77,36 @@ class TestSourceOperations:
         sources = await repository.get_all_sources()
         assert len(sources) == 2
 
+    async def test_get_all_sources_filtered_by_channel(self, repository: Repository) -> None:
+        await repository.add_source(
+            source_type=SourceType.SUBSTACK,
+            name="Channel A Source",
+            identifier="source-a",
+            channel_id="channel-a",
+        )
+        await repository.add_source(
+            source_type=SourceType.YOUTUBE,
+            name="Channel B Source",
+            identifier="source-b",
+            channel_id="channel-b",
+        )
+        await repository.add_source(
+            source_type=SourceType.RSS,
+            name="No Channel Source",
+            identifier="source-none",
+        )
+
+        sources_a = await repository.get_all_sources(channel_id="channel-a")
+        assert len(sources_a) == 1
+        assert sources_a[0].name == "Channel A Source"
+
+        sources_b = await repository.get_all_sources(channel_id="channel-b")
+        assert len(sources_b) == 1
+        assert sources_b[0].name == "Channel B Source"
+
+        all_sources = await repository.get_all_sources()
+        assert len(all_sources) == 3
+
     async def test_set_source_active(self, repository: Repository) -> None:
         await repository.add_source(
             source_type=SourceType.RSS,


### PR DESCRIPTION
## Summary

- `/source list` now only shows sources configured for the channel where the command is run
- Added `channel_id` parameter to `get_all_sources()` repository method
- Removed the "Channel" field from the embed since all listed sources are for the current channel

## Test plan

- [ ] Run `/source list` in a channel with sources - should only show those sources
- [ ] Run `/source list` in a channel without sources - should show "No sources configured for this channel"
- [ ] Verify sources from other channels are not shown