### PR TITLE
Guard lore vector collections before opening zvec files

### DIFF
--- a/src/intelstream/database/vector_store.py
+++ b/src/intelstream/database/vector_store.py
@@ -88,6 +88,9 @@ class VectorStore:
     def _collection_metadata_path(self, collection_name: str, path: str | None = None) -> Path:
         return Path(path or self._collection_path(collection_name)) / _METADATA_FILENAME
 
+    def _collection_metadata_exists(self, collection_name: str, path: str | None = None) -> bool:
+        return self._collection_metadata_path(collection_name, path).exists()
+
     def _collection_attr_name(self, collection_name: str) -> str:
         if collection_name == self._ARTICLES_COLLECTION:
             return "_articles"
@@ -310,6 +313,16 @@ class VectorStore:
         path = self._collection_path(self._ARTICLES_COLLECTION)
         if not create and not await asyncio.to_thread(os.path.exists, path):
             return None
+        if not create and not await asyncio.to_thread(
+            self._collection_metadata_exists,
+            self._ARTICLES_COLLECTION,
+            path,
+        ):
+            logger.warning(
+                "Article vector collection metadata missing; treating collection as unavailable",
+                path=path,
+            )
+            return None
 
         self._articles = await self._open_or_create_collection(
             self._ARTICLES_COLLECTION,
@@ -328,10 +341,23 @@ class VectorStore:
         path = self._message_chunk_collection_path(guild_id)
         if not create and not await asyncio.to_thread(os.path.exists, path):
             return None
+        collection_name = self._message_chunk_collection_name(guild_id)
+        if not create and not await asyncio.to_thread(
+            self._collection_metadata_exists,
+            collection_name,
+            path,
+        ):
+            logger.warning(
+                "Lore vector collection metadata missing; treating collection as unavailable",
+                guild_id=guild_id,
+                path=path,
+            )
+            return None
 
         collection = await self._open_or_create_collection(
-            self._message_chunk_collection_name(guild_id),
+            collection_name,
             path=path,
+            validate_metadata=True,
         )
         self._message_chunks[guild_id] = collection
         return collection
@@ -350,6 +376,7 @@ class VectorStore:
         recreated = await self._open_or_create_collection(
             self._message_chunk_collection_name(guild_id),
             path=path,
+            validate_metadata=True,
         )
         self._message_chunks[guild_id] = recreated
         return recreated

--- a/tests/test_vector_store.py
+++ b/tests/test_vector_store.py
@@ -47,6 +47,31 @@ class TestInitialize:
 
         await store.close()
 
+    async def test_missing_article_metadata_treated_as_unavailable(self, tmp_path):
+        collection_dir = tmp_path / "vectors" / "article_chunks"
+        collection_dir.mkdir(parents=True)
+        (collection_dir / "manifest.0").write_text("placeholder")
+
+        store = VectorStore(data_dir=str(tmp_path / "vectors"), dimensions=4, model_name="model-a")
+        await store.initialize()
+
+        assert await store.article_doc_count() == 0
+        assert store._articles is None
+
+        await store.close()
+
+    async def test_missing_message_metadata_treated_as_unavailable(self, tmp_path):
+        collection_dir = tmp_path / "vectors" / "message_chunks" / "guild-1"
+        collection_dir.mkdir(parents=True)
+        (collection_dir / "manifest.0").write_text("placeholder")
+
+        store = VectorStore(data_dir=str(tmp_path / "vectors"), dimensions=4, model_name="model-a")
+        await store.initialize()
+
+        assert await store.message_chunk_doc_count("guild-1") == 0
+
+        await store.close()
+
     async def test_reopens_existing_collection(self, tmp_path):
         data_dir = str(tmp_path / "reopen_test")
         store1 = VectorStore(data_dir=data_dir, dimensions=4, model_name="model-a")
@@ -122,6 +147,10 @@ class TestUpsertAndSearch:
         await vector_store.upsert_message_chunk("guild-1", "chunk-2", [0.0, 1.0, 0.0, 0.0])
 
         assert await vector_store.message_chunk_doc_count("guild-1") == 2
+        assert vector_store._collection_metadata_path(
+            vector_store._message_chunk_collection_name("guild-1"),
+            vector_store._message_chunk_collection_path("guild-1"),
+        ).exists()
 
     async def test_message_chunk_collections_are_guild_scoped(self, vector_store):
         await vector_store.upsert_message_chunk("guild-1", "chunk-1", [1.0, 0.0, 0.0, 0.0])


### PR DESCRIPTION
## Root Cause
- after `#238`, article startup no longer eagerly opened the broken article collection
- the remaining startup flood was coming from lore recovery: `_ensure_message_chunk_index()` called `message_chunk_doc_count()`, which eagerly opened the guild-scoped zvec collection
- on your data that existing lore collection had a corrupted `embedding.index.1.proxima`, so zvec emitted thousands of native `vector indexer not found for field embedding` errors before lore could decide to rebuild

## Fix
- treat article/message vector collections with missing IntelStream metadata as unavailable instead of opening them
- validate/write IntelStream metadata for guild-scoped lore collections too, not just article collections
- this lets lore health checks fall back to `indexed=0` and rebuild cleanly from SQLite without touching corrupted zvec files first
- add regression tests for missing article/message metadata and lore collection metadata creation

## Verification
- `uv run ruff check src/intelstream/database/vector_store.py tests/test_vector_store.py`
- `uv run pytest tests/test_vector_store.py tests/test_discord/test_search.py tests/test_discord/test_lore.py -q`
- startup replay against a copied snapshot of your current data now logs a single warning about missing lore metadata and immediately chooses the rebuild path, with no native zvec flood

## Note
- `/search` may still say it is rebuilding for a while after startup because your article index is genuinely incomplete and is rebuilding from scratch (`807` indexed articles vs `1815` summarized items in the copied snapshot I checked)
