### PR TITLE
Reduce excessive DEBUG logging in message forwarding

### DIFF
--- a/src/intelstream/discord/cogs/message_forwarding.py
+++ b/src/intelstream/discord/cogs/message_forwarding.py
@@ -62,25 +62,8 @@ class MessageForwarding(commands.Cog):
         if not rules:
             return
 
-        logger.debug(
-            "Message received in forwarding source channel",
-            channel_id=channel_id,
-            channel_name=getattr(message.channel, "name", "Unknown"),
-            message_id=message.id,
-            author_id=message.author.id,
-            rules_count=len(rules),
-        )
-
         for rule in rules:
             destination_id = int(rule.destination_channel_id)
-
-            logger.debug(
-                "Attempting to forward message",
-                source_channel_id=channel_id,
-                destination_id=destination_id,
-                destination_type=rule.destination_type,
-                rule_id=rule.id,
-            )
 
             forwarded = await self.forwarder.forward_message(
                 message=message,

--- a/src/intelstream/services/message_forwarder.py
+++ b/src/intelstream/services/message_forwarder.py
@@ -73,50 +73,16 @@ class MessageForwarder:
     async def _get_destination(
         self, destination_id: int, destination_type: str
     ) -> discord.TextChannel | discord.Thread | None:
-        logger.debug(
-            "Resolving forwarding destination",
-            destination_id=destination_id,
-            destination_type=destination_type,
-        )
-
         if destination_type == "thread":
             channel = self.bot.get_channel(destination_id)
-            logger.debug(
-                "Thread lookup via get_channel",
-                destination_id=destination_id,
-                found=channel is not None,
-                channel_type=type(channel).__name__ if channel else None,
-            )
             if isinstance(channel, discord.Thread):
-                logger.debug(
-                    "Thread found via get_channel",
-                    thread_id=destination_id,
-                    thread_name=channel.name,
-                    archived=channel.archived,
-                )
                 return channel
 
-            logger.debug(
-                "Thread not in channel cache, searching guilds",
-                destination_id=destination_id,
-                guild_count=len(self.bot.guilds),
-            )
             for guild in self.bot.guilds:
                 thread = guild.get_thread(destination_id)
                 if thread is not None:
-                    logger.debug(
-                        "Thread found via guild search",
-                        thread_id=destination_id,
-                        thread_name=thread.name,
-                        guild_id=guild.id,
-                        archived=thread.archived,
-                    )
                     return thread
 
-            logger.debug(
-                "Thread not in any guild cache, attempting API fetch",
-                destination_id=destination_id,
-            )
             for guild in self.bot.guilds:
                 try:
                     fetched = await guild.fetch_channel(destination_id)
@@ -124,35 +90,21 @@ class MessageForwarder:
                         logger.info(
                             "Thread fetched from API",
                             thread_id=destination_id,
-                            thread_name=fetched.name,
                             guild_id=guild.id,
-                            archived=fetched.archived,
                         )
                         return fetched
                 except discord.NotFound:
                     continue
                 except discord.Forbidden:
-                    logger.debug(
-                        "No permission to fetch channel in guild",
-                        guild_id=guild.id,
-                        destination_id=destination_id,
-                    )
                     continue
 
             logger.warning(
-                "Thread not found in any cache or via API",
+                "Thread not found",
                 destination_id=destination_id,
-                guilds_searched=[g.id for g in self.bot.guilds],
             )
             return None
 
         channel = self.bot.get_channel(destination_id)
-        logger.debug(
-            "Channel lookup via get_channel",
-            destination_id=destination_id,
-            found=channel is not None,
-            channel_type=type(channel).__name__ if channel else None,
-        )
         if isinstance(channel, discord.TextChannel):
             return channel
 


### PR DESCRIPTION
## Summary

- Remove verbose DEBUG logs that fire on every message/rule in message forwarding
- Consolidate destination resolution logs in message_forwarder service
- Keep useful INFO/WARNING logs for unusual cases and actual failures

Changes:
- `message_forwarding.py`: Remove pre-forward DEBUG logs per message/rule
- `message_forwarder.py`: Remove step-by-step DEBUG logs in `_get_destination()`

## Test plan

- [x] All existing tests pass (387 tests)
- [x] Message forwarding tests pass (34 tests specifically)
- [x] Ruff linter passes

Fixes #100
Fixes #87

@greptile