### PR TITLE
Add logging to forwarding feature and fix thread cache miss

### DIFF
--- a/tests/test_services/test_message_forwarder.py
+++ b/tests/test_services/test_message_forwarder.py
@@ -95,13 +95,31 @@ class TestGetDestination:
 
     async def test_get_destination_not_found(self, forwarder, mock_bot):
         mock_guild = MagicMock()
+        mock_guild.id = 123456
         mock_guild.get_thread = MagicMock(return_value=None)
+        mock_guild.fetch_channel = AsyncMock(side_effect=discord.NotFound(MagicMock(), "Not found"))
         mock_bot.guilds = [mock_guild]
         mock_bot.get_channel = MagicMock(return_value=None)
 
         result = await forwarder._get_destination(99999, "thread")
 
         assert result is None
+
+    async def test_get_thread_destination_via_api_fetch(self, forwarder, mock_bot):
+        mock_thread = MagicMock(spec=discord.Thread)
+        mock_thread.name = "test-thread"
+        mock_thread.archived = False
+        mock_guild = MagicMock()
+        mock_guild.id = 123456
+        mock_guild.get_thread = MagicMock(return_value=None)
+        mock_guild.fetch_channel = AsyncMock(return_value=mock_thread)
+        mock_bot.guilds = [mock_guild]
+        mock_bot.get_channel = MagicMock(return_value=None)
+
+        result = await forwarder._get_destination(12345, "thread")
+
+        assert result == mock_thread
+        mock_guild.fetch_channel.assert_called_once_with(12345)
 
 
 class TestDownloadAttachments:


### PR DESCRIPTION
## Summary
- Add comprehensive debug logging throughout the message forwarding flow
- Fix thread forwarding failures by adding API fallback when threads aren't in Discord.py's cache
- Log cache refresh events with rule counts and monitored source channels

## Problem
Thread forwarding was silently failing because Discord.py doesn't cache threads that are archived or haven't had recent activity. The `get_channel()` and `get_thread()` methods only work for cached threads.

## Solution
Added a fallback that calls `guild.fetch_channel()` to retrieve threads directly from the Discord API when they're not in the cache.

## Test plan
- [x] All 365 tests pass
- [x] Type checking passes (mypy)
- [x] Linting passes (ruff)
- [ ] Manual test: Send message in source channel, verify forwarding works to thread destination
- [ ] Verify logs show thread resolution path (cache hit vs API fetch)