### PR TITLE
Enable DEBUG logging for third-party libraries when LOG_LEVEL=DEBUG

### DIFF
--- a/src/intelstream/main.py
+++ b/src/intelstream/main.py
@@ -30,9 +30,10 @@ def configure_logging(log_level: str) -> None:
         level=getattr(logging, log_level.upper()),
     )
 
-    logging.getLogger("discord").setLevel(logging.WARNING)
-    logging.getLogger("discord.http").setLevel(logging.WARNING)
-    logging.getLogger("httpx").setLevel(logging.WARNING)
+    third_party_level = logging.DEBUG if log_level.upper() == "DEBUG" else logging.WARNING
+    logging.getLogger("discord").setLevel(third_party_level)
+    logging.getLogger("discord.http").setLevel(third_party_level)
+    logging.getLogger("httpx").setLevel(third_party_level)
 
 
 def main() -> None:


### PR DESCRIPTION
## Summary

- When `LOG_LEVEL=DEBUG`, third-party loggers (discord.py, httpx) now also use DEBUG level
- For other log levels, third-party loggers remain at WARNING to reduce noise
- Enables troubleshooting Discord connection and HTTP issues when needed

## Test plan

- [x] All existing tests pass (387 tests)
- [x] Ruff linter passes

Fixes #90

@greptile