### PR TITLE
Add database index on discord_message_id column

### DIFF
--- a/src/intelstream/database/models.py
+++ b/src/intelstream/database/models.py
@@ -64,7 +64,7 @@ class ContentItem(Base):
     summary: Mapped[str | None] = mapped_column(Text, nullable=True)
     thumbnail_url: Mapped[str | None] = mapped_column(String(1024), nullable=True)
     posted_to_discord: Mapped[bool] = mapped_column(Boolean, default=False)
-    discord_message_id: Mapped[str | None] = mapped_column(String(36), nullable=True)
+    discord_message_id: Mapped[str | None] = mapped_column(String(36), nullable=True, index=True)
     created_at: Mapped[datetime] = mapped_column(DateTime, default=lambda: datetime.now(UTC))
 
     source: Mapped["Source"] = relationship("Source", back_populates="content_items")


### PR DESCRIPTION
## Summary

- Add index to `discord_message_id` column in `content_items` table

## Context

While this column is not currently queried directly (it's only written to when marking items as posted), adding an index is a defensive measure that will improve performance if future features need to look up content by Discord message ID.

The index has minimal overhead on writes since `discord_message_id` is only set once per content item.

## Test plan

- [x] All 31 database tests pass
- [x] Ruff lint and format checks pass
- [x] MyPy type check passes

Fixes #42

@greptile