### PR TITLE
Fix: Handle timezone-naive datetimes from SQLite in poll scheduling (closes #155)

### DIFF
--- a/src/intelstream/services/pipeline.py
+++ b/src/intelstream/services/pipeline.py
@@ -84,9 +84,11 @@ class ContentPipeline:
         for i, source in enumerate(sources):
             if source.last_polled_at is not None:
                 interval = self._settings.get_poll_interval(source.type)
-                next_poll_at = source.last_polled_at + timedelta(minutes=interval)
-                now = datetime.now(UTC).replace(tzinfo=next_poll_at.tzinfo)
-                if now < next_poll_at:
+                last_polled = source.last_polled_at
+                if last_polled.tzinfo is None:
+                    last_polled = last_polled.replace(tzinfo=UTC)
+                next_poll_at = last_polled + timedelta(minutes=interval)
+                if datetime.now(UTC) < next_poll_at:
                     logger.debug(
                         "Skipping source, not due yet",
                         source_name=source.name,


### PR DESCRIPTION
## Summary
SQLite returns timezone-naive datetimes, but the poll scheduling code compared them with `datetime.now(UTC)` using a brittle `replace(tzinfo=...)` approach. When `last_polled_at` was naive (no tzinfo), the comparison could produce incorrect results, causing sources to be polled too frequently or skipped entirely.

## Issues Resolved
- Closes #155

## Changes
- `src/intelstream/services/pipeline.py` -- Replaced `datetime.now(UTC).replace(tzinfo=next_poll_at.tzinfo)` with explicit handling: if `last_polled_at.tzinfo is None`, attach UTC before computing `next_poll_at`, then compare directly with `datetime.now(UTC)`

## Testing
- [x] Existing tests pass
- [x] Handles both naive (SQLite) and aware (PostgreSQL) datetime inputs correctly

## Risk Assessment
Low -- Single comparison logic change with clear before/after behavior. No effect when datetimes are already timezone-aware.