### PR TITLE
Validate SQLite-only database support at startup

### DIFF
--- a/src/intelstream/database/repository.py
+++ b/src/intelstream/database/repository.py
@@ -40,9 +40,8 @@ MAX_POLL_INTERVAL_MINUTES = 60
 class Repository:
     def __init__(self, database_url: str) -> None:
         if not database_url.startswith("sqlite"):
-            raise ValueError(
-                f"Only SQLite databases are supported. Got: {database_url.split('://')[0]}"
-            )
+            db_type = database_url.split("://")[0] if "://" in database_url else database_url
+            raise ValueError(f"Only SQLite databases are supported. Got: {db_type}")
         self._engine = create_async_engine(database_url, echo=False)
         self._session_factory: async_sessionmaker[AsyncSession] = async_sessionmaker(
             self._engine, class_=AsyncSession, expire_on_commit=False

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -26,9 +26,10 @@ class TestRepositoryInitialization:
         with pytest.raises(ValueError, match="Only SQLite databases are supported"):
             Repository("mysql+aiomysql://localhost/test")
 
-    def test_accepts_sqlite_database_url(self) -> None:
+    async def test_accepts_sqlite_database_url(self) -> None:
         repo = Repository("sqlite+aiosqlite:///:memory:")
         assert repo is not None
+        await repo.close()
 
 
 class TestSourceOperations:


### PR DESCRIPTION
## Summary
- Add validation in Repository constructor to reject non-SQLite database URLs
- Provide clear error message indicating only SQLite is supported
- Add tests for the validation logic

This implements Option 3 from #98: document SQLite-only support by validating at startup rather than failing with confusing SQLite-specific SQL errors.

## Test plan
- [x] Test rejects PostgreSQL URLs
- [x] Test rejects MySQL URLs
- [x] Test accepts SQLite URLs
- [x] Existing tests still pass

Closes #98

@greptile