### PR TITLE
Add global error handler for Discord app commands

### DIFF
--- a/src/intelstream/bot.py
+++ b/src/intelstream/bot.py
@@ -80,9 +80,7 @@ class RestrictedCommandTree(app_commands.CommandTree):
             interaction, "An unexpected error occurred. Please try again."
         )
 
-    async def _send_error_response(
-        self, interaction: discord.Interaction, message: str
-    ) -> None:
+    async def _send_error_response(self, interaction: discord.Interaction, message: str) -> None:
         try:
             if interaction.response.is_done():
                 await interaction.followup.send(message, ephemeral=True)

--- a/tests/test_discord/test_bot.py
+++ b/tests/test_discord/test_bot.py
@@ -71,9 +71,7 @@ class TestRestrictedCommandTreeErrorHandler:
         interaction.followup.send = AsyncMock()
         return interaction
 
-    async def test_handles_forbidden_error(
-        self, mock_interaction: MagicMock
-    ) -> None:
+    async def test_handles_forbidden_error(self, mock_interaction: MagicMock) -> None:
         mock_response = MagicMock()
         mock_response.status = 403
         error = app_commands.CommandInvokeError(
@@ -86,9 +84,7 @@ class TestRestrictedCommandTreeErrorHandler:
         mock_interaction.response.send_message.assert_not_called()
         mock_interaction.followup.send.assert_not_called()
 
-    async def test_handles_not_found_error(
-        self, mock_interaction: MagicMock
-    ) -> None:
+    async def test_handles_not_found_error(self, mock_interaction: MagicMock) -> None:
         mock_response = MagicMock()
         mock_response.status = 404
         error = app_commands.CommandInvokeError(
@@ -101,9 +97,7 @@ class TestRestrictedCommandTreeErrorHandler:
         mock_interaction.response.send_message.assert_not_called()
         mock_interaction.followup.send.assert_not_called()
 
-    async def test_handles_http_exception_with_response(
-        self, mock_interaction: MagicMock
-    ) -> None:
+    async def test_handles_http_exception_with_response(self, mock_interaction: MagicMock) -> None:
         mock_response = MagicMock()
         mock_response.status = 500
         error = app_commands.CommandInvokeError(
@@ -121,9 +115,7 @@ class TestRestrictedCommandTreeErrorHandler:
         assert args[0] == mock_interaction
         assert "Discord error" in args[1]
 
-    async def test_handles_generic_exception(
-        self, mock_interaction: MagicMock
-    ) -> None:
+    async def test_handles_generic_exception(self, mock_interaction: MagicMock) -> None:
         error = app_commands.CommandInvokeError(
             mock_interaction.command,
             ValueError("Something went wrong"),
@@ -148,9 +140,7 @@ class TestRestrictedCommandTreeErrorHandler:
             MagicMock(), mock_interaction, "Test error message"
         )
 
-        mock_interaction.followup.send.assert_called_once_with(
-            "Test error message", ephemeral=True
-        )
+        mock_interaction.followup.send.assert_called_once_with("Test error message", ephemeral=True)
         mock_interaction.response.send_message.assert_not_called()
 
     async def test_send_error_response_uses_response_when_not_done(


### PR DESCRIPTION
## Summary

- Add global error handler for Discord app commands in `RestrictedCommandTree`
- Handle Discord-specific errors gracefully with appropriate logging
- Send user-friendly error messages when possible

## Problem

All Discord cogs call `interaction.response.defer()`, `interaction.response.send_message()`, and `interaction.followup.send()` without error handling. These can fail for various reasons:

1. **Interaction timeout** - Discord interactions must be responded to within 3 seconds
2. **Permission changes** - If bot loses permissions mid-command, `followup.send()` fails with `Forbidden`
3. **Discord API issues** - Temporary Discord outages cause `HTTPException`
4. **Rate limiting** - Discord rate limits can cause sends to fail

Without error handling:
- Uncaught exceptions crash command handlers
- Users see generic "interaction failed" errors
- No logging of what went wrong

## Solution

Added a global `on_error` handler in `RestrictedCommandTree` that:

| Error Type | Behavior |
|------------|----------|
| `Forbidden` | Log error, don't try to respond (permissions already gone) |
| `NotFound` | Log warning, don't try to respond (interaction expired) |
| `HTTPException` | Log error, attempt to send user-friendly message |
| Other exceptions | Log exception with traceback, attempt to send generic error |

Also added `_send_error_response` helper that:
- Checks if interaction response is done (use followup) or not (use response)
- Silently handles HTTPException when sending error response fails

## Changes

| File | Change |
|------|--------|
| `bot.py` | Added `on_error` and `_send_error_response` methods to `RestrictedCommandTree`, switched to structlog |
| `test_bot.py` | Added tests for error handler |

## Test plan

- [x] Test Forbidden errors are logged without attempting response
- [x] Test NotFound errors are logged without attempting response
- [x] Test HTTPException errors attempt to send error response
- [x] Test generic exceptions log and attempt to send error response
- [x] Test followup is used when response is already done
- [x] Test response is used when response not yet done
- [x] All 429 tests pass
- [x] Linting passes
- [x] Type checking passes

Fixes #74

@greptile