### PR TITLE
Add validation for API keys and summarization delay

### DIFF
--- a/src/intelstream/config.py
+++ b/src/intelstream/config.py
@@ -14,7 +14,7 @@ class Settings(BaseSettings):
         extra="ignore",
     )
 
-    discord_bot_token: str = Field(description="Discord bot token")
+    discord_bot_token: str = Field(min_length=1, description="Discord bot token")
     discord_guild_id: int = Field(description="Discord guild (server) ID")
     discord_channel_id: int | None = Field(
         default=None,
@@ -24,7 +24,7 @@ class Settings(BaseSettings):
         description="Discord user ID of the bot owner for DM notifications"
     )
 
-    anthropic_api_key: str = Field(description="Anthropic API key for Claude")
+    anthropic_api_key: str = Field(min_length=1, description="Anthropic API key for Claude")
 
     youtube_api_key: str | None = Field(default=None, description="YouTube Data API key (optional)")
 
@@ -99,7 +99,7 @@ class Settings(BaseSettings):
 
     summarization_delay_seconds: float = Field(
         default=0.5,
-        ge=0,
+        ge=0.1,
         le=5.0,
         description="Delay between summarization requests to avoid rate limiting",
     )

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -91,3 +91,31 @@ class TestSettings:
         repr_str = repr(settings)
 
         assert "youtube_api_key=None" in repr_str
+
+    def test_empty_discord_bot_token_rejected(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("DISCORD_BOT_TOKEN", "")
+        monkeypatch.setenv("DISCORD_GUILD_ID", "123456789")
+        monkeypatch.setenv("DISCORD_OWNER_ID", "111222333")
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-test")
+
+        with pytest.raises(ValidationError):
+            Settings(_env_file=None)
+
+    def test_empty_anthropic_api_key_rejected(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("DISCORD_BOT_TOKEN", "test_token")
+        monkeypatch.setenv("DISCORD_GUILD_ID", "123456789")
+        monkeypatch.setenv("DISCORD_OWNER_ID", "111222333")
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "")
+
+        with pytest.raises(ValidationError):
+            Settings(_env_file=None)
+
+    def test_summarization_delay_minimum(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("DISCORD_BOT_TOKEN", "test_token")
+        monkeypatch.setenv("DISCORD_GUILD_ID", "123456789")
+        monkeypatch.setenv("DISCORD_OWNER_ID", "111222333")
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-test")
+        monkeypatch.setenv("SUMMARIZATION_DELAY_SECONDS", "0")
+
+        with pytest.raises(ValidationError):
+            Settings(_env_file=None)


### PR DESCRIPTION
## Summary

- Add `min_length=1` validation to `discord_bot_token` and `anthropic_api_key` to reject empty strings at startup
- Change `summarization_delay_seconds` minimum from 0 to 0.1 to ensure rate limiting is always active

## Test plan

- [x] All tests pass (392 tests)
- [x] New tests verify empty API keys are rejected
- [x] New test verifies summarization_delay_seconds=0 is rejected
- [x] Ruff linter passes

Fixes #80
Fixes #97

@greptile