### PR TITLE
Add pause_reason field to differentiate inactive source states

### DIFF
--- a/src/intelstream/database/models.py
+++ b/src/intelstream/database/models.py
@@ -19,6 +19,12 @@ class SourceType(enum.Enum):
     BLOG = "blog"
 
 
+class PauseReason(enum.Enum):
+    NONE = "none"
+    USER_PAUSED = "user_paused"
+    CONSECUTIVE_FAILURES = "consecutive_failures"
+
+
 class Source(Base):
     __tablename__ = "sources"
 
@@ -36,6 +42,9 @@ class Source(Base):
     consecutive_failures: Mapped[int] = mapped_column(Integer, default=0, server_default="0")
     poll_interval_minutes: Mapped[int] = mapped_column(Integer, default=5)
     is_active: Mapped[bool] = mapped_column(Boolean, default=True)
+    pause_reason: Mapped[str] = mapped_column(
+        String(32), default=PauseReason.NONE.value, server_default="none"
+    )
     last_polled_at: Mapped[datetime | None] = mapped_column(DateTime, nullable=True)
     created_at: Mapped[datetime] = mapped_column(DateTime, default=lambda: datetime.now(UTC))
     updated_at: Mapped[datetime] = mapped_column(

--- a/src/intelstream/database/repository.py
+++ b/src/intelstream/database/repository.py
@@ -14,6 +14,7 @@ from intelstream.database.models import (
     DiscordConfig,
     ExtractionCache,
     ForwardingRule,
+    PauseReason,
     Source,
     SourceType,
 )
@@ -25,6 +26,7 @@ SOURCES_MIGRATIONS: list[tuple[str, str]] = [
     ("consecutive_failures", "INTEGER DEFAULT 0"),
     ("guild_id", "VARCHAR(36)"),
     ("channel_id", "VARCHAR(36)"),
+    ("pause_reason", "VARCHAR(32) DEFAULT 'none'"),
 ]
 
 
@@ -135,12 +137,21 @@ class Repository:
                 source.last_polled_at = datetime.now(UTC)
                 await session.commit()
 
-    async def set_source_active(self, identifier: str, is_active: bool) -> Source | None:
+    async def set_source_active(
+        self,
+        identifier: str,
+        is_active: bool,
+        pause_reason: PauseReason | None = None,
+    ) -> Source | None:
         async with self.session() as session:
             result = await session.execute(select(Source).where(Source.identifier == identifier))
             source = result.scalar_one_or_none()
             if source:
                 source.is_active = is_active
+                if pause_reason is not None:
+                    source.pause_reason = pause_reason.value
+                elif is_active:
+                    source.pause_reason = PauseReason.NONE.value
                 await session.commit()
                 await session.refresh(source)
             return source

--- a/tests/test_discord/test_source_management.py
+++ b/tests/test_discord/test_source_management.py
@@ -3,7 +3,7 @@ from unittest.mock import AsyncMock, MagicMock
 import discord
 import pytest
 
-from intelstream.database.models import SourceType
+from intelstream.database.models import PauseReason, SourceType
 from intelstream.discord.cogs.source_management import (
     SourceManagement,
     parse_source_identifier,
@@ -222,6 +222,7 @@ class TestSourceManagementList:
         source1.name = "Source 1"
         source1.type = SourceType.SUBSTACK
         source1.is_active = True
+        source1.pause_reason = PauseReason.NONE.value
         source1.last_polled_at = None
         source1.channel_id = "123456789"
 
@@ -229,6 +230,8 @@ class TestSourceManagementList:
         source2.name = "Source 2"
         source2.type = SourceType.RSS
         source2.is_active = False
+        source2.pause_reason = PauseReason.USER_PAUSED.value
+        source2.consecutive_failures = 0
         source2.last_polled_at = None
         source2.channel_id = None
 
@@ -306,7 +309,9 @@ class TestSourceManagementToggle:
             source_management, interaction, name="Test Source"
         )
 
-        mock_bot.repository.set_source_active.assert_called_once_with("test-identifier", True)
+        mock_bot.repository.set_source_active.assert_called_once_with(
+            "test-identifier", True, pause_reason=PauseReason.NONE
+        )
         call_args = interaction.followup.send.call_args
         assert "enabled" in call_args[0][0]
 
@@ -332,7 +337,9 @@ class TestSourceManagementToggle:
             source_management, interaction, name="Test Source"
         )
 
-        mock_bot.repository.set_source_active.assert_called_once_with("test-identifier", False)
+        mock_bot.repository.set_source_active.assert_called_once_with(
+            "test-identifier", False, pause_reason=PauseReason.USER_PAUSED
+        )
         call_args = interaction.followup.send.call_args
         assert "disabled" in call_args[0][0]
 


### PR DESCRIPTION
## Summary

- Add `PauseReason` enum to track why a source was deactivated
- Update `/source toggle` to set `USER_PAUSED` when disabling
- Update `/source list` to show the specific reason when a source is paused

## Problem

Previously, both user-paused sources and failure-disabled sources had the same `is_active = False` state. This made it impossible to:
1. Tell users why a source is inactive
2. Implement auto-recovery logic that respects user preferences

## Solution

Add a `pause_reason` field with three possible values:
- `NONE`: Source is active
- `USER_PAUSED`: User manually paused via `/source toggle`
- `CONSECUTIVE_FAILURES`: Reserved for future auto-disable functionality

The `/source list` command now shows:
- "Active" for active sources
- "Paused by user" for user-paused sources
- "Disabled: N consecutive failures" for failure-disabled sources

## Test plan

- [x] Full test suite passes (365 tests)
- [x] Ruff lint and format checks pass
- [x] MyPy type check passes
- [x] Updated tests to verify pause_reason is set correctly

Fixes #46

@greptile