### PR TITLE
Fix: Add content count warning to /source remove (closes #176)

### DIFF
--- a/src/intelstream/database/repository.py
+++ b/src/intelstream/database/repository.py
@@ -222,6 +222,15 @@ class Repository:
             )
             return source
 
+    async def get_content_count_for_source(self, source_id: str) -> int:
+        async with self.session() as session:
+            result = await session.execute(
+                select(func.count())
+                .select_from(ContentItem)
+                .where(ContentItem.source_id == source_id)
+            )
+            return result.scalar_one()
+
     async def delete_source(self, identifier: str) -> bool:
         async with self.session() as session:
             result = await session.execute(select(Source).where(Source.identifier == identifier))

--- a/src/intelstream/discord/cogs/source_management.py
+++ b/src/intelstream/discord/cogs/source_management.py
@@ -380,6 +380,8 @@ class SourceManagement(commands.Cog):
             )
             return
 
+        content_count = await self.bot.repository.get_content_count_for_source(source.id)
+
         try:
             await self.bot.repository.delete_source(source.identifier)
             logger.info(
@@ -387,8 +389,17 @@ class SourceManagement(commands.Cog):
                 name=name,
                 identifier=source.identifier,
                 user_id=interaction.user.id,
+                content_items_deleted=content_count,
             )
-            await interaction.followup.send(f"Source **{name}** has been removed.", ephemeral=True)
+            if content_count > 0:
+                msg = (
+                    f"Source **{name}** and {content_count} content item"
+                    f"{'s' if content_count != 1 else ''} "
+                    f"have been removed. Use `/source toggle` next time to disable without deleting."
+                )
+            else:
+                msg = f"Source **{name}** has been removed."
+            await interaction.followup.send(msg, ephemeral=True)
         except SourceNotFoundError:
             await interaction.followup.send(
                 f"Source **{name}** was already removed.", ephemeral=True


### PR DESCRIPTION
## Summary
`/source remove` cascade-deleted all associated content items with no warning. Users had no indication that removing a source was destructive. This adds a content count to the success message and suggests `/source toggle` as a non-destructive alternative.

## Issues Resolved
- Closes #176

## Changes
- `src/intelstream/database/repository.py` -- Added `get_content_count_for_source(source_id)` method using `func.count()`
- `src/intelstream/discord/cogs/source_management.py` -- Updated `source_remove` to fetch content count before deleting; success message now includes count and mentions `/source toggle` when items were deleted
- `tests/test_discord/test_source_management.py` -- Updated existing remove test to mock count method; added new test verifying warning message with content count

## Testing
- [x] Existing tests pass
- [x] Added test for warning message with content items

## Risk Assessment
Low -- Informational change only. Delete behavior is unchanged; users now see what was deleted.