### PR TITLE
Validate source poll_interval when adding sources

### DIFF
--- a/src/intelstream/database/repository.py
+++ b/src/intelstream/database/repository.py
@@ -27,6 +27,9 @@ SOURCES_MIGRATIONS: list[tuple[str, str]] = [
     ("channel_id", "VARCHAR(36)"),
 ]
 
+MIN_POLL_INTERVAL_MINUTES = 1
+MAX_POLL_INTERVAL_MINUTES = 60
+
 
 class Repository:
     def __init__(self, database_url: str) -> None:
@@ -82,6 +85,12 @@ class Repository:
         guild_id: str | None = None,
         channel_id: str | None = None,
     ) -> Source:
+        if not MIN_POLL_INTERVAL_MINUTES <= poll_interval_minutes <= MAX_POLL_INTERVAL_MINUTES:
+            raise ValueError(
+                f"poll_interval_minutes must be between {MIN_POLL_INTERVAL_MINUTES} and "
+                f"{MAX_POLL_INTERVAL_MINUTES}, got {poll_interval_minutes}"
+            )
+
         async with self.session() as session:
             source = Source(
                 type=source_type,

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -48,6 +48,41 @@ class TestSourceOperations:
         assert source.guild_id == "guild-123"
         assert source.channel_id == "channel-456"
 
+    async def test_add_source_poll_interval_too_low(self, repository: Repository) -> None:
+        with pytest.raises(ValueError, match="poll_interval_minutes must be between"):
+            await repository.add_source(
+                source_type=SourceType.SUBSTACK,
+                name="Test",
+                identifier="test-low",
+                poll_interval_minutes=0,
+            )
+
+    async def test_add_source_poll_interval_too_high(self, repository: Repository) -> None:
+        with pytest.raises(ValueError, match="poll_interval_minutes must be between"):
+            await repository.add_source(
+                source_type=SourceType.SUBSTACK,
+                name="Test",
+                identifier="test-high",
+                poll_interval_minutes=61,
+            )
+
+    async def test_add_source_poll_interval_at_boundaries(self, repository: Repository) -> None:
+        source_min = await repository.add_source(
+            source_type=SourceType.SUBSTACK,
+            name="Min Interval",
+            identifier="test-min",
+            poll_interval_minutes=1,
+        )
+        assert source_min.poll_interval_minutes == 1
+
+        source_max = await repository.add_source(
+            source_type=SourceType.SUBSTACK,
+            name="Max Interval",
+            identifier="test-max",
+            poll_interval_minutes=60,
+        )
+        assert source_max.poll_interval_minutes == 60
+
     async def test_get_source_by_identifier(self, repository: Repository) -> None:
         await repository.add_source(
             source_type=SourceType.YOUTUBE,


### PR DESCRIPTION
## Summary

Add validation to `repository.add_source()` to ensure `poll_interval_minutes` is between 1 and 60, matching the Settings validation. This prevents sources from being created with invalid polling intervals.

## Problem

The `Settings` class validates `default_poll_interval_minutes` to be between 1-60, but when sources are added via the repository, there was no validation. This could allow:
- `poll_interval=0` (constant polling, potential DoS)
- `poll_interval=1000000` (effectively never polls)

## Solution

Added constants `MIN_POLL_INTERVAL_MINUTES` and `MAX_POLL_INTERVAL_MINUTES` and validation in `add_source()` that raises `ValueError` for out-of-range values.

## Test plan

- [x] Added test for poll_interval too low (0)
- [x] Added test for poll_interval too high (61)
- [x] Added test for boundary values (1 and 60)
- [x] Run full test suite - all 368 tests pass
- [x] Run `ruff check` - all checks pass

Fixes #48