### PR TITLE
Add rate limiting for external source fetching

### DIFF
--- a/src/intelstream/config.py
+++ b/src/intelstream/config.py
@@ -83,6 +83,13 @@ class Settings(BaseSettings):
         description="Maximum Discord message length (Discord limit is 2000)",
     )
 
+    fetch_delay_seconds: float = Field(
+        default=1.0,
+        ge=0,
+        le=30.0,
+        description="Delay between fetching sources to avoid rate limiting",
+    )
+
     @field_validator("database_url")
     @classmethod
     def ensure_data_directory(cls, v: str) -> str:

--- a/src/intelstream/services/pipeline.py
+++ b/src/intelstream/services/pipeline.py
@@ -72,8 +72,9 @@ class ContentPipeline:
         logger.info("Fetching content from sources", count=len(sources))
 
         total_new_items = 0
+        fetch_delay = self._settings.fetch_delay_seconds
 
-        for source in sources:
+        for i, source in enumerate(sources):
             try:
                 new_items = await self._fetch_source(source)
                 total_new_items += new_items
@@ -84,6 +85,9 @@ class ContentPipeline:
                     source_type=source.type.value,
                     error=str(e),
                 )
+
+            if fetch_delay > 0 and i < len(sources) - 1:
+                await asyncio.sleep(fetch_delay)
 
         logger.info("Fetch complete", total_new_items=total_new_items)
         return total_new_items


### PR DESCRIPTION
## Summary
- Add configurable `fetch_delay_seconds` setting (default 1.0s, range 0-30s)
- Apply delay between sequential source fetches in pipeline to prevent aggressive crawling
- Add test for rate limiting behavior

## Test plan
- [x] All 366 tests pass
- [x] Lint checks pass (ruff check, ruff format)
- [x] Type checks pass (mypy)

Fixes #37

@greptile