### PR TITLE
Replace MD5 with SHA256 for content hashing

### DIFF
--- a/src/intelstream/adapters/strategies/llm_extraction.py
+++ b/src/intelstream/adapters/strategies/llm_extraction.py
@@ -123,9 +123,9 @@ class LLMExtractionStrategy(DiscoveryStrategy):
 
         if main:
             text = " ".join(main.get_text().split())
-            return hashlib.md5(text.encode()).hexdigest()
+            return hashlib.sha256(text.encode()).hexdigest()
 
-        return hashlib.md5(html.encode()).hexdigest()
+        return hashlib.sha256(html.encode()).hexdigest()
 
     async def _fetch_html(self, url: str) -> str | None:
         headers = {


### PR DESCRIPTION
## Summary

- Replace MD5 with SHA256 for content hashing in LLM extraction strategy
- MD5 is cryptographically broken and triggers security scanner warnings
- SHA256 is the modern standard with negligible performance overhead

## Test plan

- [x] All existing tests pass (387 tests)
- [x] Ruff linter passes
- [x] Specific `test_llm_extraction.py` tests pass (12 tests)

Fixes #94

@greptile