### PR TITLE
Fix: Content poster missing labels, thread support, and query limit (closes #168, #169, #170)

### DIFF
--- a/src/intelstream/database/repository.py
+++ b/src/intelstream/database/repository.py
@@ -293,13 +293,14 @@ class Repository:
             )
             return result.scalar_one()
 
-    async def get_unposted_content_items(self) -> list[ContentItem]:
+    async def get_unposted_content_items(self, limit: int = 10) -> list[ContentItem]:
         async with self.session() as session:
             result = await session.execute(
                 select(ContentItem)
                 .where(ContentItem.posted_to_discord == False)  # noqa: E712
                 .where(ContentItem.summary.isnot(None))
                 .order_by(ContentItem.published_at.asc())
+                .limit(limit)
             )
             return list(result.scalars().all())
 

--- a/src/intelstream/services/content_poster.py
+++ b/src/intelstream/services/content_poster.py
@@ -15,6 +15,8 @@ SOURCE_TYPE_LABELS: dict[SourceType, str] = {
     SourceType.YOUTUBE: "YouTube",
     SourceType.RSS: "RSS",
     SourceType.PAGE: "Web",
+    SourceType.ARXIV: "ArXiv",
+    SourceType.BLOG: "Blog",
     SourceType.TWITTER: "Twitter",
 }
 
@@ -124,7 +126,7 @@ class ContentPoster:
 
     async def post_content(
         self,
-        channel: discord.TextChannel,
+        channel: discord.TextChannel | discord.Thread,
         content_item: ContentItem,
         source_type: SourceType,
         source_name: str,
@@ -192,7 +194,9 @@ class ContentPoster:
                     channel_id = source.channel_id
 
                 channel = self._bot.get_channel(int(channel_id))
-                if channel is None or not isinstance(channel, discord.TextChannel):
+                if channel is None or not isinstance(
+                    channel, (discord.TextChannel, discord.Thread)
+                ):
                     logger.warning(
                         "Could not find channel for source",
                         source_id=source.id,


### PR DESCRIPTION
## Summary
Three bugs in the content posting pipeline: ArXiv and Blog sources displayed "Unknown" as their source type label, content added from Discord threads was never posted due to a type check rejecting threads, and `get_unposted_content_items()` had no result limit risking channel flooding after downtime.

## Issues Resolved
- Closes #168
- Closes #169
- Closes #170

## Changes
- `src/intelstream/services/content_poster.py` -- Added `SourceType.ARXIV: "ArXiv"` and `SourceType.BLOG: "Blog"` to `SOURCE_TYPE_LABELS`; updated isinstance check to accept `discord.Thread` alongside `discord.TextChannel`; updated `post_content` channel type hint to `discord.TextChannel | discord.Thread`
- `src/intelstream/database/repository.py` -- Added `limit: int = 10` parameter to `get_unposted_content_items()` with `.limit(limit)` on the query

## Testing
- [x] Existing tests pass (567 passed)
- [x] Changes match patterns used in `github_polling.py` (thread support) and `get_unsummarized_content_items` (limit param)

## Risk Assessment
Low -- Two dict entries added, one isinstance check widened, one query limit added with backward-compatible default.