### PR TITLE
Fix forwarded messages to display native URL embeds at full size

### DIFF
--- a/src/intelstream/services/message_forwarder.py
+++ b/src/intelstream/services/message_forwarder.py
@@ -46,13 +46,11 @@ class MessageForwarder:
                         return None
 
                 content = self._build_forwarded_content(message)
-                embeds = message.embeds[:10] if message.embeds else []
                 files = await self._download_attachments(message, destination)
 
                 try:
                     forwarded = await destination.send(
                         content=content,
-                        embeds=embeds,
                         files=files,
                     )
                 except Exception:

--- a/tests/test_services/test_message_forwarder.py
+++ b/tests/test_services/test_message_forwarder.py
@@ -270,7 +270,8 @@ class TestForwardMessage:
         assert result == mock_forwarded
         mock_destination.edit.assert_called_once_with(archived=False)
 
-    async def test_forward_message_with_embeds(self, forwarder, mock_bot):
+    async def test_forward_message_does_not_include_embeds(self, forwarder, mock_bot):
+        """Embeds are not forwarded so Discord can generate native URL previews."""
         mock_destination = MagicMock(spec=discord.TextChannel)
         mock_destination.guild = MagicMock()
         mock_destination.guild.filesize_limit = 8_000_000
@@ -287,7 +288,7 @@ class TestForwardMessage:
         message.id = 222
         message.author = MagicMock()
         message.author.bot = False
-        message.content = "Test"
+        message.content = "Check out this video: https://youtu.be/example"
         message.embeds = [mock_embed]
         message.attachments = []
 
@@ -295,7 +296,8 @@ class TestForwardMessage:
 
         assert result == mock_forwarded
         call_kwargs = mock_destination.send.call_args.kwargs
-        assert call_kwargs["embeds"] == [mock_embed]
+        assert "embeds" not in call_kwargs
+        assert call_kwargs["content"] == "Check out this video: https://youtu.be/example"
 
     async def test_forward_message_closes_files_on_send_failure(self, forwarder, mock_bot):
         mock_file = MagicMock(spec=discord.File)


### PR DESCRIPTION
## Summary

Fixes an issue where forwarded messages displayed YouTube videos and images as tiny thumbnails instead of full-size embeds.

## Problem

When a user posts a YouTube URL in a source channel, Discord auto-generates a rich embed with a large video preview. However, when the bot forwarded the message by copying and re-sending those embed objects, Discord rendered them as "bot embeds" which display much smaller.

**Before (destination channel):**
- YouTube videos: tiny thumbnail in a small embed div
- Images from URLs: tiny thumbnails

**After (destination channel):**
- YouTube videos: full-size video player (same as source)
- Images from URLs: full-size display (same as source)

## Solution

Remove explicit embed forwarding. Instead of copying `message.embeds` and sending them with the forwarded message, we now only send the message content (which contains the URLs). Discord then naturally generates the URL previews, resulting in identical display to the source channel.

## Changes

- `src/intelstream/services/message_forwarder.py`: Removed embed copying from `forward_message()`
- `tests/test_services/test_message_forwarder.py`: Updated test to verify embeds are NOT included in forwarded messages

## Test plan

- [x] Unit tests pass
- [ ] Manual test: Forward a message with a YouTube URL - should display full-size video player
- [ ] Manual test: Forward a message with image URLs - should display full-size images