### PR TITLE
Add user permission validation for forwarding rules

### DIFF
--- a/src/intelstream/discord/cogs/message_forwarding.py
+++ b/src/intelstream/discord/cogs/message_forwarding.py
@@ -129,6 +129,17 @@ class MessageForwarding(commands.Cog):
             )
             return
 
+        member = interaction.user
+        if (
+            isinstance(member, discord.Member)
+            and not destination.permissions_for(member).send_messages
+        ):
+            await interaction.followup.send(
+                f"You don't have permission to send messages in {destination.mention}.",
+                ephemeral=True,
+            )
+            return
+
         await self.bot.repository.add_forwarding_rule(
             guild_id=str(interaction.guild_id),
             source_channel_id=str(source.id),


### PR DESCRIPTION
## Summary
- Add validation that the user has send_messages permission in the destination channel
- Previously only the bot's permissions were checked
- Prevents users from configuring forwarding to channels they shouldn't access

## Security fix
Discord slash commands show all channels the bot can see, not just what the user can see. This allowed users to potentially configure forwarding rules to channels they shouldn't have access to.

## Test plan
- [x] Test bot permission check still works
- [x] Test user permission check rejects unauthorized users
- [x] Test success case with both permissions
- [x] All existing tests pass

Closes #96

@greptile