### PR TITLE
Fix potential NameError when HTTP client creation fails

### DIFF
--- a/src/intelstream/services/web_fetcher.py
+++ b/src/intelstream/services/web_fetcher.py
@@ -31,15 +31,15 @@ class WebFetcher:
         self._owns_client = http_client is None
 
     async def fetch(self, url: str) -> WebContent:
-        client = self._client or httpx.AsyncClient(
-            timeout=DEFAULT_TIMEOUT,
-            follow_redirects=True,
-            headers={
-                "User-Agent": "Mozilla/5.0 (compatible; IntelStream/1.0; +https://github.com/intelstream)"
-            },
-        )
-
+        client = None
         try:
+            client = self._client or httpx.AsyncClient(
+                timeout=DEFAULT_TIMEOUT,
+                follow_redirects=True,
+                headers={
+                    "User-Agent": "Mozilla/5.0 (compatible; IntelStream/1.0; +https://github.com/intelstream)"
+                },
+            )
             response = await client.get(url)
             response.raise_for_status()
 

--- a/tests/test_services/test_web_fetcher.py
+++ b/tests/test_services/test_web_fetcher.py
@@ -1,4 +1,4 @@
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import httpx
 import pytest
@@ -299,3 +299,12 @@ class TestWebFetcher:
         result = await fetcher.fetch("https://example.com/article")
 
         assert result.thumbnail_url == "https://example.com/twitter-image.jpg"
+
+    async def test_fetch_no_nameerror_when_client_creation_fails(self):
+        with patch(
+            "intelstream.services.web_fetcher.httpx.AsyncClient",
+            side_effect=RuntimeError("Client creation failed"),
+        ):
+            fetcher = WebFetcher()
+            with pytest.raises(RuntimeError, match="Client creation failed"):
+                await fetcher.fetch("https://example.com/article")


### PR DESCRIPTION
## Summary

- Initialize `client` to `None` before the try block in `WebFetcher.fetch()`
- Prevents `NameError` in the finally block if `httpx.AsyncClient()` raises during creation
- Add test case to verify the fix

## Problem

If `httpx.AsyncClient()` raises an exception during creation (e.g., due to invalid SSL config), the `client` variable is never assigned. When the `finally` block executes, accessing `client` in `client is not None` raises `NameError`, masking the original error.

## Changes

- Move client creation inside the try block
- Initialize `client = None` before try to ensure it's always defined
- Add test case that mocks `httpx.AsyncClient` to raise during creation

## Test plan

- [x] Test client creation failure no longer causes NameError
- [x] All 397 tests pass
- [x] Linting passes
- [x] Type checking passes

Fixes #72

@greptile