### PR TITLE
Add __repr__ to Settings to mask sensitive fields

### DIFF
--- a/src/intelstream/config.py
+++ b/src/intelstream/config.py
@@ -135,6 +135,19 @@ class Settings(BaseSettings):
                 path.parent.mkdir(parents=True, exist_ok=True)
         return v
 
+    def __repr__(self) -> str:
+        return (
+            f"Settings("
+            f"discord_bot_token='*****', "
+            f"discord_guild_id={self.discord_guild_id}, "
+            f"discord_owner_id={self.discord_owner_id}, "
+            f"anthropic_api_key='*****', "
+            f"youtube_api_key={'*****' if self.youtube_api_key else None}, "
+            f"database_url={self.database_url!r}, "
+            f"log_level={self.log_level!r}"
+            f")"
+        )
+
 
 @lru_cache
 def get_settings() -> Settings:


### PR DESCRIPTION
## Summary

- Add custom `__repr__` method to Settings class that masks sensitive fields
- Prevents accidental logging of API keys (discord_bot_token, anthropic_api_key, youtube_api_key)
- Non-sensitive configuration values remain visible for debugging

## Test plan

- [x] All existing tests pass (389 tests)
- [x] New tests verify secrets are masked in repr
- [x] New test verifies None youtube_api_key is handled correctly
- [x] Ruff linter passes

Fixes #81

@greptile