### PR TITLE
Fix orphaned sub-bullets in summary truncation

### DIFF
--- a/src/intelstream/services/content_poster.py
+++ b/src/intelstream/services/content_poster.py
@@ -53,11 +53,16 @@ def truncate_summary_at_bullet(summary: str, max_length: int) -> str:
     is_sub_bullet = last_line.strip().startswith("- ") and last_line.startswith("  ")
 
     if is_sub_bullet:
+        found_parent = False
         for j in range(len(result_lines) - 1, -1, -1):
             line = result_lines[j]
             if line.strip().startswith("- **") and not line.startswith("  "):
                 result_lines = result_lines[: j + 1]
+                found_parent = True
                 break
+
+        if not found_parent:
+            result_lines = result_lines[:-1]
 
         result = "\n".join(result_lines)
 

--- a/tests/test_services/test_content_poster.py
+++ b/tests/test_services/test_content_poster.py
@@ -400,3 +400,13 @@ class TestTruncateSummaryAtBullet:
         result = truncate_summary_at_bullet(summary, len(summary))
         assert result == summary
         assert TRUNCATION_NOTICE not in result
+
+    def test_removes_orphaned_sub_bullet_when_no_parent_found(self):
+        summary = """Some intro text
+  - Sub bullet A
+  - Sub bullet B
+  - Sub bullet C"""
+        result = truncate_summary_at_bullet(summary, 60)
+        assert "Some intro text" in result
+        assert "Sub bullet" not in result
+        assert TRUNCATION_NOTICE.strip() in result


### PR DESCRIPTION
## Summary

When truncating summaries at bullet boundaries, if the last line is a sub-bullet and no parent bullet is found, the sub-bullet was left orphaned. Now it's removed to avoid incomplete-looking output.

## Example

**Before (orphaned sub-bullet left behind):**
```
Some intro text
  - Sub bullet A   <-- orphaned, looks incomplete

*[Summary truncated]*
```

**After (orphaned sub-bullet removed):**
```
Some intro text

*[Summary truncated]*
```

## Test plan

- [x] Added test for orphaned sub-bullet removal
- [x] Run `pytest tests/test_services/test_content_poster.py` - all 28 tests pass
- [x] Run full test suite - all 366 tests pass
- [x] Run `ruff check` - all checks pass

Fixes #43