### PR TITLE
Fix race condition in forwarding rules cache refresh

### DIFF
--- a/src/intelstream/discord/cogs/message_forwarding.py
+++ b/src/intelstream/discord/cogs/message_forwarding.py
@@ -29,16 +29,18 @@ class MessageForwarding(commands.Cog):
         await self._refresh_cache()
 
     async def _refresh_cache(self) -> None:
-        self._rules_cache.clear()
+        new_cache: dict[str, list[Any]] = {}
         total_rules = 0
         for guild in self.bot.guilds:
             rules = await self.bot.repository.get_forwarding_rules_for_guild(str(guild.id))
             for rule in rules:
                 if rule.is_active:
-                    if rule.source_channel_id not in self._rules_cache:
-                        self._rules_cache[rule.source_channel_id] = []
-                    self._rules_cache[rule.source_channel_id].append(rule)
+                    if rule.source_channel_id not in new_cache:
+                        new_cache[rule.source_channel_id] = []
+                    new_cache[rule.source_channel_id].append(rule)
                     total_rules += 1
+
+        self._rules_cache = new_cache
 
         logger.info(
             "Forwarding rules cache refreshed",


### PR DESCRIPTION
## Summary

- Fixed race condition where messages arriving during cache refresh would not be forwarded
- Changed from `clear()` + rebuild pattern to atomic swap pattern - old cache remains accessible until new one is fully built

## Problem

The `_refresh_cache()` method was clearing the cache before rebuilding it. During the rebuild window (which involves async database queries for each guild), any messages arriving would find an empty cache and not be forwarded.

## Solution

Build a new cache dict, then replace the reference in one atomic operation.

Fixes #35

## Test plan

- [x] Existing tests pass (365 tests)
- [x] Ruff lint and format checks pass
- [x] MyPy type check passes

@greptile