### PR TITLE
Fix: Add SSRF validation to content extractor and discovery strategies (closes #153, #157)

### DIFF
--- a/src/intelstream/adapters/strategies/sitemap_discovery.py
+++ b/src/intelstream/adapters/strategies/sitemap_discovery.py
@@ -13,6 +13,7 @@ from intelstream.adapters.strategies.base import (
     DiscoveryStrategy,
 )
 from intelstream.config import get_settings
+from intelstream.utils.url_validation import SSRFError, validate_url_for_ssrf
 
 logger = structlog.get_logger()
 
@@ -127,6 +128,14 @@ class SitemapDiscoveryStrategy(DiscoveryStrategy):
                 line = line.strip()
                 if line.lower().startswith("sitemap:"):
                     sitemap_url = line.split(":", 1)[1].strip()
+                    try:
+                        validate_url_for_ssrf(sitemap_url)
+                    except SSRFError:
+                        logger.warning(
+                            "Skipping sitemap URL blocked by SSRF protection",
+                            url=sitemap_url,
+                        )
+                        return None
                     return sitemap_url
 
         except httpx.HTTPError:
@@ -215,6 +224,11 @@ class SitemapDiscoveryStrategy(DiscoveryStrategy):
                 break
             loc = sitemap.find("sm:loc", SITEMAP_NS)
             if loc is not None and loc.text:
+                try:
+                    validate_url_for_ssrf(loc.text)
+                except SSRFError:
+                    logger.warning("Skipping sub-sitemap blocked by SSRF protection", url=loc.text)
+                    continue
                 child_urls = await self._parse_sitemap(loc.text)
                 all_urls.extend(child_urls)
                 sitemap_count += 1
@@ -226,6 +240,11 @@ class SitemapDiscoveryStrategy(DiscoveryStrategy):
                 break
             loc = sitemap.find("loc")
             if loc is not None and loc.text:
+                try:
+                    validate_url_for_ssrf(loc.text)
+                except SSRFError:
+                    logger.warning("Skipping sub-sitemap blocked by SSRF protection", url=loc.text)
+                    continue
                 child_urls = await self._parse_sitemap(loc.text)
                 all_urls.extend(child_urls)
                 sitemap_count += 1


### PR DESCRIPTION
## Summary
Multiple code paths fetch URLs without SSRF validation: the content extractor, RSS discovery (following `<link>` hrefs), sitemap discovery (following robots.txt and child sitemaps), and LLM extraction (using LLM-returned URLs). This adds `validate_url_for_ssrf()` checks at each entry point.

## Issues Resolved
- Closes #153
- Closes #157

## Changes
- `src/intelstream/services/content_extractor.py` -- Added SSRF validation at the top of `extract()`, returning empty content for blocked URLs
- `src/intelstream/adapters/strategies/rss_discovery.py` -- Added SSRF validation on discovered feed URLs in `_find_rss_in_html()`
- `src/intelstream/adapters/strategies/sitemap_discovery.py` -- Added SSRF validation on sitemap URLs from robots.txt and child sitemaps in `_parse_sitemap_index()`
- `src/intelstream/adapters/strategies/llm_extraction.py` -- Added SSRF validation on LLM-extracted post URLs before adding to results

## Testing
- [x] Existing tests pass
- [x] All validation uses existing `validate_url_for_ssrf()` / `SSRFError` from `url_validation.py`

## Risk Assessment
Low -- All changes are guard clauses that skip/log blocked URLs. No change to happy-path behavior for legitimate external URLs.