### PR TITLE
Fix forwarding rules not loading on startup

### DIFF
--- a/src/intelstream/discord/cogs/message_forwarding.py
+++ b/src/intelstream/discord/cogs/message_forwarding.py
@@ -24,7 +24,8 @@ class MessageForwarding(commands.Cog):
         self.forwarder = MessageForwarder(bot)
         self._rules_cache: dict[str, list[Any]] = {}
 
-    async def cog_load(self) -> None:
+    @commands.Cog.listener()
+    async def on_ready(self) -> None:
         await self._refresh_cache()
 
     async def _refresh_cache(self) -> None:


### PR DESCRIPTION
## Summary
- Replace `cog_load` with `on_ready` for cache initialization

## Problem
Forwarding rules were not loading on bot startup because `cog_load` runs before the bot connects to Discord. At that point, `self.bot.guilds` is empty, so no rules are loaded into the cache. This caused forwarding to silently fail for all messages.

## Solution
Use the `on_ready` event listener instead, which fires after the bot is fully connected and has received guild data from Discord.

## Test plan
- [x] All 18 forwarding tests pass
- [ ] Start bot and verify log shows rules loaded (non-zero `total_active_rules`)
- [ ] Send message in source channel, verify it forwards to destination