### PR TITLE
Fix: Add ExtractionCache eviction to prevent unbounded growth (closes #159)

### DIFF
--- a/src/intelstream/services/pipeline.py
+++ b/src/intelstream/services/pipeline.py
@@ -167,6 +167,8 @@ class ContentPipeline:
             if fetch_delay > 0 and i < len(sources) - 1:
                 await asyncio.sleep(fetch_delay)
 
+        await self._repository.cleanup_extraction_cache()
+
         logger.info("Fetch complete", total_new_items=total_new_items)
         return total_new_items
 


### PR DESCRIPTION
## Summary
The `extraction_cache` table grew indefinitely with no cleanup mechanism. This adds a `cleanup_extraction_cache()` method that removes entries older than 7 days, called automatically at the end of each fetch cycle.

## Issues Resolved
- Closes #159

## Changes
- `src/intelstream/database/repository.py` -- Added `cleanup_extraction_cache(max_age_days=7)` method that deletes entries where `cached_at` is older than the cutoff
- `src/intelstream/services/pipeline.py` -- Added `await self._repository.cleanup_extraction_cache()` call at the end of `fetch_all_sources()`
- `tests/test_database.py` -- Added `TestExtractionCacheCleanup` with two tests: verifying old entries are removed while recent ones are kept, and verifying zero return when nothing to remove

## Testing
- [x] Existing tests pass
- [x] Added 2 new tests for cache cleanup

## Risk Assessment
Low -- Additive change. Cleanup only removes entries older than 7 days, well past any reasonable cache utility window.