### PR TITLE
[codex] Improve source routing and forwarding cleanup

### DIFF
--- a/src/intelstream/discord/cogs/source_management.py
+++ b/src/intelstream/discord/cogs/source_management.py
@@ -215,8 +215,9 @@ class SourceManagement(commands.Cog):
     @app_commands.describe(
         source_type="Type of source to add",
         name="Display name for this source",
-        url="URL of the source (Substack, YouTube, RSS, Twitter/X account, or blog page)",
+        url="URL of the source, or Arxiv category code",
         summarize="Whether to summarize content before posting (default: True)",
+        channel="Channel or thread where this source should post (defaults to current)",
     )
     @app_commands.choices(
         source_type=[
@@ -238,6 +239,7 @@ class SourceManagement(commands.Cog):
         name: str,
         url: str,
         summarize: bool = True,
+        channel: discord.TextChannel | discord.Thread | None = None,
     ) -> None:
         await interaction.response.defer(ephemeral=True)
 
@@ -285,6 +287,12 @@ class SourceManagement(commands.Cog):
                 ephemeral=True,
             )
             return
+
+        target_channel_raw_id = channel.id if channel else interaction.channel_id
+        if target_channel_raw_id is None:
+            await interaction.followup.send("Could not determine target channel.", ephemeral=True)
+            return
+        target_channel_id = str(target_channel_raw_id)
 
         try:
             identifier, feed_url = parse_source_identifier(stype, url)
@@ -372,7 +380,7 @@ class SourceManagement(commands.Cog):
                 discovery_strategy=discovery_strategy,
                 url_pattern=discovered_url_pattern,
                 guild_id=str(interaction.guild_id) if interaction.guild_id else None,
-                channel_id=str(interaction.channel_id),
+                channel_id=target_channel_id,
                 skip_summary=not summarize,
             )
         except DuplicateSourceError:
@@ -397,6 +405,7 @@ class SourceManagement(commands.Cog):
         )
         embed.add_field(name="Name", value=name, inline=True)
         embed.add_field(name="Type", value=source_type.name, inline=True)
+        embed.add_field(name="Channel", value=f"<#{target_channel_id}>", inline=True)
         embed.add_field(name="Identifier", value=identifier, inline=False)
         if final_feed_url:
             embed.add_field(name="Feed URL", value=final_feed_url, inline=False)

--- a/src/intelstream/services/message_forwarder.py
+++ b/src/intelstream/services/message_forwarder.py
@@ -66,9 +66,8 @@ class MessageForwarder:
                             content=content,
                             files=files,
                         )
-                except Exception:
+                finally:
                     self._close_files(files)
-                    raise
 
                 logger.info(
                     "Message forwarded",

--- a/tests/test_discord/test_source_management.py
+++ b/tests/test_discord/test_source_management.py
@@ -226,6 +226,46 @@ class TestSourceManagementAdd:
         call_kwargs = interaction.followup.send.call_args.kwargs
         assert "embed" in call_kwargs
 
+    async def test_add_source_uses_selected_channel(
+        self, source_management: SourceManagement, mock_bot: MagicMock
+    ) -> None:
+        interaction = MagicMock(spec=discord.Interaction)
+        interaction.response = MagicMock()
+        interaction.response.defer = AsyncMock()
+        interaction.followup = MagicMock()
+        interaction.followup.send = AsyncMock()
+        interaction.user = MagicMock()
+        interaction.user.id = 123
+        interaction.guild_id = 456
+        interaction.channel_id = 789
+
+        target_channel = MagicMock(spec=discord.TextChannel)
+        target_channel.id = 999
+
+        source_type_choice = MagicMock()
+        source_type_choice.value = "substack"
+        source_type_choice.name = "Substack"
+
+        mock_bot.repository.get_source_by_identifier = AsyncMock(return_value=None)
+        mock_bot.repository.get_source_by_name = AsyncMock(return_value=None)
+
+        mock_source = MagicMock()
+        mock_source.id = "new-source-id"
+        mock_bot.repository.add_source = AsyncMock(return_value=mock_source)
+
+        await source_management.source_add.callback(
+            source_management,
+            interaction,
+            source_type=source_type_choice,
+            name="Test Newsletter",
+            url="https://test.substack.com",
+            channel=target_channel,
+        )
+
+        mock_bot.repository.add_source.assert_called_once()
+        call_kwargs = mock_bot.repository.add_source.call_args.kwargs
+        assert call_kwargs["channel_id"] == "999"
+
     async def test_add_source_duplicate_identifier(self, source_management, mock_bot):
         interaction = MagicMock(spec=discord.Interaction)
         interaction.response = MagicMock()

--- a/tests/test_services/test_message_forwarder.py
+++ b/tests/test_services/test_message_forwarder.py
@@ -210,6 +210,39 @@ class TestForwardMessage:
         assert result == mock_forwarded
         mock_destination.send.assert_called_once()
 
+    async def test_forward_message_closes_files_after_successful_send(
+        self, forwarder: MessageForwarder, mock_bot: MagicMock
+    ) -> None:
+        mock_file = MagicMock(spec=discord.File)
+        mock_attachment = MagicMock()
+        mock_attachment.size = 1000
+        mock_attachment.to_file = AsyncMock(return_value=mock_file)
+
+        mock_destination = MagicMock(spec=discord.TextChannel)
+        mock_destination.guild = MagicMock()
+        mock_destination.guild.filesize_limit = 8_000_000
+        mock_forwarded = MagicMock(spec=discord.Message)
+        mock_destination.send = AsyncMock(return_value=mock_forwarded)
+
+        mock_bot.get_channel = MagicMock(return_value=mock_destination)
+
+        message = MagicMock(spec=discord.Message)
+        message.channel = MagicMock()
+        message.channel.id = 111
+        message.channel.name = "source"
+        message.id = 222
+        message.author = MagicMock()
+        message.author.bot = False
+        message.content = "Test message"
+        message.embeds = []
+        message.attachments = [mock_attachment]
+
+        result = await forwarder.forward_message(message, 333, "channel")
+
+        assert result == mock_forwarded
+        assert mock_destination.send.call_args.kwargs["files"] == [mock_file]
+        mock_file.close.assert_called_once()
+
     async def test_forward_message_destination_not_found(self, forwarder, mock_bot):
         mock_bot.get_channel = MagicMock(return_value=None)
         mock_bot.guilds = []


### PR DESCRIPTION
## Summary

- close forwarded Discord attachment files after successful sends to avoid leaking file handles in long-running bot processes
- add the documented optional `channel` target to `/source add`, while preserving the current-channel default
- clarify the `/source add` URL description to include Arxiv category codes now supported on `main`
- add regression coverage for the forwarding cleanup and selected source channels

## Why

Forwarded attachment files were only closed on send failures, so successful forwarding could leave file handles open. The source add command also documented channel-targeted source routing, but the implementation always stored the current interaction channel.

This branch was rebuilt onto current `main` to remove stale branch history and resolve the conflicts from the old worktree.

## Validation

- `uv run --extra dev ruff check src tests`
- `uv run --extra dev pytest tests/test_services/test_message_forwarder.py tests/test_discord/test_source_management.py` (79 passed)
- `uv run --extra dev mypy src`
- `uv run --extra dev pytest` (791 passed)