### PR TITLE
Fix N+1 query pattern in content posting

### DIFF
--- a/src/intelstream/database/repository.py
+++ b/src/intelstream/database/repository.py
@@ -110,6 +110,14 @@ class Repository:
             result = await session.execute(select(Source).where(Source.id == source_id))
             return result.scalar_one_or_none()
 
+    async def get_sources_by_ids(self, source_ids: set[str]) -> dict[str, Source]:
+        if not source_ids:
+            return {}
+        async with self.session() as session:
+            result = await session.execute(select(Source).where(Source.id.in_(source_ids)))
+            sources = result.scalars().all()
+            return {source.id: source for source in sources}
+
     async def get_source_by_name(self, name: str) -> Source | None:
         async with self.session() as session:
             result = await session.execute(select(Source).where(Source.name == name))

--- a/src/intelstream/services/content_poster.py
+++ b/src/intelstream/services/content_poster.py
@@ -142,11 +142,14 @@ class ContentPoster:
             logger.debug("No unposted content items to post")
             return 0
 
+        source_ids = {item.source_id for item in items}
+        sources_map = await self._bot.repository.get_sources_by_ids(source_ids)
+
         posted_count = 0
 
         for item in items:
             try:
-                source = await self._bot.repository.get_source_by_id(item.source_id)
+                source = sources_map.get(item.source_id)
                 if source is None:
                     logger.warning("Source not found for content item", item_id=item.id)
                     continue

--- a/tests/test_services/test_content_poster.py
+++ b/tests/test_services/test_content_poster.py
@@ -216,7 +216,9 @@ class TestContentPosterPostUnpostedItems:
         mock_source.name = "Test Source"
         mock_source.guild_id = "123"
         mock_source.channel_id = "456"
-        mock_bot.repository.get_source_by_id = AsyncMock(return_value=mock_source)
+        mock_bot.repository.get_sources_by_ids = AsyncMock(
+            return_value={sample_content_item.source_id: mock_source}
+        )
         mock_bot.repository.mark_content_item_posted = AsyncMock()
 
         result = await content_poster.post_unposted_items(guild_id=123)
@@ -251,7 +253,9 @@ class TestContentPosterPostUnpostedItems:
         mock_source.name = "Test Source"
         mock_source.guild_id = None
         mock_source.channel_id = None
-        mock_bot.repository.get_source_by_id = AsyncMock(return_value=mock_source)
+        mock_bot.repository.get_sources_by_ids = AsyncMock(
+            return_value={sample_content_item.source_id: mock_source}
+        )
         mock_bot.repository.mark_content_item_posted = AsyncMock()
 
         result = await content_poster.post_unposted_items(guild_id=123)
@@ -271,7 +275,9 @@ class TestContentPosterPostUnpostedItems:
         mock_source.name = "Test Source"
         mock_source.guild_id = "999"
         mock_source.channel_id = "456"
-        mock_bot.repository.get_source_by_id = AsyncMock(return_value=mock_source)
+        mock_bot.repository.get_sources_by_ids = AsyncMock(
+            return_value={sample_content_item.source_id: mock_source}
+        )
 
         result = await content_poster.post_unposted_items(guild_id=123)
 
@@ -291,7 +297,9 @@ class TestContentPosterPostUnpostedItems:
         mock_source.name = "Test Source"
         mock_source.guild_id = None
         mock_source.channel_id = None
-        mock_bot.repository.get_source_by_id = AsyncMock(return_value=mock_source)
+        mock_bot.repository.get_sources_by_ids = AsyncMock(
+            return_value={sample_content_item.source_id: mock_source}
+        )
 
         result = await content_poster.post_unposted_items(guild_id=123)
 
@@ -311,7 +319,9 @@ class TestContentPosterPostUnpostedItems:
         mock_source.name = "Test Source"
         mock_source.guild_id = "123"
         mock_source.channel_id = "456"
-        mock_bot.repository.get_source_by_id = AsyncMock(return_value=mock_source)
+        mock_bot.repository.get_sources_by_ids = AsyncMock(
+            return_value={sample_content_item.source_id: mock_source}
+        )
 
         result = await content_poster.post_unposted_items(guild_id=123)
 
@@ -335,7 +345,9 @@ class TestContentPosterPostUnpostedItems:
         mock_source.name = "Test Source"
         mock_source.guild_id = "123"
         mock_source.channel_id = "456"
-        mock_bot.repository.get_source_by_id = AsyncMock(return_value=mock_source)
+        mock_bot.repository.get_sources_by_ids = AsyncMock(
+            return_value={sample_content_item.source_id: mock_source}
+        )
 
         result = await content_poster.post_unposted_items(guild_id=123)
 
@@ -347,7 +359,7 @@ class TestContentPosterPostUnpostedItems:
         mock_bot.repository.get_unposted_content_items = AsyncMock(
             return_value=[sample_content_item]
         )
-        mock_bot.repository.get_source_by_id = AsyncMock(return_value=None)
+        mock_bot.repository.get_sources_by_ids = AsyncMock(return_value={})
 
         result = await content_poster.post_unposted_items(guild_id=123)
 


### PR DESCRIPTION
## Summary

- Add `get_sources_by_ids()` repository method for batch loading sources
- Update `post_unposted_items()` to batch-fetch all sources in one query
- Update tests to use the new batch method

## Problem

The `post_unposted_items()` method had a classic N+1 query problem. For each unposted content item, it made a separate database query to fetch its source:

```python
for item in items:  # N items
    source = await self._bot.repository.get_source_by_id(item.source_id)  # N queries
```

With 100 unposted items, this resulted in 101 database queries.

## Solution

Collect all unique source IDs first, then fetch all sources in a single batch query:

```python
source_ids = {item.source_id for item in items}
sources_map = await self._bot.repository.get_sources_by_ids(source_ids)  # 1 query

for item in items:
    source = sources_map.get(item.source_id)
```

This reduces queries from N+1 to 2 (one for items, one for sources).

## Test plan

- [x] All 27 content poster tests pass
- [x] Full test suite passes (365 tests)
- [x] Ruff lint and format checks pass
- [x] MyPy type check passes

Fixes #36

@greptile