### PR TITLE
Fix test quality and resource management (#202, #207, #210, #213)

### DIFF
--- a/src/intelstream/discord/cogs/channel_summary.py
+++ b/src/intelstream/discord/cogs/channel_summary.py
@@ -35,6 +35,11 @@ class ChannelSummary(commands.Cog):
         )
         logger.info("ChannelSummary cog loaded")
 
+    async def cog_unload(self) -> None:
+        if self._summarizer:
+            await self._summarizer.close()
+        logger.info("ChannelSummary cog unloaded")
+
     @app_commands.command(
         name="summary",
         description="Summarize recent messages in a channel",

--- a/src/intelstream/discord/cogs/content_posting.py
+++ b/src/intelstream/discord/cogs/content_posting.py
@@ -25,6 +25,7 @@ class ContentPosting(commands.Cog):
         self.bot = bot
         self._pipeline: ContentPipeline | None = None
         self._poster: ContentPoster | None = None
+        self._summarizer: SummarizationService | None = None
         self._initialized = False
         self._consecutive_failures = 0
         self._base_interval: int = 5
@@ -35,7 +36,7 @@ class ContentPosting(commands.Cog):
             api_key=self.bot.settings.llm_api_key,
             model=self.bot.settings.summary_model,
         )
-        summarizer = SummarizationService(
+        self._summarizer = SummarizationService(
             client=llm_client,
             max_tokens=self.bot.settings.summary_max_tokens,
             max_input_length=self.bot.settings.summary_max_input_length,
@@ -44,7 +45,7 @@ class ContentPosting(commands.Cog):
         self._pipeline = ContentPipeline(
             settings=self.bot.settings,
             repository=self.bot.repository,
-            summarizer=summarizer,
+            summarizer=self._summarizer,
             get_search_services=lambda: (
                 self.bot.embedding_service,
                 self.bot.vector_store,
@@ -88,9 +89,12 @@ class ContentPosting(commands.Cog):
             logger.error("Pipeline close timed out during cog unload")
         except Exception as e:
             logger.error("Error closing pipeline during cog unload", error=str(e))
-        finally:
-            self._initialized = False
-            logger.info("Content posting cog unloaded")
+
+        if self._summarizer:
+            await self._summarizer.close()
+
+        self._initialized = False
+        logger.info("Content posting cog unloaded")
 
     @tasks.loop(minutes=5)
     async def content_loop(self) -> None:

--- a/src/intelstream/discord/cogs/summarize.py
+++ b/src/intelstream/discord/cogs/summarize.py
@@ -76,6 +76,8 @@ class Summarize(commands.Cog):
         logger.info("Summarize cog loaded")
 
     async def cog_unload(self) -> None:
+        if self._summarizer:
+            await self._summarizer.close()
         if self._http_client:
             await self._http_client.aclose()
         logger.info("Summarize cog unloaded")

--- a/src/intelstream/services/summarizer.py
+++ b/src/intelstream/services/summarizer.py
@@ -68,6 +68,9 @@ class SummarizationService:
         self._max_input_length = max_input_length
         self._system_prompt = SYSTEM_PROMPT
 
+    async def close(self) -> None:
+        await self._client.close()
+
     @retry(
         retry=retry_if_exception_type(LLMRateLimitError),
         wait=wait_exponential(multiplier=1, min=4, max=60),

--- a/tests/test_discord/test_channel_summary.py
+++ b/tests/test_discord/test_channel_summary.py
@@ -1,5 +1,5 @@
 from datetime import UTC, datetime
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import discord
 import pytest
@@ -7,6 +7,9 @@ from discord import MessageType
 
 from intelstream.discord.cogs.channel_summary import ChannelSummary
 from intelstream.services.summarizer import SummarizationError
+
+PATCH_CREATE_LLM = "intelstream.discord.cogs.channel_summary.create_llm_client"
+PATCH_SUMMARIZER = "intelstream.discord.cogs.channel_summary.SummarizationService"
 
 
 @pytest.fixture
@@ -276,13 +279,43 @@ class TestFormatMessages:
 
 
 class TestCogLoad:
-    async def test_cog_load_creates_summarizer(self, mock_bot):
+    @patch(PATCH_CREATE_LLM)
+    @patch(PATCH_SUMMARIZER)
+    async def test_cog_load_creates_summarizer(self, mock_summarizer_cls, mock_create_llm, mock_bot):
+        mock_llm_client = MagicMock()
+        mock_create_llm.return_value = mock_llm_client
+
+        mock_summarizer = MagicMock()
+        mock_summarizer_cls.return_value = mock_summarizer
+
         cog = ChannelSummary(mock_bot)
         assert cog._summarizer is None
 
         await cog.cog_load()
 
-        assert cog._summarizer is not None
+        mock_create_llm.assert_called_once_with(
+            provider="anthropic",
+            api_key="test-api-key",
+            model="claude-sonnet-4-20250514",
+        )
+        mock_summarizer_cls.assert_called_once_with(
+            client=mock_llm_client,
+            max_tokens=2048,
+            max_input_length=100000,
+        )
+        assert cog._summarizer is mock_summarizer
+
+
+class TestCogUnload:
+    async def test_cog_unload_closes_summarizer(self, mock_bot):
+        cog = ChannelSummary(mock_bot)
+        mock_summarizer = MagicMock()
+        mock_summarizer.close = AsyncMock()
+        cog._summarizer = mock_summarizer
+
+        await cog.cog_unload()
+
+        mock_summarizer.close.assert_called_once()
 
 
 class _async_iter:

--- a/tests/test_discord/test_content_posting.py
+++ b/tests/test_discord/test_content_posting.py
@@ -52,6 +52,7 @@ def _patch_cog_deps():
         mock_create_llm.return_value = mock_llm_client
 
         mock_summarizer = MagicMock()
+        mock_summarizer.close = AsyncMock()
         mock_summarizer_cls.return_value = mock_summarizer
 
         yield {
@@ -121,7 +122,7 @@ class TestContentPostingCogLoad:
 
         await cog.cog_load()
 
-        assert cog.content_loop.is_running() or True
+        assert cog.content_loop.is_running()
 
 
 class TestContentPostingCogUnload:
@@ -135,6 +136,16 @@ class TestContentPostingCogUnload:
 
         deps["pipeline"].close.assert_called_once()
         assert cog._initialized is False
+
+    async def test_cog_unload_closes_summarizer(self, _patch_cog_deps, mock_bot):
+        deps = _patch_cog_deps
+
+        cog = ContentPosting(mock_bot)
+        await cog.cog_load()
+
+        await cog.cog_unload()
+
+        deps["summarizer"].close.assert_called_once()
 
 
 class TestContentLoop:


### PR DESCRIPTION
## Summary

- **#202**: Fix tautological assertion in `test_content_posting.py` -- removed `or True` from `assert cog.content_loop.is_running() or True` which always passed regardless of the actual loop state
- **#207**: Fix LLM client resource leak on cog unload -- added `close()` method to `SummarizationService` that delegates to `self._client.close()`, and call it from `SummarizeCog`, `ChannelSummary`, and `ContentPostingCog` `cog_unload()` methods
- **#210**: Add `create_llm_client` verification to `ChannelSummary` `cog_load` test -- patched `create_llm_client` and `SummarizationService`, verifying they are called with correct `provider`, `api_key`, and `model` arguments. Also added `TestCogUnload` class to verify summarizer cleanup.
- **#213**: Already resolved by worker-1's model validator changes that reject empty API keys at construction time

## Test plan

- [x] All 69 affected tests pass (test_content_posting, test_channel_summary, test_summarize)
- [x] Full test suite passes (756 tests)
- [x] `ruff check .` passes with no issues