### PR TITLE
Fix: Logging improvements across pipeline, posting, and cogs (closes #177)

### DIFF
--- a/src/intelstream/bot.py
+++ b/src/intelstream/bot.py
@@ -126,7 +126,9 @@ class IntelStreamBot(commands.Bot):
             )
             if migrated > 0:
                 logger.info(
-                    f"Migrated {migrated} existing sources to channel {self.settings.discord_channel_id}"
+                    "Migrated existing sources to channel",
+                    migrated=migrated,
+                    channel_id=self.settings.discord_channel_id,
                 )
 
         await self.add_cog(CoreCommands(self))
@@ -159,16 +161,23 @@ class IntelStreamBot(commands.Bot):
 
     async def on_ready(self) -> None:
         self.start_time = datetime.now(UTC)
-        logger.info(f"Logged in as {self.user} (ID: {self.user.id if self.user else 'Unknown'})")
+        logger.info(
+            "Logged in",
+            user=str(self.user),
+            user_id=self.user.id if self.user else None,
+        )
 
         try:
             self._owner = await self.fetch_user(self.settings.discord_owner_id)
-            logger.info(f"Owner set to {self._owner}")
+            logger.info("Owner set", owner=str(self._owner))
         except discord.NotFound:
-            logger.warning(f"Could not find owner with ID {self.settings.discord_owner_id}")
+            logger.warning(
+                "Could not find owner",
+                owner_id=self.settings.discord_owner_id,
+            )
 
     async def on_error(self, event_method: str, *_args: Any, **_kwargs: Any) -> None:
-        logger.exception(f"Error in {event_method}")
+        logger.exception("Error in event handler", event_method=event_method)
         await self.notify_owner(f"Error in {event_method}. Check logs for details.")
 
     async def notify_owner(self, message: str) -> None:
@@ -184,14 +193,14 @@ class IntelStreamBot(commands.Bot):
 
         try:
             await self._owner.send(f"**IntelStream Alert**\n{message}")
-            logger.info(f"Notified owner: {message[:50]}...")
+            logger.info("Notified owner", message_preview=message[:50])
         except discord.NotFound:
             logger.error("Owner user not found - check DISCORD_OWNER_ID")
             self._owner = None
         except discord.Forbidden:
             logger.error("Cannot DM owner: DMs may be disabled")
         except discord.HTTPException as e:
-            logger.error(f"Failed to DM owner: {e}")
+            logger.error("Failed to DM owner", error=str(e))
 
     async def close(self) -> None:
         logger.info("Shutting down bot...")

--- a/src/intelstream/discord/cogs/suck_boobs.py
+++ b/src/intelstream/discord/cogs/suck_boobs.py
@@ -49,6 +49,13 @@ class SuckBoobs(commands.Cog):
             pinged_user_id=str(target.id),
         )
 
+        logger.info(
+            "suck_boobs command used",
+            user_id=interaction.user.id,
+            target_id=target.id,
+            guild_id=interaction.guild_id,
+        )
+
         await interaction.response.send_message(
             f"🍼 {interaction.user.display_name} sucks <@{target.id}>'s boobs 🥛😳"
         )
@@ -60,6 +67,12 @@ class SuckBoobs(commands.Cog):
                 "This command can only be used in a server.", ephemeral=True
             )
             return
+
+        logger.debug(
+            "suck_boobs_score command invoked",
+            user_id=interaction.user.id,
+            guild_id=interaction.guild_id,
+        )
 
         await interaction.response.defer()
 

--- a/src/intelstream/services/content_poster.py
+++ b/src/intelstream/services/content_poster.py
@@ -178,6 +178,12 @@ class ContentPoster:
                 # Skip sources belonging to a different guild.
                 # Sources without guild_id are legacy/global and can post to any guild.
                 if source.guild_id and str(guild_id) != source.guild_id:
+                    logger.debug(
+                        "Skipping item, guild mismatch",
+                        item_id=item.id,
+                        source_guild_id=source.guild_id,
+                        current_guild_id=guild_id,
+                    )
                     continue
 
                 if not source.channel_id:
@@ -223,14 +229,21 @@ class ContentPoster:
                 logger.error(
                     "Failed to post content item",
                     item_id=item.id,
+                    title=item.title,
+                    source_name=source.name if source else "unknown",
                     error=str(e),
                 )
             except Exception as e:
                 logger.error(
                     "Unexpected error posting content item",
                     item_id=item.id,
+                    title=item.title,
+                    source_name=source.name if source else "unknown",
                     error=str(e),
                 )
 
-        logger.info("Posted unposted items", count=posted_count, guild_id=guild_id)
+        if posted_count > 0:
+            logger.info("Posted unposted items", count=posted_count, guild_id=guild_id)
+        else:
+            logger.debug("No items to post for guild", guild_id=guild_id)
         return posted_count


### PR DESCRIPTION
## Summary
Running at INFO level left significant blind spots - key events were at DEBUG, cycle summaries were missing, and several logs used f-strings instead of structlog kwargs. This PR addresses all 5 sections of #177.

## Issues Resolved
- Closes #177

## Changes
- `src/intelstream/services/pipeline.py` — Promote "Fetching source" and "Item summarized" to INFO; add elapsed time to fetch/summarize; add sources_polled/skipped/failed counters; add source_name to summarize logs; suppress empty summarize_pending pair; demote pipeline init/close to DEBUG
- `src/intelstream/services/content_poster.py` — Add DEBUG log for guild mismatch skip; add source_name/title to posting error logs; split posted/no-items log levels
- `src/intelstream/discord/cogs/content_posting.py` — Consolidate pipeline cycle summary with posted count and elapsed time
- `src/intelstream/discord/cogs/github_polling.py` — Add per-cycle summary log (repos_polled, repos_failed, events_posted); return event count from _process_repo; log first-poll even with 0 events
- `src/intelstream/discord/cogs/suck_boobs.py` — Add command invocation logging (INFO for suck_boobs, DEBUG for score)
- `src/intelstream/bot.py` — Convert all f-string logs to structlog kwargs

## Testing
- [x] Existing tests pass (567 passed)
- [x] mypy passes with no issues
- [x] ruff check and format pass

## Risk Assessment
Low — All changes are logging-only. No behavioral changes to business logic. Every log call uses existing structlog patterns.