### PR TITLE
Log article index status during recovery

### DIFF
--- a/src/intelstream/discord/cogs/search.py
+++ b/src/intelstream/discord/cogs/search.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 from contextlib import suppress
+from dataclasses import dataclass
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING
 
@@ -34,6 +35,14 @@ INDEX_BATCH_SIZE = 50
 HEALTH_CHECK_TOPK = 10
 INDEX_RECOVERY_MAX_ATTEMPTS = 3
 INDEX_RECOVERY_BASE_DELAY_SECONDS = 2.0
+
+
+@dataclass(frozen=True)
+class ArticleIndexStatus:
+    expected_articles: int
+    indexed_articles: int
+    stored_chunks: int
+    vector_chunks: int
 
 
 class Search(commands.Cog):
@@ -206,7 +215,16 @@ class Search(commands.Cog):
                     logger.info("No summarized content found; skipping article index rebuild")
                     return
 
-                if await self._article_index_is_healthy(expected_count):
+                status = await self._get_article_index_status(expected_count)
+                logger.info(
+                    "Article search index status",
+                    expected_articles=status.expected_articles,
+                    indexed_articles=status.indexed_articles,
+                    stored_chunks=status.stored_chunks,
+                    vector_chunks=status.vector_chunks,
+                )
+
+                if await self._article_index_is_healthy(status):
                     self._index_rebuild_error = None
                     logger.info("Article search index is healthy", items=expected_count)
                     return
@@ -241,23 +259,28 @@ class Search(commands.Cog):
                 )
                 await asyncio.sleep(delay_seconds)
 
-    async def _article_index_is_healthy(self, expected_count: int) -> bool:
-        indexed_article_count = await self.bot.repository.count_article_chunk_items()
-        if indexed_article_count != expected_count:
+    async def _get_article_index_status(self, expected_count: int) -> ArticleIndexStatus:
+        return ArticleIndexStatus(
+            expected_articles=expected_count,
+            indexed_articles=await self.bot.repository.count_article_chunk_items(),
+            stored_chunks=await self.bot.repository.count_article_chunk_metas(),
+            vector_chunks=await self._vector_store.article_chunk_doc_count(),
+        )
+
+    async def _article_index_is_healthy(self, status: ArticleIndexStatus) -> bool:
+        if status.indexed_articles != status.expected_articles:
             logger.warning(
                 "Article search index article count mismatch",
-                expected=expected_count,
-                indexed=indexed_article_count,
+                expected=status.expected_articles,
+                indexed=status.indexed_articles,
             )
             return False
 
-        stored_chunk_count = await self.bot.repository.count_article_chunk_metas()
-        vector_chunk_count = await self._vector_store.article_chunk_doc_count()
-        if stored_chunk_count != vector_chunk_count:
+        if status.stored_chunks != status.vector_chunks:
             logger.warning(
                 "Article search index chunk count mismatch",
-                stored=stored_chunk_count,
-                indexed=vector_chunk_count,
+                stored=status.stored_chunks,
+                indexed=status.vector_chunks,
             )
             return False
 

--- a/tests/test_discord/test_search.py
+++ b/tests/test_discord/test_search.py
@@ -5,6 +5,7 @@ import discord
 import pytest
 
 from intelstream.database.vector_store import ArticleChunkSearchResult
+from intelstream.discord.cogs import search as search_module
 from intelstream.discord.cogs.search import Search, _truncate
 from intelstream.services.article_search import RankedArticleChunk
 
@@ -235,6 +236,27 @@ class TestIndex:
         assert search_cog._rebuild_article_index.await_count == 2
         sleep_mock.assert_awaited_once()
         assert search_cog._index_rebuild_error is None
+
+    async def test_ensure_article_index_logs_status(
+        self, search_cog, mock_bot, mock_vector_store, monkeypatch
+    ):
+        mock_bot.repository.count_summarized_content_items.return_value = 3
+        mock_bot.repository.count_article_chunk_items.return_value = 2
+        mock_bot.repository.count_article_chunk_metas.return_value = 9
+        mock_vector_store.article_chunk_doc_count.return_value = 8
+        search_cog._article_index_is_healthy = AsyncMock(return_value=True)
+        fake_logger = MagicMock()
+        monkeypatch.setattr(search_module, "logger", fake_logger)
+
+        await search_cog._ensure_article_index()
+
+        fake_logger.info.assert_any_call(
+            "Article search index status",
+            expected_articles=3,
+            indexed_articles=2,
+            stored_chunks=9,
+            vector_chunks=8,
+        )
 
 
 class TestTruncate:


### PR DESCRIPTION
## Summary
- log a compact article index status snapshot before health/rebuild decisions
- reuse a small status object so the same counts drive both logging and health checks
- cover the new startup log with a focused search-cog test

## Verification
- uv run ruff check src/intelstream/discord/cogs/search.py tests/test_discord/test_search.py
- uv run pytest tests/test_discord/test_search.py -q