### PR TITLE
Fix: Increment failure count on 404 responses (closes #160)

### DIFF
--- a/src/intelstream/services/pipeline.py
+++ b/src/intelstream/services/pipeline.py
@@ -115,6 +115,7 @@ class ContentPipeline:
                         source_name=source.name,
                         source_type=source.type.value,
                     )
+                    await self._repository.increment_failure_count(source.id)
                 elif status == 429:
                     logger.warning(
                         "Rate limited by source",

--- a/tests/test_services/test_pipeline.py
+++ b/tests/test_services/test_pipeline.py
@@ -445,7 +445,7 @@ class TestFetchAllSources:
 
         await pipeline.close()
 
-    async def test_fetch_404_does_not_increment_failure_count(
+    async def test_fetch_404_increments_failure_count(
         self,
         pipeline: ContentPipeline,
         mock_repository: AsyncMock,
@@ -472,7 +472,7 @@ class TestFetchAllSources:
             result = await pipeline.fetch_all_sources()
 
         assert result == 0
-        mock_repository.increment_failure_count.assert_not_called()
+        mock_repository.increment_failure_count.assert_called_once_with(sample_source.id)
 
         await pipeline.close()
 


### PR DESCRIPTION
## Summary
When a source returned HTTP 404, the pipeline logged an error but did not increment the failure count, so broken sources would never be auto-disabled. This adds the missing `increment_failure_count` call.

## Issues Resolved
- Closes #160

## Changes
- `src/intelstream/services/pipeline.py` -- Added `await self._repository.increment_failure_count(source.id)` in the 404 handler
- `tests/test_services/test_pipeline.py` -- Updated test from `assert_not_called()` to `assert_called_once_with(sample_source.id)` and renamed to `test_fetch_404_increments_failure_count`

## Testing
- [x] Existing tests pass
- [x] Updated existing test to verify the new behavior

## Risk Assessment
Low -- Single line addition in error handler. Consistent with behavior for other HTTP error codes (429, 401, 403, 5xx).