### PR TITLE
Catch malformed CSS selector errors in page analyzer

### DIFF
--- a/src/intelstream/services/page_analyzer.py
+++ b/src/intelstream/services/page_analyzer.py
@@ -245,7 +245,20 @@ Respond with ONLY a JSON object, no markdown formatting."""
     def _validate_profile(self, html: str, profile: ExtractionProfile) -> dict[str, Any]:
         soup = BeautifulSoup(html, "lxml")
 
-        posts = soup.select(profile.post_selector)
+        try:
+            posts = soup.select(profile.post_selector)
+        except Exception as e:
+            logger.warning(
+                "Invalid CSS selector from LLM",
+                selector=profile.post_selector,
+                error=str(e),
+            )
+            return {
+                "valid": False,
+                "reason": f"Invalid post selector: {profile.post_selector}",
+                "post_count": 0,
+            }
+
         if not posts:
             return {
                 "valid": False,
@@ -255,8 +268,21 @@ Respond with ONLY a JSON object, no markdown formatting."""
 
         valid_posts = 0
         for post in posts[:10]:
-            title_elem = post.select_one(profile.title_selector)
-            url_elem = post.select_one(profile.url_selector)
+            try:
+                title_elem = post.select_one(profile.title_selector)
+                url_elem = post.select_one(profile.url_selector)
+            except Exception as e:
+                logger.warning(
+                    "Invalid CSS selector from LLM",
+                    title_selector=profile.title_selector,
+                    url_selector=profile.url_selector,
+                    error=str(e),
+                )
+                return {
+                    "valid": False,
+                    "reason": f"Invalid title/url selector: {e}",
+                    "post_count": 0,
+                }
 
             if title_elem and url_elem:
                 url_value = url_elem.get(profile.url_attribute)

--- a/tests/test_services/test_page_analyzer.py
+++ b/tests/test_services/test_page_analyzer.py
@@ -327,6 +327,34 @@ class TestPageAnalyzer:
         assert result["valid"] is False
         assert "Could not extract" in result["reason"]
 
+    def test_validate_profile_invalid_post_selector(self, sample_html: str) -> None:
+        profile = ExtractionProfile(
+            site_name="Test",
+            post_selector="[invalid[selector",
+            title_selector="h3",
+            url_selector="a",
+            url_attribute="href",
+        )
+        analyzer = PageAnalyzer(api_key="test-key")
+        result = analyzer._validate_profile(sample_html, profile)
+
+        assert result["valid"] is False
+        assert "Invalid post selector" in result["reason"]
+
+    def test_validate_profile_invalid_title_selector(self, sample_html: str) -> None:
+        profile = ExtractionProfile(
+            site_name="Test",
+            post_selector="article.post-card",
+            title_selector="h3[[[",
+            url_selector="a.post-link",
+            url_attribute="href",
+        )
+        analyzer = PageAnalyzer(api_key="test-key")
+        result = analyzer._validate_profile(sample_html, profile)
+
+        assert result["valid"] is False
+        assert "Invalid title/url selector" in result["reason"]
+
     async def test_analyze_extracts_json_from_markdown(
         self, sample_html: str, valid_llm_response: dict
     ) -> None:


### PR DESCRIPTION
## Summary

Wrap BeautifulSoup's `select()` and `select_one()` calls in try/except to handle invalid CSS selectors from LLM output gracefully. Returns validation failure with helpful error message instead of crashing.

## Problem

The `_validate_profile()` method uses CSS selectors that come from LLM output. If the LLM generates an invalid selector syntax (e.g., `[invalid[selector`), BeautifulSoup raises an exception that wasn't caught, causing the entire operation to fail with an unclear error.

## Solution

Catch exceptions from selector operations and return a validation failure result with a descriptive error message, allowing the system to handle the failure gracefully.

## Test plan

- [x] Added test for invalid post_selector
- [x] Added test for invalid title_selector
- [x] Run `pytest tests/test_services/test_page_analyzer.py` - all 19 tests pass
- [x] Run full test suite - all 367 tests pass
- [x] Run `ruff check` - all checks pass

Fixes #45