### PR TITLE
Remove 'do' subcommand requirement from /suck_boobs

### DIFF
--- a/src/intelstream/discord/cogs/suck_boobs.py
+++ b/src/intelstream/discord/cogs/suck_boobs.py
@@ -13,11 +13,6 @@ logger = structlog.get_logger()
 
 
 class SuckBoobs(commands.Cog):
-    suck_boobs_group = app_commands.Group(
-        name="suck_boobs",
-        description="The suck_boobs command",
-    )
-
     def __init__(self, bot: "IntelStreamBot") -> None:
         self.bot = bot
 
@@ -29,8 +24,8 @@ class SuckBoobs(commands.Cog):
             return None
         return random.choice(eligible)
 
-    @suck_boobs_group.command(name="do", description="Suck someone's boobs")
-    async def suck_boobs_do(self, interaction: discord.Interaction) -> None:
+    @app_commands.command(name="suck_boobs", description="Suck someone's boobs")
+    async def suck_boobs(self, interaction: discord.Interaction) -> None:
         if interaction.guild is None or not isinstance(
             interaction.channel, (discord.TextChannel, discord.Thread)
         ):
@@ -58,7 +53,7 @@ class SuckBoobs(commands.Cog):
             f"🍼 {interaction.user.display_name} sucks <@{target.id}>'s boobs 🥛😳"
         )
 
-    @suck_boobs_group.command(name="score", description="Show the suck_boobs leaderboard")
+    @app_commands.command(name="suck_boobs_score", description="Show the suck_boobs leaderboard")
     async def suck_boobs_score(self, interaction: discord.Interaction) -> None:
         if interaction.guild is None:
             await interaction.response.send_message(


### PR DESCRIPTION
## Summary
- Convert `/suck_boobs do` to just `/suck_boobs` (no subcommand needed)
- Convert `/suck_boobs score` to `/suck_boobs_score` (standalone command)

The command group pattern required users to type `/suck_boobs do` which was cumbersome. Now the main action can be invoked directly with `/suck_boobs`.

## Test plan
- [ ] Verify `/suck_boobs` works without any arguments
- [ ] Verify `/suck_boobs_score` shows the leaderboard
- [ ] Verify old `/suck_boobs do` and `/suck_boobs score` no longer appear after syncing commands