### PR TITLE
Fix: Wrap synchronous YouTube API calls with asyncio.to_thread (closes #156)

### DIFF
--- a/src/intelstream/adapters/youtube.py
+++ b/src/intelstream/adapters/youtube.py
@@ -123,13 +123,13 @@ class YouTubeAdapter(BaseAdapter):
         identifier = identifier.lstrip("@")
 
         request = self._youtube.channels().list(part="id", forHandle=identifier)
-        response: dict[str, Any] = request.execute()
+        response: dict[str, Any] = await asyncio.to_thread(request.execute)
 
         if response.get("items"):
             return str(response["items"][0]["id"])
 
         request = self._youtube.channels().list(part="id", forUsername=identifier)
-        response = request.execute()
+        response = await asyncio.to_thread(request.execute)
 
         if response.get("items"):
             return str(response["items"][0]["id"])
@@ -137,7 +137,7 @@ class YouTubeAdapter(BaseAdapter):
         request = self._youtube.search().list(
             part="snippet", q=identifier, type="channel", maxResults=1
         )
-        response = request.execute()
+        response = await asyncio.to_thread(request.execute)
 
         if response.get("items"):
             return str(response["items"][0]["snippet"]["channelId"])
@@ -146,7 +146,7 @@ class YouTubeAdapter(BaseAdapter):
 
     async def _get_uploads_playlist_id(self, channel_id: str) -> str:
         request = self._youtube.channels().list(part="contentDetails", id=channel_id)
-        response: dict[str, Any] = request.execute()
+        response: dict[str, Any] = await asyncio.to_thread(request.execute)
 
         if not response.get("items"):
             raise ValueError(f"Channel not found: {channel_id}")
@@ -161,7 +161,7 @@ class YouTubeAdapter(BaseAdapter):
             playlistId=playlist_id,
             maxResults=max_results,
         )
-        response: dict[str, Any] = request.execute()
+        response: dict[str, Any] = await asyncio.to_thread(request.execute)
         return list(response.get("items", []))
 
     async def _create_content_data(

--- a/src/intelstream/discord/cogs/summarize.py
+++ b/src/intelstream/discord/cogs/summarize.py
@@ -1,3 +1,4 @@
+import asyncio
 import contextlib
 import re
 from datetime import UTC, datetime
@@ -153,7 +154,7 @@ class Summarize(commands.Cog):
         youtube = build("youtube", "v3", developerKey=api_key)
 
         request = youtube.videos().list(part="snippet", id=video_id)
-        response = request.execute()
+        response = await asyncio.to_thread(request.execute)
 
         if not response.get("items"):
             raise WebFetchError("Video not found")


### PR DESCRIPTION
## Summary
The YouTube adapter and summarize cog called `request.execute()` synchronously inside async methods, blocking the event loop during network I/O. This wraps all 6 call sites with `asyncio.to_thread()` so they run in a thread pool without blocking.

## Issues Resolved
- Closes #156

## Changes
- `src/intelstream/adapters/youtube.py` -- Wrapped 5 `request.execute()` calls with `await asyncio.to_thread(request.execute)` in `_get_channel_id_by_handle_or_username` (3), `_get_uploads_playlist_id` (1), `_get_playlist_videos` (1)
- `src/intelstream/discord/cogs/summarize.py` -- Added `import asyncio` and wrapped `request.execute()` in `_fetch_youtube_content` with `await asyncio.to_thread(request.execute)`

## Testing
- [x] Existing tests pass
- [x] `asyncio.to_thread` is the standard pattern for wrapping sync I/O in async contexts

## Risk Assessment
Low -- `asyncio.to_thread` is a straightforward wrapper. Return values and exceptions propagate identically.