### PR TITLE
Add debug logging for Twitter API response

### DIFF
--- a/src/intelstream/adapters/twitter.py
+++ b/src/intelstream/adapters/twitter.py
@@ -52,6 +52,15 @@ class TwitterAdapter(BaseAdapter):
         response.raise_for_status()
         data = response.json()
 
+        tweets_raw = data.get("tweets", [])
+        logger.debug(
+            "Twitter API response",
+            identifier=identifier,
+            status=data.get("status"),
+            tweet_count=len(tweets_raw),
+            has_next_page=data.get("has_next_page"),
+        )
+
         if data.get("status") != "success":
             logger.error(
                 "Twitter API returned error",
@@ -61,7 +70,7 @@ class TwitterAdapter(BaseAdapter):
             return []
 
         items: list[ContentData] = []
-        for tweet in data.get("tweets", []):
+        for tweet in tweets_raw:
             if tweet.get("retweeted_tweet"):
                 continue
 


### PR DESCRIPTION
## Summary

- Adds debug-level logging of the raw Twitter API response metadata (status, tweet count, pagination) to help diagnose cases where the API returns empty results for a user.
- Also reuses the already-fetched `tweets` list instead of calling `data.get("tweets", [])` twice.

## Context

Investigating an issue where twitterapi.io returns `status: "success"` with 0 tweets for a valid account. Without this logging, the only visibility is the final `count=0` at info level, making it impossible to distinguish between "API returned empty array" vs "all tweets filtered as retweets".

## Test plan

- [x] All 17 Twitter adapter tests pass
- [x] Full suite: 561 tests pass, mypy/ruff clean