### PR TITLE
Fix initial content flood on new source subscription

### DIFF
--- a/src/intelstream/services/pipeline.py
+++ b/src/intelstream/services/pipeline.py
@@ -242,12 +242,20 @@ class ContentPipeline:
                     logger.debug("Content item already exists", external_id=item.external_id)
                     continue
 
-                if is_first_poll:
+        if is_first_poll and new_count > 0:
+            most_recent = await self._repository.get_most_recent_item_for_source(source.id)
+            if most_recent:
+                backfilled = await self._repository.mark_items_as_backfilled(
+                    source_id=source.id,
+                    exclude_item_id=most_recent.id,
+                )
+                if backfilled > 0:
                     logger.info(
-                        "First poll for source, limiting to most recent item",
+                        "First poll: backfilled pre-existing items",
                         source_name=source.name,
+                        backfilled_count=backfilled,
+                        most_recent_title=most_recent.title,
                     )
-                    break
 
         await self._repository.update_source_last_polled(source.id)
 


### PR DESCRIPTION
## Summary

- Fixes a bug where subscribing to a new source (Twitter, Substack, RSS, etc.) would flood the Discord channel with all pre-existing content on the second poll cycle
- On first poll, all fetched items are now stored in the database but immediately marked as backfilled (except the most recent), preventing re-discovery on subsequent polls
- The existing `_handle_first_posting_backfill` safety net in `summarize_pending` is retained as a secondary defense

## Root Cause

The previous approach stored only 1 item on first poll then broke out of the loop. On the next poll cycle, the adapter would return the same batch of items. The 1 already-stored item was skipped, but all remaining items were treated as new content and posted to Discord.

## Test plan

- [x] `test_first_poll_stores_all_items_and_backfills` - verifies all items stored and backfill called
- [x] `test_first_poll_no_backfill_when_single_item` - verifies single-item first poll works correctly
- [x] `test_subsequent_poll_stores_all_new_items` - verifies non-first polls unchanged
- [x] All 597 existing tests pass
- [x] ruff check, ruff format, mypy all clean