### PR TITLE
Preserve original message formatting when forwarding

### DIFF
--- a/src/intelstream/services/message_forwarder.py
+++ b/src/intelstream/services/message_forwarder.py
@@ -184,15 +184,4 @@ class MessageForwarder:
         return files
 
     def _build_forwarded_content(self, message: discord.Message) -> str:
-        parts = []
-        source_name = getattr(message.channel, "name", "Unknown")
-        parts.append(f"**Forwarded from #{source_name}**")
-
-        if message.author.bot:
-            parts.append(f"*Original author: {message.author.name}*")
-
-        if message.content:
-            parts.append("")
-            parts.append(message.content)
-
-        return "\n".join(parts)
+        return message.content

--- a/tests/test_services/test_message_forwarder.py
+++ b/tests/test_services/test_message_forwarder.py
@@ -22,45 +22,27 @@ def forwarder(mock_bot):
 class TestBuildForwardedContent:
     def test_build_content_with_text(self, forwarder):
         message = MagicMock(spec=discord.Message)
-        message.channel = MagicMock()
-        message.channel.name = "announcements"
-        message.author = MagicMock()
-        message.author.bot = False
         message.content = "Hello world!"
 
         content = forwarder._build_forwarded_content(message)
 
-        assert "**Forwarded from #announcements**" in content
-        assert "Hello world!" in content
-        assert "Original author" not in content
+        assert content == "Hello world!"
 
     def test_build_content_with_bot_author(self, forwarder):
         message = MagicMock(spec=discord.Message)
-        message.channel = MagicMock()
-        message.channel.name = "news"
-        message.author = MagicMock()
-        message.author.bot = True
-        message.author.name = "NewsBot"
         message.content = "Breaking news!"
 
         content = forwarder._build_forwarded_content(message)
 
-        assert "**Forwarded from #news**" in content
-        assert "*Original author: NewsBot*" in content
-        assert "Breaking news!" in content
+        assert content == "Breaking news!"
 
     def test_build_content_without_text(self, forwarder):
         message = MagicMock(spec=discord.Message)
-        message.channel = MagicMock()
-        message.channel.name = "media"
-        message.author = MagicMock()
-        message.author.bot = False
         message.content = ""
 
         content = forwarder._build_forwarded_content(message)
 
-        assert "**Forwarded from #media**" in content
-        assert content.strip().endswith("#media**")
+        assert content == ""
 
 
 class TestGetDestination:


### PR DESCRIPTION
## Summary

- Remove the "Forwarded from #channel" header and author attribution from forwarded messages
- Messages now appear exactly as they do in the source channel, preserving original formatting, embeds, and attachments

## Context

Previously, forwarded messages included additional metadata:
```
**Forwarded from #channel-name**
*Original author: BotName*

[original content]
```

This change removes that formatting so forwarded messages look identical to the originals.

## Test plan

- [x] Run `pytest tests/test_services/test_message_forwarder.py` - all 16 tests pass
- [x] Run full test suite - all 365 tests pass
- [x] Run `ruff check` on changed files - all checks pass

@greptile