### PR TITLE
Clamp max_tokens to model limit in SummarizationService

### DIFF
--- a/tests/test_discord/test_summarize.py
+++ b/tests/test_discord/test_summarize.py
@@ -14,6 +14,10 @@ def mock_bot():
     bot.settings = MagicMock()
     bot.settings.anthropic_api_key = "test-api-key"
     bot.settings.youtube_api_key = "test-youtube-key"
+    bot.settings.http_timeout_seconds = 30.0
+    bot.settings.summary_model_interactive = "claude-sonnet-4-20250514"
+    bot.settings.summary_max_tokens = 2048
+    bot.settings.summary_max_input_length = 100000
     return bot
 
 


### PR DESCRIPTION
## Summary

- Add model-aware max_tokens validation to prevent API errors
- Clamp max_tokens at initialization when it exceeds model limit
- Log warning when clamping occurs

## Problem

The config allows `summary_max_tokens` up to 8192, but Claude models have varying limits:
- Claude 3 Haiku: 4096
- Claude 3.5 Haiku: 8192
- Claude Sonnet 4: 16384
- etc.

If max_tokens exceeds the model's limit, the Anthropic API rejects the request with an error. This is confusing because the config validates but the API call fails.

## Solution

- Add `MODEL_MAX_OUTPUT_TOKENS` mapping for known Claude models
- Clamp max_tokens at service initialization with a warning log
- Use conservative default (4096) for unknown models
- This allows graceful handling without crashing

## Test plan

- [x] Test max_tokens is clamped when exceeding model limit
- [x] Test max_tokens unchanged when within limit
- [x] Test default limit used for unknown models
- [x] Fix mock_bot fixture to include required settings
- [x] All 399 tests pass
- [x] Linting passes
- [x] Type checking passes

Fixes #89

@greptile