### PR TITLE
Fix timezone mismatch in /status command

### DIFF
--- a/src/intelstream/bot.py
+++ b/src/intelstream/bot.py
@@ -206,6 +206,8 @@ class CoreCommands(commands.Cog):
         return f"{hours}h {minutes}m {seconds}s"
 
     def _format_relative_time(self, dt: datetime) -> str:
+        if dt.tzinfo is None:
+            dt = dt.replace(tzinfo=UTC)
         delta = datetime.now(UTC) - dt
         total_seconds = int(delta.total_seconds())
 


### PR DESCRIPTION
## Summary
- Fix TypeError when comparing naive and timezone-aware datetimes in `/status` command
- SQLite returns naive datetimes, but `_format_relative_time` was comparing against `datetime.now(UTC)` which is timezone-aware
- Add UTC tzinfo to naive datetimes before subtraction

## Test plan
- [ ] Run `/status` command and verify "Last Post" displays correctly without errors
- [ ] Verify existing bot tests still pass