### PR TITLE
Add logging for all Discord slash commands

### DIFF
--- a/src/intelstream/bot.py
+++ b/src/intelstream/bot.py
@@ -265,6 +265,12 @@ class CoreCommands(commands.Cog):
 
     @app_commands.command(name="status", description="Show bot status and information")
     async def status(self, interaction: discord.Interaction) -> None:
+        logger.debug(
+            "status command invoked",
+            user_id=interaction.user.id,
+            guild_id=str(interaction.guild_id) if interaction.guild_id else None,
+        )
+
         guild_id = str(interaction.guild_id) if interaction.guild_id else None
 
         sources = await self.bot.repository.get_all_sources(active_only=False)
@@ -369,6 +375,11 @@ class CoreCommands(commands.Cog):
 
     @app_commands.command(name="ping", description="Check if the bot is responsive")
     async def ping(self, interaction: discord.Interaction) -> None:
+        logger.debug(
+            "ping command invoked",
+            user_id=interaction.user.id,
+            guild_id=str(interaction.guild_id) if interaction.guild_id else None,
+        )
         latency = round(self.bot.latency * 1000)
         await interaction.response.send_message(f"Pong! Latency: {latency}ms")
 

--- a/src/intelstream/discord/cogs/config_management.py
+++ b/src/intelstream/discord/cogs/config_management.py
@@ -79,6 +79,12 @@ class ConfigManagement(commands.Cog):
     async def config_show(self, interaction: discord.Interaction) -> None:
         await interaction.response.defer(ephemeral=True)
 
+        logger.debug(
+            "config_show command invoked",
+            user_id=interaction.user.id,
+            guild_id=str(interaction.guild_id) if interaction.guild_id else None,
+        )
+
         if interaction.guild is None:
             await interaction.followup.send(
                 "This command must be used in a server.", ephemeral=True

--- a/src/intelstream/discord/cogs/github.py
+++ b/src/intelstream/discord/cogs/github.py
@@ -155,6 +155,13 @@ class GitHubCommands(commands.Cog):
     ) -> None:
         await interaction.response.defer()
 
+        logger.debug(
+            "github_list command invoked",
+            user_id=interaction.user.id,
+            guild_id=str(interaction.guild_id) if interaction.guild_id else None,
+            channel_id=str(channel.id) if channel else None,
+        )
+
         target_channel = channel or interaction.channel
         if target_channel is None:
             await interaction.followup.send("Could not determine target channel.")

--- a/src/intelstream/discord/cogs/message_forwarding.py
+++ b/src/intelstream/discord/cogs/message_forwarding.py
@@ -167,6 +167,12 @@ class MessageForwarding(commands.Cog):
     async def forward_list(self, interaction: discord.Interaction) -> None:
         await interaction.response.defer(ephemeral=True)
 
+        logger.debug(
+            "forward_list command invoked",
+            user_id=interaction.user.id,
+            guild_id=str(interaction.guild_id) if interaction.guild_id else None,
+        )
+
         if interaction.guild is None:
             await interaction.followup.send(
                 "This command can only be used in a server.", ephemeral=True

--- a/src/intelstream/discord/cogs/source_management.py
+++ b/src/intelstream/discord/cogs/source_management.py
@@ -132,6 +132,15 @@ class SourceManagement(commands.Cog):
     ) -> None:
         await interaction.response.defer(ephemeral=True)
 
+        logger.info(
+            "source_add command invoked",
+            user_id=interaction.user.id,
+            guild_id=str(interaction.guild_id) if interaction.guild_id else None,
+            source_type=source_type.value,
+            name=name,
+            url=url,
+        )
+
         try:
             stype = SourceType(source_type.value)
         except ValueError:
@@ -275,6 +284,13 @@ class SourceManagement(commands.Cog):
     @source_group.command(name="list", description="List sources for this channel")
     async def source_list(self, interaction: discord.Interaction) -> None:
         await interaction.response.defer()
+
+        logger.debug(
+            "source_list command invoked",
+            user_id=interaction.user.id,
+            guild_id=str(interaction.guild_id) if interaction.guild_id else None,
+            channel_id=str(interaction.channel_id),
+        )
 
         channel_id = str(interaction.channel_id)
         sources = await self.bot.repository.get_all_sources(

--- a/src/intelstream/discord/cogs/summarize.py
+++ b/src/intelstream/discord/cogs/summarize.py
@@ -260,6 +260,13 @@ class Summarize(commands.Cog):
     async def summarize(self, interaction: discord.Interaction, url: str) -> None:
         await interaction.response.defer()
 
+        logger.info(
+            "summarize command invoked",
+            user_id=interaction.user.id,
+            guild_id=str(interaction.guild_id) if interaction.guild_id else None,
+            url=url,
+        )
+
         parsed = urlparse(url)
         if not parsed.scheme or not parsed.netloc:
             await interaction.followup.send("Please provide a valid URL.", ephemeral=True)


### PR DESCRIPTION
## Summary

Adds logging at command invocation for all Discord slash commands to improve observability.

### Changes

**State-modifying commands** (use `logger.info()`):
- `/source add` - logs at start with source_type, name, url
- `/summarize` - logs at start with url

**Read-only commands** (use `logger.debug()` to reduce noise):
- `/source list`
- `/config show`
- `/forward list`
- `/github list`
- `/status`
- `/ping`

### Log Format

All command logs include:
- `user_id` - who invoked the command
- `guild_id` - which server (if applicable)
- Command-specific parameters

### Testing

- All 525 tests pass
- Lint, format, and type checks pass