### PR TITLE
Simplify /lore command and fix ingestion crash

### DIFF
--- a/src/intelstream/bot.py
+++ b/src/intelstream/bot.py
@@ -212,11 +212,11 @@ class IntelStreamBot(commands.Bot):
             )
 
         lore_cog = self.cogs.get("Lore")
-        if lore_cog is not None and hasattr(lore_cog, "auto_resume_ingestion"):
+        if lore_cog is not None and hasattr(lore_cog, "auto_start_ingestion"):
             try:
-                await lore_cog.auto_resume_ingestion()
+                await lore_cog.auto_start_ingestion()
             except Exception as e:
-                logger.error("Failed to auto-resume lore ingestion", error=str(e))
+                logger.error("Failed to auto-start lore ingestion", error=str(e))
 
     async def on_error(self, event_method: str, *_args: Any, **_kwargs: Any) -> None:
         logger.exception("Error in event handler", event_method=event_method)

--- a/src/intelstream/config.py
+++ b/src/intelstream/config.py
@@ -245,10 +245,6 @@ class Settings(BaseSettings):
         le=50,
         description="Number of chunks to retrieve per lore query",
     )
-    lore_auto_resume: bool = Field(
-        default=True,
-        description="Auto-resume in-progress ingestion on bot restart",
-    )
 
     def get_poll_interval(self, source_type: SourceType) -> int:
         from intelstream.database.models import SourceType

--- a/src/intelstream/discord/cogs/lore.py
+++ b/src/intelstream/discord/cogs/lore.py
@@ -4,12 +4,12 @@ import re
 from datetime import UTC, datetime, timedelta
 from typing import TYPE_CHECKING
 
-import anthropic
 import discord
 import structlog
 from discord import MessageType, app_commands
 from discord.ext import commands, tasks
 
+from intelstream.services.llm_client import LLMClient, LLMError, create_llm_client
 from intelstream.services.message_ingestion import (
     MessageChunker,
     MessageIngestionService,
@@ -60,6 +60,23 @@ def _parse_timeframe(timeframe: str) -> tuple[datetime | None, datetime | None]:
     return None, None
 
 
+def _split_message(text: str, max_len: int = MAX_DISCORD_MESSAGE_LENGTH) -> list[str]:
+    if len(text) <= max_len:
+        return [text]
+
+    parts: list[str] = []
+    while text:
+        if len(text) <= max_len:
+            parts.append(text)
+            break
+        split_at = text.rfind("\n", 0, max_len)
+        if split_at == -1:
+            split_at = max_len
+        parts.append(text[:split_at])
+        text = text[split_at:].lstrip("\n")
+    return parts
+
+
 class Lore(commands.Cog):
     def __init__(
         self,
@@ -71,7 +88,7 @@ class Lore(commands.Cog):
         self._embedding_service = embedding_service
         self._vector_store = vector_store
         self._ingestion_service: MessageIngestionService | None = None
-        self._anthropic: anthropic.AsyncAnthropic | None = None
+        self._llm_client: LLMClient | None = None
         self._message_buffers: dict[str, list[RawMessage]] = {}
         self._chunker: MessageChunker | None = None
 
@@ -83,11 +100,14 @@ class Lore(commands.Cog):
             gap_minutes=self.bot.settings.lore_chunk_gap_minutes,
             max_messages=self.bot.settings.lore_chunk_max_messages,
         )
-        api_key = self.bot.settings.anthropic_api_key
-        if api_key and api_key.strip():
-            self._anthropic = anthropic.AsyncAnthropic(api_key=api_key)
-        else:
-            logger.warning("ANTHROPIC_API_KEY not set; lore query feature will be disabled")
+        try:
+            self._llm_client = create_llm_client(
+                provider=self.bot.settings.llm_provider,
+                api_key=self.bot.settings.llm_api_key,
+                model=self.bot.settings.summary_model_interactive,
+            )
+        except ValueError:
+            logger.warning("No LLM API key configured; /lore queries will be disabled")
         self._chunker = MessageChunker(
             gap_minutes=self.bot.settings.lore_chunk_gap_minutes,
             max_messages=self.bot.settings.lore_chunk_max_messages,
@@ -100,18 +120,18 @@ class Lore(commands.Cog):
         if self._ingestion_service and self._ingestion_service.is_running:
             self._ingestion_service.stop_backfill()
         await self._flush_all_buffers()
+        if self._llm_client:
+            await self._llm_client.close()
         logger.info("Lore cog unloaded")
 
-    lore_group = app_commands.Group(name="lore", description="Server lore and history commands")
-
-    @lore_group.command(name="query", description="Query server lore with natural language")
+    @app_commands.command(name="lore", description="Ask about server history and lore")
     @app_commands.describe(
         query="What do you want to know about?",
         channel="Limit search to a specific channel",
         timeframe="Time range, e.g. 'last 6 months', '2024'",
     )
     @app_commands.checks.cooldown(rate=1, per=120.0)
-    async def lore_query(
+    async def lore(
         self,
         interaction: discord.Interaction,
         query: str,
@@ -127,8 +147,15 @@ class Lore(commands.Cog):
             )
             return
 
+        if self._llm_client is None:
+            await interaction.followup.send(
+                "Lore queries are unavailable. No LLM API key is configured.",
+                ephemeral=True,
+            )
+            return
+
         logger.info(
-            "lore query invoked",
+            "Lore query",
             user_id=interaction.user.id,
             query=query,
             channel=channel.name if channel else None,
@@ -141,7 +168,7 @@ class Lore(commands.Cog):
 
         if not results:
             await interaction.followup.send(
-                "No lore found. The message index may be empty. Run `/lore setup` first.",
+                "No lore found. The message index may still be building.",
                 ephemeral=True,
             )
             return
@@ -191,23 +218,13 @@ class Lore(commands.Cog):
             f"--- Message History ---\n{context_text}"
         )
 
-        if self._anthropic is None:
-            await interaction.followup.send(
-                "Lore queries are unavailable. ANTHROPIC_API_KEY is not configured.",
-                ephemeral=True,
-            )
-            return
         try:
-            message = await self._anthropic.messages.create(
-                model=self.bot.settings.summary_model_interactive,
-                max_tokens=2048,
+            response_text = await self._llm_client.complete(
                 system=LORE_SYSTEM_PROMPT,
-                messages=[{"role": "user", "content": prompt}],
+                user_message=prompt,
+                max_tokens=2048,
             )
-            response_text = "\n\n".join(
-                block.text for block in message.content if hasattr(block, "text")
-            ).strip()
-        except Exception as e:
+        except LLMError as e:
             logger.error("Failed to generate lore response", error=str(e))
             await interaction.followup.send(
                 "Failed to generate lore response. Please try again later.", ephemeral=True
@@ -220,104 +237,6 @@ class Lore(commands.Cog):
             parts = _split_message(response_text)
             for part in parts:
                 await interaction.followup.send(part)
-
-    @lore_group.command(
-        name="setup", description="Start ingesting server message history (admin only)"
-    )
-    @app_commands.checks.has_permissions(administrator=True)
-    async def lore_setup(self, interaction: discord.Interaction) -> None:
-        await interaction.response.defer(ephemeral=True)
-
-        if not interaction.guild:
-            await interaction.followup.send(
-                "This command can only be used in a server.", ephemeral=True
-            )
-            return
-
-        assert self._ingestion_service is not None
-
-        if self._ingestion_service.is_running:
-            await interaction.followup.send("Ingestion is already running.", ephemeral=True)
-            return
-
-        channels = [
-            ch
-            for ch in interaction.guild.text_channels
-            if ch.permissions_for(interaction.guild.me).read_message_history
-        ]
-
-        self._ingestion_service.start_backfill(interaction.guild)
-
-        await interaction.followup.send(
-            f"Started message ingestion for {len(channels)} channels. "
-            f"Use `/lore status` to check progress.",
-            ephemeral=True,
-        )
-
-    @lore_group.command(name="status", description="Show message ingestion progress")
-    async def lore_status(self, interaction: discord.Interaction) -> None:
-        guild_id = str(interaction.guild_id) if interaction.guild_id else None
-        if not guild_id:
-            await interaction.response.send_message("Server only.", ephemeral=True)
-            return
-
-        progress_list = await self.bot.repository.get_ingestion_progress_for_guild(guild_id)
-        if not progress_list:
-            await interaction.response.send_message(
-                "No ingestion started. Run `/lore setup` to begin.", ephemeral=True
-            )
-            return
-
-        lines = []
-        total_fetched = 0
-        completed = 0
-        for p in progress_list:
-            status_icon = {
-                "pending": "-",
-                "in_progress": ">",
-                "completed": "+",
-                "paused": "||",
-            }.get(p.status, "?")
-            lines.append(
-                f"`{status_icon}` <#{p.channel_id}> -- {p.total_fetched:,} messages ({p.status})"
-            )
-            total_fetched += p.total_fetched or 0
-            if p.status == "completed":
-                completed += 1
-
-        header = f"**Lore Ingestion** ({completed}/{len(progress_list)} channels done, {total_fetched:,} total messages)\n"
-        text = header + "\n".join(lines[:20])
-        if len(progress_list) > 20:
-            text += f"\n*... and {len(progress_list) - 20} more channels*"
-
-        if len(text) > MAX_DISCORD_MESSAGE_LENGTH:
-            text = text[: MAX_DISCORD_MESSAGE_LENGTH - 3] + "..."
-
-        await interaction.response.send_message(text, ephemeral=True)
-
-    @lore_group.command(name="pause", description="Pause message ingestion (admin only)")
-    @app_commands.checks.has_permissions(administrator=True)
-    async def lore_pause(self, interaction: discord.Interaction) -> None:
-        assert self._ingestion_service is not None
-        if not self._ingestion_service.is_running:
-            await interaction.response.send_message("No ingestion is running.", ephemeral=True)
-            return
-        self._ingestion_service.pause()
-        await interaction.response.send_message("Ingestion paused.", ephemeral=True)
-
-    @lore_group.command(name="resume", description="Resume paused message ingestion (admin only)")
-    @app_commands.checks.has_permissions(administrator=True)
-    async def lore_resume(self, interaction: discord.Interaction) -> None:
-        if not interaction.guild:
-            await interaction.response.send_message("Server only.", ephemeral=True)
-            return
-        assert self._ingestion_service is not None
-        if self._ingestion_service.is_running:
-            self._ingestion_service.resume()
-            await interaction.response.send_message("Ingestion resumed.", ephemeral=True)
-        else:
-            self._ingestion_service.start_backfill(interaction.guild)
-            await interaction.response.send_message("Restarted ingestion.", ephemeral=True)
 
     @commands.Cog.listener("on_message")
     async def on_message(self, message: discord.Message) -> None:
@@ -380,8 +299,8 @@ class Lore(commands.Cog):
         if chunks and self._ingestion_service:
             stored = await self._ingestion_service.store_chunks(chunks)
             if stored > 0:
-                logger.debug(
-                    "Flushed real-time message buffer",
+                logger.info(
+                    "Real-time lore flush",
                     channel=channel_name,
                     chunks=stored,
                     messages=len(buf),
@@ -392,24 +311,34 @@ class Lore(commands.Cog):
         for key in keys:
             await self._flush_buffer(key)
 
-    async def auto_resume_ingestion(self) -> None:
-        if not self.bot.settings.lore_auto_resume:
+    async def start_ingestion_for_guild(self, guild: discord.Guild) -> None:
+        if not self._ingestion_service:
+            return
+        if self._ingestion_service.is_running:
             return
 
-        in_progress = await self.bot.repository.get_in_progress_ingestions()
-        if not in_progress:
+        progress = await self.bot.repository.get_ingestion_progress_for_guild(str(guild.id))
+        in_progress_or_paused = [p for p in progress if p.status in ("in_progress", "paused")]
+        all_completed = progress and all(p.status == "completed" for p in progress)
+
+        if all_completed:
+            logger.info("Lore ingestion already complete", guild=guild.name)
             return
 
-        guild_ids = {p.guild_id for p in in_progress}
-        for gid in guild_ids:
-            guild = self.bot.get_guild(int(gid))
-            if guild and self._ingestion_service:
-                logger.info("Auto-resuming ingestion", guild=guild.name)
-                self._ingestion_service.start_backfill(guild)
-                break
+        if in_progress_or_paused:
+            logger.info("Resuming lore ingestion", guild=guild.name)
+        else:
+            logger.info("Starting lore ingestion", guild=guild.name)
 
-    @lore_query.error
-    async def lore_query_error(
+        self._ingestion_service.start_backfill(guild)
+
+    async def auto_start_ingestion(self) -> None:
+        for guild in self.bot.guilds:
+            await self.start_ingestion_for_guild(guild)
+            break
+
+    @lore.error
+    async def lore_error(
         self, interaction: discord.Interaction, error: app_commands.AppCommandError
     ) -> None:
         if isinstance(error, app_commands.CommandOnCooldown):
@@ -420,53 +349,3 @@ class Lore(commands.Cog):
             )
         else:
             raise error
-
-    @lore_setup.error
-    async def lore_setup_error(
-        self, interaction: discord.Interaction, error: app_commands.AppCommandError
-    ) -> None:
-        if isinstance(error, app_commands.MissingPermissions):
-            await interaction.response.send_message(
-                "Administrator permissions required.", ephemeral=True
-            )
-        else:
-            raise error
-
-    @lore_pause.error
-    async def lore_pause_error(
-        self, interaction: discord.Interaction, error: app_commands.AppCommandError
-    ) -> None:
-        if isinstance(error, app_commands.MissingPermissions):
-            await interaction.response.send_message(
-                "Administrator permissions required.", ephemeral=True
-            )
-        else:
-            raise error
-
-    @lore_resume.error
-    async def lore_resume_error(
-        self, interaction: discord.Interaction, error: app_commands.AppCommandError
-    ) -> None:
-        if isinstance(error, app_commands.MissingPermissions):
-            await interaction.response.send_message(
-                "Administrator permissions required.", ephemeral=True
-            )
-        else:
-            raise error
-
-
-def _split_message(text: str, max_len: int = MAX_DISCORD_MESSAGE_LENGTH) -> list[str]:
-    if len(text) <= max_len:
-        return [text]
-
-    parts: list[str] = []
-    while text:
-        if len(text) <= max_len:
-            parts.append(text)
-            break
-        split_at = text.rfind("\n", 0, max_len)
-        if split_at == -1:
-            split_at = max_len
-        parts.append(text[:split_at])
-        text = text[split_at:].lstrip("\n")
-    return parts

--- a/src/intelstream/services/message_ingestion.py
+++ b/src/intelstream/services/message_ingestion.py
@@ -226,6 +226,13 @@ class MessageIngestionService:
         await self._repository.add_message_chunk_metas_batch(metas)
         await self._vector_store.upsert_message_chunks_batch(vector_items)
 
+        total_messages = sum(len(c.messages) for c in chunks)
+        logger.info(
+            "Stored message chunks",
+            chunks=len(metas),
+            messages=total_messages,
+        )
+
         return len(metas)
 
     async def ingest_channel(
@@ -364,7 +371,7 @@ class MessageIngestionService:
         channels = [
             ch for ch in guild.text_channels if ch.permissions_for(guild.me).read_message_history
         ]
-        channels.sort(key=lambda c: c.last_message_id or "", reverse=True)
+        channels.sort(key=lambda c: c.last_message_id or 0, reverse=True)
 
         logger.info(
             "Starting backfill",
@@ -372,19 +379,34 @@ class MessageIngestionService:
             channels=len(channels),
         )
 
+        completed = 0
         for channel in channels:
             if self._paused:
-                logger.info("Backfill paused by user")
+                logger.info("Backfill paused", completed_channels=completed)
                 return
             await self.ingest_channel(channel, guild_id)
+            completed += 1
 
-        logger.info("Backfill complete", guild=guild.name)
+        logger.info(
+            "Backfill complete",
+            guild=guild.name,
+            channels=completed,
+        )
 
     def start_backfill(self, guild: discord.Guild) -> None:
         if self.is_running:
             return
         self._paused = False
-        self._backfill_task = asyncio.create_task(self.run_backfill(guild))
+        self._backfill_task = asyncio.create_task(
+            self._run_backfill_safe(guild),
+            name=f"lore-backfill-{guild.id}",
+        )
+
+    async def _run_backfill_safe(self, guild: discord.Guild) -> None:
+        try:
+            await self.run_backfill(guild)
+        except Exception:
+            logger.exception("Backfill task crashed", guild=guild.name)
 
     def stop_backfill(self) -> None:
         self._paused = True

--- a/tests/test_discord/test_lore.py
+++ b/tests/test_discord/test_lore.py
@@ -15,11 +15,12 @@ def mock_bot():
     bot.settings.lore_chunk_gap_minutes = 10
     bot.settings.lore_chunk_max_messages = 20
     bot.settings.lore_search_results = 15
-    bot.settings.lore_auto_resume = True
-    bot.settings.anthropic_api_key = "test-key"
+    bot.settings.llm_provider = "anthropic"
+    bot.settings.llm_api_key = "test-key"
     bot.settings.summary_model_interactive = "claude-test"
     bot.repository = AsyncMock()
     bot.get_guild = MagicMock(return_value=None)
+    bot.guilds = []
     bot.cogs = {}
     return bot
 
@@ -43,7 +44,8 @@ def lore_cog(mock_bot, mock_embedding_service, mock_vector_store):
     cog = Lore(mock_bot, mock_embedding_service, mock_vector_store)
     cog._ingestion_service = MagicMock()
     cog._ingestion_service.is_running = False
-    cog._anthropic = AsyncMock()
+    cog._llm_client = AsyncMock()
+    cog._llm_client.complete = AsyncMock(return_value="Here is the lore about that topic.")
     cog._chunker = MagicMock()
     return cog
 
@@ -131,13 +133,13 @@ class TestSplitMessage:
 class TestLoreQuery:
     async def test_query_no_guild(self, lore_cog, mock_interaction):
         mock_interaction.guild_id = None
-        await lore_cog.lore_query.callback(lore_cog, mock_interaction, "test")
+        await lore_cog.lore.callback(lore_cog, mock_interaction, "test")
         mock_interaction.followup.send.assert_called_once()
         assert "server" in mock_interaction.followup.send.call_args[0][0].lower()
 
     async def test_query_no_results(self, lore_cog, mock_interaction, mock_vector_store):
         mock_vector_store.search_message_chunks.return_value = []
-        await lore_cog.lore_query.callback(lore_cog, mock_interaction, "test query")
+        await lore_cog.lore.callback(lore_cog, mock_interaction, "test query")
         mock_interaction.followup.send.assert_called_once()
         assert "no lore" in mock_interaction.followup.send.call_args[0][0].lower()
 
@@ -158,13 +160,9 @@ class TestLoreQuery:
         meta.text = "Some conversation text here"
         mock_bot.repository.get_message_chunk_metas_by_ids.return_value = [meta]
 
-        response_block = MagicMock()
-        response_block.text = "Here is the lore about that topic."
-        claude_response = MagicMock()
-        claude_response.content = [response_block]
-        lore_cog._anthropic.messages.create = AsyncMock(return_value=claude_response)
+        lore_cog._llm_client.complete = AsyncMock(return_value="Here is the lore about that topic.")
 
-        await lore_cog.lore_query.callback(lore_cog, mock_interaction, "test query")
+        await lore_cog.lore.callback(lore_cog, mock_interaction, "test query")
         mock_interaction.followup.send.assert_called()
         sent_text = mock_interaction.followup.send.call_args[0][0]
         assert "lore" in sent_text.lower()
@@ -182,137 +180,89 @@ class TestLoreQuery:
         meta.channel_id = "999"
         mock_bot.repository.get_message_chunk_metas_by_ids.return_value = [meta]
 
-        await lore_cog.lore_query.callback(lore_cog, mock_interaction, "test query")
+        await lore_cog.lore.callback(lore_cog, mock_interaction, "test query")
         mock_interaction.followup.send.assert_called()
         assert "no relevant" in mock_interaction.followup.send.call_args[0][0].lower()
 
+    async def test_query_no_llm_client(self, lore_cog, mock_interaction):
+        lore_cog._llm_client = None
+        await lore_cog.lore.callback(lore_cog, mock_interaction, "test query")
+        mock_interaction.followup.send.assert_called_once()
+        assert "unavailable" in mock_interaction.followup.send.call_args[0][0].lower()
 
-class TestLoreCogLoadWithoutAnthropicKey:
+
+class TestLoreCogLoadWithoutApiKey:
     async def test_cog_load_without_api_key(
         self, mock_bot, mock_embedding_service, mock_vector_store
     ):
-        mock_bot.settings.anthropic_api_key = None
+        type(mock_bot.settings).llm_api_key = property(
+            lambda _: (_ for _ in ()).throw(ValueError("No API key"))
+        )
         cog = Lore(mock_bot, mock_embedding_service, mock_vector_store)
         cog._flush_buffers = MagicMock()
         cog._flush_buffers.start = MagicMock()
 
         await cog.cog_load()
 
-        assert cog._anthropic is None
+        assert cog._llm_client is None
         assert cog._ingestion_service is not None
         assert cog._chunker is not None
 
-    async def test_cog_load_with_empty_api_key(
-        self, mock_bot, mock_embedding_service, mock_vector_store
-    ):
-        mock_bot.settings.anthropic_api_key = "  "
-        cog = Lore(mock_bot, mock_embedding_service, mock_vector_store)
-        cog._flush_buffers = MagicMock()
-        cog._flush_buffers.start = MagicMock()
 
-        await cog.cog_load()
-
-        assert cog._anthropic is None
-
-    async def test_query_returns_error_when_no_anthropic(
-        self, mock_interaction, mock_vector_store, mock_bot, mock_embedding_service
-    ):
-        mock_bot.settings.anthropic_api_key = None
-        cog = Lore(mock_bot, mock_embedding_service, mock_vector_store)
-        cog._anthropic = None
-        cog._ingestion_service = MagicMock()
-        cog._chunker = MagicMock()
-
-        mock_vector_store.search_message_chunks.return_value = [
-            ChunkSearchResult(chunk_id="chunk-1", score=0.9),
-        ]
-        meta = MagicMock()
-        meta.id = "chunk-1"
-        meta.guild_id = str(mock_interaction.guild_id)
-        meta.channel_id = "999"
-        meta.channel_name = "general"
-        meta.start_timestamp = datetime(2024, 6, 1, tzinfo=UTC)
-        meta.end_timestamp = datetime(2024, 6, 1, 1, 0, tzinfo=UTC)
-        meta.text = "Some text"
-        mock_bot.repository.get_message_chunk_metas_by_ids.return_value = [meta]
-
-        await cog.lore_query.callback(cog, mock_interaction, "test query")
-
-        mock_interaction.followup.send.assert_called()
-        sent_text = mock_interaction.followup.send.call_args[0][0]
-        assert "unavailable" in sent_text.lower()
-
-
-class TestLoreSetup:
-    async def test_setup_no_guild(self, lore_cog, mock_interaction):
-        mock_interaction.guild = None
-        await lore_cog.lore_setup.callback(lore_cog, mock_interaction)
-        mock_interaction.followup.send.assert_called_once()
-        assert (
-            "server"
-            in mock_interaction.followup.send.call_args.kwargs.get(
-                "content", mock_interaction.followup.send.call_args[0][0]
-            ).lower()
-        )
-
-    async def test_setup_already_running(self, lore_cog, mock_interaction):
-        lore_cog._ingestion_service.is_running = True
-        await lore_cog.lore_setup.callback(lore_cog, mock_interaction)
-        mock_interaction.followup.send.assert_called_once()
-        assert "already running" in mock_interaction.followup.send.call_args[0][0].lower()
-
-    async def test_setup_starts_backfill(self, lore_cog, mock_interaction):
-        lore_cog._ingestion_service.is_running = False
-        await lore_cog.lore_setup.callback(lore_cog, mock_interaction)
-        lore_cog._ingestion_service.start_backfill.assert_called_once()
-
-
-class TestLoreStatus:
-    async def test_status_no_guild(self, lore_cog, mock_interaction):
-        mock_interaction.guild_id = None
-        await lore_cog.lore_status.callback(lore_cog, mock_interaction)
-        mock_interaction.response.send_message.assert_called_once()
-
-    async def test_status_no_ingestion(self, lore_cog, mock_interaction, mock_bot):
+class TestAutoStartIngestion:
+    async def test_starts_for_guild_with_no_progress(self, lore_cog, mock_bot):
+        guild = MagicMock(spec=discord.Guild)
+        guild.id = 111
+        guild.name = "Test Server"
         mock_bot.repository.get_ingestion_progress_for_guild.return_value = []
-        await lore_cog.lore_status.callback(lore_cog, mock_interaction)
-        mock_interaction.response.send_message.assert_called_once()
-        assert "no ingestion" in mock_interaction.response.send_message.call_args[0][0].lower()
 
-    async def test_status_shows_progress(self, lore_cog, mock_interaction, mock_bot):
+        await lore_cog.start_ingestion_for_guild(guild)
+        lore_cog._ingestion_service.start_backfill.assert_called_once_with(guild)
+
+    async def test_skips_completed_guild(self, lore_cog, mock_bot):
+        guild = MagicMock(spec=discord.Guild)
+        guild.id = 111
+        guild.name = "Test Server"
         progress = MagicMock()
-        progress.channel_id = "123"
-        progress.total_fetched = 5000
-        progress.status = "in_progress"
+        progress.status = "completed"
         mock_bot.repository.get_ingestion_progress_for_guild.return_value = [progress]
 
-        await lore_cog.lore_status.callback(lore_cog, mock_interaction)
-        mock_interaction.response.send_message.assert_called_once()
-        text = mock_interaction.response.send_message.call_args[0][0]
-        assert "5,000" in text
+        await lore_cog.start_ingestion_for_guild(guild)
+        lore_cog._ingestion_service.start_backfill.assert_not_called()
 
+    async def test_resumes_paused_guild(self, lore_cog, mock_bot):
+        guild = MagicMock(spec=discord.Guild)
+        guild.id = 111
+        guild.name = "Test Server"
+        progress = MagicMock()
+        progress.status = "paused"
+        mock_bot.repository.get_ingestion_progress_for_guild.return_value = [progress]
 
-class TestLorePauseResume:
-    async def test_pause_not_running(self, lore_cog, mock_interaction):
-        lore_cog._ingestion_service.is_running = False
-        await lore_cog.lore_pause.callback(lore_cog, mock_interaction)
-        mock_interaction.response.send_message.assert_called_once()
-        assert "no ingestion" in mock_interaction.response.send_message.call_args[0][0].lower()
+        await lore_cog.start_ingestion_for_guild(guild)
+        lore_cog._ingestion_service.start_backfill.assert_called_once_with(guild)
 
-    async def test_pause_running(self, lore_cog, mock_interaction):
+    async def test_skips_if_already_running(self, lore_cog):
+        guild = MagicMock(spec=discord.Guild)
+        guild.id = 111
         lore_cog._ingestion_service.is_running = True
-        await lore_cog.lore_pause.callback(lore_cog, mock_interaction)
-        lore_cog._ingestion_service.pause.assert_called_once()
 
-    async def test_resume_restarts_when_not_running(self, lore_cog, mock_interaction):
-        lore_cog._ingestion_service.is_running = False
-        await lore_cog.lore_resume.callback(lore_cog, mock_interaction)
-        lore_cog._ingestion_service.start_backfill.assert_called_once()
+        await lore_cog.start_ingestion_for_guild(guild)
+        lore_cog._ingestion_service.start_backfill.assert_not_called()
 
-    async def test_resume_unpauses_when_running(self, lore_cog, mock_interaction):
-        lore_cog._ingestion_service.is_running = True
-        await lore_cog.lore_resume.callback(lore_cog, mock_interaction)
-        lore_cog._ingestion_service.resume.assert_called_once()
+    async def test_auto_start_uses_first_guild(self, lore_cog, mock_bot):
+        guild = MagicMock(spec=discord.Guild)
+        guild.id = 111
+        guild.name = "Test Server"
+        mock_bot.guilds = [guild]
+        mock_bot.repository.get_ingestion_progress_for_guild.return_value = []
+
+        await lore_cog.auto_start_ingestion()
+        lore_cog._ingestion_service.start_backfill.assert_called_once_with(guild)
+
+    async def test_auto_start_no_guilds(self, lore_cog, mock_bot):
+        mock_bot.guilds = []
+        await lore_cog.auto_start_ingestion()
+        lore_cog._ingestion_service.start_backfill.assert_not_called()
 
 
 class TestOnMessage:


### PR DESCRIPTION
## Summary

- **Fix silent backfill crash**: `channels.sort(key=lambda c: c.last_message_id or "")` mixed `int` and `str` sort keys, causing a `TypeError` that was silently swallowed by `asyncio.create_task`. This is why `/lore setup` reported success but `/lore status` showed no progress. Changed back to `or 0`.
- **Auto-start ingestion**: Lore ingestion now starts automatically on bot ready for all guilds. Removed `/lore setup`, `/lore status`, `/lore pause`, `/lore resume` commands and the `lore_auto_resume` config setting.
- **Flat `/lore` command**: Replaced `/lore query <text>` with just `/lore <text>`.
- **Multi-LLM support**: Migrated from hardcoded `anthropic.AsyncAnthropic` to the `LLMClient` abstraction from the multi-LLM refactor.
- **Better logging**: Backfill task crashes are now logged instead of silently lost. Ingestion progress and real-time chunk storage logged at info level.

## Test plan

- [ ] Verify `/lore` command appears in Discord after bot restart (was previously missing due to crash)
- [ ] Verify ingestion starts automatically on bot ready without any manual setup
- [ ] Verify `/lore <question>` returns synthesized server history
- [ ] Check logs for ingestion progress messages at info level
- [ ] Verify old `/lore setup`, `/lore status` etc. are no longer registered