### PR TITLE
Add structural validation to LLM extraction JSON parsing

### DIFF
--- a/src/intelstream/adapters/strategies/llm_extraction.py
+++ b/src/intelstream/adapters/strategies/llm_extraction.py
@@ -80,9 +80,7 @@ class LLMExtractionStrategy(DiscoveryStrategy):
                     posts = []
                     for p in posts_data:
                         if isinstance(p, dict) and isinstance(p.get("url"), str) and p.get("url"):
-                            posts.append(
-                                DiscoveredPost(url=p["url"], title=p.get("title", ""))
-                            )
+                            posts.append(DiscoveredPost(url=p["url"], title=p.get("title", "")))
                     if posts:
                         logger.debug(
                             "Using cached LLM extraction",

--- a/tests/test_adapters/test_strategies/test_llm_extraction.py
+++ b/tests/test_adapters/test_strategies/test_llm_extraction.py
@@ -205,9 +205,7 @@ class TestLLMExtractionStrategy:
         result = llm_strategy._extract_json_from_response(text)
         assert len(result) == 1
 
-    async def test_extract_json_filters_non_dict_items(
-        self, llm_strategy: LLMExtractionStrategy
-    ):
+    async def test_extract_json_filters_non_dict_items(self, llm_strategy: LLMExtractionStrategy):
         text = '["string1", "string2", {"url": "valid", "title": "Valid Post"}]'
         result = llm_strategy._extract_json_from_response(text)
         assert len(result) == 1
@@ -237,9 +235,7 @@ class TestLLMExtractionStrategy:
         assert len(result) == 1
         assert result[0]["url"] == "valid"
 
-    async def test_extract_json_handles_non_string_title(
-        self, llm_strategy: LLMExtractionStrategy
-    ):
+    async def test_extract_json_handles_non_string_title(self, llm_strategy: LLMExtractionStrategy):
         text = '[{"url": "test", "title": 123}]'
         result = llm_strategy._extract_json_from_response(text)
         assert len(result) == 1
@@ -286,7 +282,10 @@ class TestLLMExtractionStrategy:
         cached = MagicMock(spec=ExtractionCache)
         cached.content_hash = expected_hash
         cached.posts_json = json.dumps(
-            [{"url": "", "title": "Empty URL"}, {"url": "https://example.com/valid", "title": "Valid"}]
+            [
+                {"url": "", "title": "Empty URL"},
+                {"url": "https://example.com/valid", "title": "Valid"},
+            ]
         )
 
         mock_repository.get_extraction_cache.return_value = cached


### PR DESCRIPTION
## Summary

- Add structural validation to LLM extraction response parsing
- Prevent TypeError/AttributeError when LLM returns malformed JSON (e.g., array of strings instead of dicts)
- Add validation to cached data loading as well

## Changes

- Update `_extract_json_from_response` to validate each item:
  - Check item is a dict
  - Check url field exists and is a non-empty string
  - Convert non-string titles to strings safely
- Update cache loading in `discover` to validate cached data structure
- Simplify `_extract_with_llm` since validation is now centralized

## Test plan

- [x] Test non-dict items are filtered out
- [x] Test items without url field are filtered out
- [x] Test items with null url are filtered out
- [x] Test items with empty url are filtered out
- [x] Test non-string titles are converted to strings
- [x] Test non-list responses return empty
- [x] Test cached data with malformed entries is validated
- [x] All 403 tests pass

Fixes #103

@greptile