### PR TITLE
test: expand edge case coverage

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,5 @@
+import socket
+
 import pytest
 from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
 from sqlalchemy.orm import sessionmaker
@@ -16,6 +18,40 @@ def mock_settings_env(monkeypatch):
     get_settings.cache_clear()
     yield
     get_settings.cache_clear()
+
+
+@pytest.fixture(autouse=True)
+def deterministic_public_dns(monkeypatch):
+    def fake_getaddrinfo(
+        host,
+        port,
+        family=socket.AF_UNSPEC,
+        type=0,
+        proto=0,
+        flags=0,
+    ):
+        _ = (host, flags)
+        if family == socket.AF_INET6:
+            return [
+                (
+                    socket.AF_INET6,
+                    type or socket.SOCK_STREAM,
+                    proto or 6,
+                    "",
+                    ("2606:2800:220:1:248:1893:25c8:1946", port or 0, 0, 0),
+                )
+            ]
+        return [
+            (
+                socket.AF_INET,
+                type or socket.SOCK_STREAM,
+                proto or 6,
+                "",
+                ("93.184.216.34", port or 0),
+            )
+        ]
+
+    monkeypatch.setattr(socket, "getaddrinfo", fake_getaddrinfo)
 
 
 @pytest.fixture

--- a/tests/test_adapters/test_arxiv.py
+++ b/tests/test_adapters/test_arxiv.py
@@ -1,10 +1,12 @@
 from typing import Any
+from unittest.mock import AsyncMock, patch
 
 import httpx
 import pytest
 import respx
 
 from intelstream.adapters.arxiv import ArxivAdapter
+from intelstream.adapters.base import ContentData
 
 SAMPLE_ARXIV_FEED = """<?xml version='1.0' encoding='UTF-8'?>
 <rss xmlns:arxiv="http://arxiv.org/schemas/atom"
@@ -282,6 +284,64 @@ class TestArxivAdapter:
 
         assert len(items) == 2
 
+    @respx.mock
+    async def test_fetch_latest_continues_after_entry_parse_error(self) -> None:
+        respx.get("https://arxiv.org/rss/cs.AI").mock(
+            return_value=httpx.Response(200, text=SAMPLE_ARXIV_FEED)
+        )
+        recovered_item = ContentData(
+            external_id="arxiv:recovered",
+            title="Recovered",
+            original_url="https://arxiv.org/abs/recovered",
+            author="Author",
+            published_at=None,
+            raw_content="Recovered abstract",
+            thumbnail_url=None,
+        )
+
+        async with httpx.AsyncClient() as client:
+            adapter = ArxivAdapter(http_client=client)
+            with patch.object(
+                adapter,
+                "_parse_entry",
+                new_callable=AsyncMock,
+                side_effect=[RuntimeError("bad entry"), recovered_item],
+            ):
+                items = await adapter.fetch_latest("cs.AI")
+
+        assert items == [recovered_item]
+
+    @respx.mock
+    async def test_fetch_latest_request_error(self) -> None:
+        respx.get("https://arxiv.org/rss/cs.AI").mock(
+            side_effect=httpx.ConnectError("network down")
+        )
+
+        async with httpx.AsyncClient() as client:
+            adapter = ArxivAdapter(http_client=client)
+
+            with pytest.raises(httpx.ConnectError):
+                await adapter.fetch_latest("cs.AI")
+
+    async def test_parse_entry_with_non_arxiv_id_skips_html_fetch(self) -> None:
+        adapter = ArxivAdapter()
+        entry = MockEntry(
+            {
+                "id": "custom-id",
+                "link": "https://example.com/papers/custom-id",
+                "title": "Custom Paper",
+                "author": "Fallback Author",
+                "description": "Abstract: Custom abstract text.",
+            }
+        )
+
+        with patch.object(adapter, "_fetch_html_content", new_callable=AsyncMock) as fetch_html:
+            item = await adapter._parse_entry(entry)
+
+        assert item.external_id == "custom-id"
+        assert item.raw_content == "Custom abstract text."
+        fetch_html.assert_not_called()
+
 
 class MockEntry(dict[str, Any]):
     def __getattr__(self, name: str) -> Any:
@@ -306,6 +366,12 @@ class TestArxivIdExtraction:
         entry = MockEntry({"link": "https://example.com", "id": "oai:arXiv.org:2401.12345v3"})
         arxiv_id = adapter._extract_arxiv_id(entry)
         assert arxiv_id == "arxiv:2401.12345"
+
+    def test_extract_falls_back_to_link_when_id_missing(self) -> None:
+        adapter = ArxivAdapter()
+        entry = MockEntry({"link": "https://example.com/paper", "id": ""})
+
+        assert adapter._extract_arxiv_id(entry) == "https://example.com/paper"
 
 
 class TestTitleCleaning:
@@ -351,6 +417,72 @@ class TestHtmlContentExtraction:
         assert content is not None
         assert "paragraph" in content
 
+    def test_extract_paper_content_falls_back_to_main(self) -> None:
+        adapter = ArxivAdapter()
+        html = """<html><body>
+            <main>
+              <section>
+                <p>This main paragraph has enough content to be extracted cleanly.</p>
+              </section>
+            </main>
+        </body></html>"""
+
+        content = adapter._extract_paper_content(html)
+
+        assert content == "This main paragraph has enough content to be extracted cleanly."
+
+    def test_extract_paper_content_removes_chrome_and_sections_without_headings(self) -> None:
+        adapter = ArxivAdapter()
+        html = """<html><body>
+            <header>Site header should be removed.</header>
+            <article>
+              <section>
+                <p>This section has no heading but still contains article content.</p>
+              </section>
+              <div><h2>Appendix</h2><p>This appendix paragraph should be removed.</p></div>
+            </article>
+        </body></html>"""
+
+        content = adapter._extract_paper_content(html)
+
+        assert content == "This section has no heading but still contains article content."
+
+    @respx.mock
+    async def test_fetch_html_content_without_injected_client_handles_404(self) -> None:
+        respx.get("https://arxiv.org/html/2401.00001").mock(return_value=httpx.Response(404))
+
+        adapter = ArxivAdapter()
+
+        assert await adapter._fetch_html_content("2401.00001") is None
+
+    @respx.mock
+    async def test_fetch_html_content_returns_none_for_empty_extraction(self) -> None:
+        respx.get("https://arxiv.org/html/2401.00002").mock(
+            return_value=httpx.Response(200, text="<html><body><p>short</p></body></html>")
+        )
+
+        async with httpx.AsyncClient() as client:
+            adapter = ArxivAdapter(http_client=client)
+            assert await adapter._fetch_html_content("2401.00002") is None
+
+    @respx.mock
+    async def test_fetch_html_content_handles_http_status_error(self) -> None:
+        respx.get("https://arxiv.org/html/2401.00003").mock(return_value=httpx.Response(503))
+
+        async with httpx.AsyncClient() as client:
+            adapter = ArxivAdapter(http_client=client)
+            assert await adapter._fetch_html_content("2401.00003") is None
+
+    @respx.mock
+    async def test_fetch_html_content_handles_request_error(self) -> None:
+        respx.get("https://arxiv.org/html/2401.00004").mock(
+            side_effect=httpx.ConnectError("network down")
+        )
+
+        async with httpx.AsyncClient() as client:
+            adapter = ArxivAdapter(http_client=client)
+            assert await adapter._fetch_html_content("2401.00004") is None
+
 
 class TestAbstractExtraction:
     def test_extract_abstract_from_description(self) -> None:
@@ -378,3 +510,30 @@ class TestAbstractExtraction:
         entry = MockEntry({"summary": None, "description": None})
         abstract = adapter._extract_abstract(entry)
         assert abstract is None
+
+
+class TestAuthorExtraction:
+    def test_extract_authors_uses_object_name_attribute(self) -> None:
+        adapter = ArxivAdapter()
+        author = type("Author", (), {"name": "Object Author"})()
+        entry = MockEntry({"authors": [author]})
+
+        assert adapter._extract_authors(entry) == "Object Author"
+
+    def test_extract_authors_falls_back_to_dc_creator(self) -> None:
+        adapter = ArxivAdapter()
+        entry = MockEntry({"authors": [], "dc_creator": "DC Creator"})
+
+        assert adapter._extract_authors(entry) == "DC Creator"
+
+    def test_extract_authors_returns_unknown_when_no_candidates(self) -> None:
+        adapter = ArxivAdapter()
+        entry = MockEntry({"authors": [{"email": "missing-name@example.com"}]})
+
+        assert adapter._extract_authors(entry) == "Unknown Authors"
+
+    def test_extract_abstract_uses_description_when_summary_missing(self) -> None:
+        adapter = ArxivAdapter()
+        entry = MockEntry({"description": "Abstract: Description fallback."})
+
+        assert adapter._extract_abstract(entry) == "Description fallback."

--- a/tests/test_adapters/test_arxiv.py
+++ b/tests/test_adapters/test_arxiv.py
@@ -407,6 +407,11 @@ class TestHtmlContentExtraction:
         content = adapter._extract_paper_content("<html><body></body></html>")
         assert content is None
 
+    def test_extract_paper_content_empty_document(self) -> None:
+        adapter = ArxivAdapter()
+
+        assert adapter._extract_paper_content("") is None
+
     def test_extract_paper_content_no_article_falls_back_to_body(self) -> None:
         adapter = ArxivAdapter()
         html = """<html><body>

--- a/tests/test_adapters/test_base_contracts.py
+++ b/tests/test_adapters/test_base_contracts.py
@@ -1,0 +1,81 @@
+from datetime import UTC, datetime
+
+import pytest
+
+from intelstream.adapters.base import BaseAdapter, ContentData
+from intelstream.adapters.strategies.base import (
+    DiscoveredPost,
+    DiscoveryResult,
+    DiscoveryStrategy,
+)
+
+
+class SuperAdapter(BaseAdapter):
+    @property
+    def source_type(self):
+        return super().source_type
+
+    async def fetch_latest(self, identifier, feed_url=None, skip_content=False):
+        return await super().fetch_latest(identifier, feed_url, skip_content)
+
+    async def get_feed_url(self, identifier):
+        return await super().get_feed_url(identifier)
+
+
+class SuperStrategy(DiscoveryStrategy):
+    @property
+    def name(self):
+        return super().name
+
+    async def discover(self, url, url_pattern=None):
+        return await super().discover(url, url_pattern)
+
+
+def test_base_adapter_is_abstract() -> None:
+    with pytest.raises(TypeError, match="abstract"):
+        BaseAdapter()
+
+
+async def test_base_adapter_super_methods_are_noops() -> None:
+    adapter = SuperAdapter()
+
+    assert adapter.source_type is None
+    assert await adapter.fetch_latest("identifier", feed_url="feed", skip_content=True) is None
+    assert await adapter.get_feed_url("identifier") is None
+
+
+def test_content_data_defaults() -> None:
+    published_at = datetime(2024, 1, 1, tzinfo=UTC)
+    content = ContentData(
+        external_id="external-1",
+        title="Title",
+        original_url="https://example.com/post",
+        author="Author",
+        published_at=published_at,
+    )
+
+    assert content.raw_content is None
+    assert content.thumbnail_url is None
+    assert content.published_at == published_at
+
+
+def test_discovery_strategy_is_abstract() -> None:
+    with pytest.raises(TypeError, match="abstract"):
+        DiscoveryStrategy()
+
+
+async def test_discovery_strategy_super_methods_are_noops() -> None:
+    strategy = SuperStrategy()
+
+    assert strategy.name is None
+    assert await strategy.discover("https://example.com", url_pattern="/posts/*") is None
+
+
+def test_discovery_dataclass_defaults() -> None:
+    post = DiscoveredPost(url="https://example.com/post", title="Post")
+    result = DiscoveryResult(posts=[post])
+
+    assert post.published_at is None
+    assert result.feed_url is None
+    assert result.url_pattern is None
+    assert result.posts == [post]

--- a/tests/test_adapters/test_page.py
+++ b/tests/test_adapters/test_page.py
@@ -250,6 +250,21 @@ class TestPageAdapter:
 
         assert adapter._parse_post(soup.select_one("article.post"), "https://example.com") is None
 
+    def test_parse_post_skips_missing_title_element(
+        self, sample_profile: ExtractionProfile
+    ) -> None:
+        soup = BeautifulSoup(
+            """
+            <article class="post">
+              <a class="link" href="/posts/no-title">Read more</a>
+            </article>
+            """,
+            "lxml",
+        )
+        adapter = PageAdapter(extraction_profile=sample_profile)
+
+        assert adapter._parse_post(soup.select_one("article.post"), "https://example.com") is None
+
     def test_parse_post_skips_missing_url_attribute(
         self, sample_profile: ExtractionProfile
     ) -> None:
@@ -316,6 +331,15 @@ class TestPageAdapter:
         adapter = PageAdapter(extraction_profile=sample_profile)
 
         result = adapter._parse_date_string("Published January 15 2024 by Editorial")
+
+        assert result == datetime(2024, 1, 15, tzinfo=UTC)
+
+    def test_parse_date_string_extracts_embedded_abbreviated_month_date(
+        self, sample_profile: ExtractionProfile
+    ) -> None:
+        adapter = PageAdapter(extraction_profile=sample_profile)
+
+        result = adapter._parse_date_string("Published Jan 15 2024 by Editorial")
 
         assert result == datetime(2024, 1, 15, tzinfo=UTC)
 

--- a/tests/test_adapters/test_page.py
+++ b/tests/test_adapters/test_page.py
@@ -343,6 +343,15 @@ class TestPageAdapter:
 
         assert result == datetime(2024, 1, 15, tzinfo=UTC)
 
+    def test_parse_date_string_invalid_embedded_month_returns_now(
+        self, sample_profile: ExtractionProfile
+    ) -> None:
+        adapter = PageAdapter(extraction_profile=sample_profile)
+
+        result = adapter._parse_date_string("Published Notamonth 15 2024")
+
+        assert (datetime.now(UTC) - result).total_seconds() < 5
+
     def test_parse_date_string_invalid_returns_now(self, sample_profile: ExtractionProfile) -> None:
         adapter = PageAdapter(extraction_profile=sample_profile)
         result = adapter._parse_date_string("not a date")

--- a/tests/test_adapters/test_page.py
+++ b/tests/test_adapters/test_page.py
@@ -3,7 +3,9 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import httpx
 import pytest
+from bs4 import BeautifulSoup
 
+from intelstream.adapters.base import ContentData
 from intelstream.adapters.page import PageAdapter
 from intelstream.services.page_analyzer import ExtractionProfile
 
@@ -137,6 +139,18 @@ class TestPageAdapter:
         with pytest.raises(httpx.HTTPStatusError):
             await adapter.fetch_latest("https://example.com/blog")
 
+    async def test_fetch_latest_handles_request_error(
+        self, sample_profile: ExtractionProfile
+    ) -> None:
+        mock_client = MagicMock(spec=httpx.AsyncClient)
+        mock_client.get = AsyncMock(
+            side_effect=httpx.ConnectError("offline", request=MagicMock())
+        )
+        adapter = PageAdapter(extraction_profile=sample_profile, http_client=mock_client)
+
+        with pytest.raises(httpx.ConnectError, match="offline"):
+            await adapter.fetch_latest("https://example.com/blog")
+
     async def test_fetch_latest_without_http_client(
         self, sample_profile: ExtractionProfile, sample_html: str
     ) -> None:
@@ -201,6 +215,59 @@ class TestPageAdapter:
         assert len(items) == 1
         assert items[0].title == "Valid Title"
 
+    def test_extract_posts_continues_after_parse_error(
+        self, sample_profile: ExtractionProfile, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        html = """
+        <article class="post"><h2 class="title">Bad</h2></article>
+        <article class="post"><h2 class="title">Good</h2></article>
+        """
+        adapter = PageAdapter(extraction_profile=sample_profile)
+        recovered = ContentData(
+            external_id="good",
+            title="Good",
+            original_url="https://example.com/good",
+            author="Author",
+            published_at=datetime(2024, 1, 1, tzinfo=UTC),
+        )
+        calls = 0
+
+        def fake_parse_post(_post: object, _base_url: str) -> ContentData:
+            nonlocal calls
+            calls += 1
+            if calls == 1:
+                raise ValueError("bad post")
+            return recovered
+
+        monkeypatch.setattr(adapter, "_parse_post", fake_parse_post)
+
+        assert adapter._extract_posts(html, "https://example.com") == [recovered]
+
+    def test_parse_post_skips_missing_url_element(self, sample_profile: ExtractionProfile) -> None:
+        soup = BeautifulSoup(
+            '<article class="post"><h2 class="title">No URL</h2></article>',
+            "lxml",
+        )
+        adapter = PageAdapter(extraction_profile=sample_profile)
+
+        assert adapter._parse_post(soup.select_one("article.post"), "https://example.com") is None
+
+    def test_parse_post_skips_missing_url_attribute(
+        self, sample_profile: ExtractionProfile
+    ) -> None:
+        soup = BeautifulSoup(
+            """
+            <article class="post">
+              <h2 class="title">No Href</h2>
+              <a class="link">Read more</a>
+            </article>
+            """,
+            "lxml",
+        )
+        adapter = PageAdapter(extraction_profile=sample_profile)
+
+        assert adapter._parse_post(soup.select_one("article.post"), "https://example.com") is None
+
     def test_parse_date_string_iso_format(self, sample_profile: ExtractionProfile) -> None:
         adapter = PageAdapter(extraction_profile=sample_profile)
         result = adapter._parse_date_string("2024-01-15T12:00:00Z")
@@ -227,10 +294,122 @@ class TestPageAdapter:
         assert result.month == 1
         assert result.day == 15
 
+    def test_parse_date_string_day_first_formats(self, sample_profile: ExtractionProfile) -> None:
+        adapter = PageAdapter(extraction_profile=sample_profile)
+
+        full_month = adapter._parse_date_string("15 January 2024")
+        short_month = adapter._parse_date_string("15 Jan 2024")
+
+        assert full_month == datetime(2024, 1, 15, tzinfo=UTC)
+        assert short_month == datetime(2024, 1, 15, tzinfo=UTC)
+
+    def test_parse_date_string_numeric_formats(self, sample_profile: ExtractionProfile) -> None:
+        adapter = PageAdapter(extraction_profile=sample_profile)
+
+        us_date = adapter._parse_date_string("01/15/2024")
+        day_first = adapter._parse_date_string("15/01/2024")
+
+        assert us_date == datetime(2024, 1, 15, tzinfo=UTC)
+        assert day_first == datetime(2024, 1, 15, tzinfo=UTC)
+
+    def test_parse_date_string_extracts_embedded_month_date(
+        self, sample_profile: ExtractionProfile
+    ) -> None:
+        adapter = PageAdapter(extraction_profile=sample_profile)
+
+        result = adapter._parse_date_string("Published January 15 2024 by Editorial")
+
+        assert result == datetime(2024, 1, 15, tzinfo=UTC)
+
     def test_parse_date_string_invalid_returns_now(self, sample_profile: ExtractionProfile) -> None:
         adapter = PageAdapter(extraction_profile=sample_profile)
         result = adapter._parse_date_string("not a date")
         assert (datetime.now(UTC) - result).total_seconds() < 5
+
+    def test_extract_date_returns_now_without_selector(
+        self, sample_profile: ExtractionProfile
+    ) -> None:
+        profile = ExtractionProfile.from_dict(
+            {
+                **sample_profile.to_dict(),
+                "date_selector": None,
+            }
+        )
+        adapter = PageAdapter(extraction_profile=profile)
+        soup = BeautifulSoup('<article class="post"></article>', "lxml")
+
+        result = adapter._extract_date(soup.select_one("article.post"))
+
+        assert (datetime.now(UTC) - result).total_seconds() < 5
+
+    def test_extract_date_returns_now_when_selector_missing(
+        self, sample_profile: ExtractionProfile
+    ) -> None:
+        adapter = PageAdapter(extraction_profile=sample_profile)
+        soup = BeautifulSoup('<article class="post"></article>', "lxml")
+
+        result = adapter._extract_date(soup.select_one("article.post"))
+
+        assert (datetime.now(UTC) - result).total_seconds() < 5
+
+    def test_extract_date_returns_now_when_attribute_missing(
+        self, sample_profile: ExtractionProfile
+    ) -> None:
+        adapter = PageAdapter(extraction_profile=sample_profile)
+        soup = BeautifulSoup(
+            '<article class="post"><time></time></article>',
+            "lxml",
+        )
+
+        result = adapter._extract_date(soup.select_one("article.post"))
+
+        assert (datetime.now(UTC) - result).total_seconds() < 5
+
+    def test_extract_date_uses_text_when_no_date_attribute(
+        self, sample_profile: ExtractionProfile
+    ) -> None:
+        profile = ExtractionProfile.from_dict(
+            {
+                **sample_profile.to_dict(),
+                "date_attribute": None,
+            }
+        )
+        adapter = PageAdapter(extraction_profile=profile)
+        soup = BeautifulSoup(
+            '<article class="post"><time>January 15, 2024</time></article>',
+            "lxml",
+        )
+
+        assert adapter._extract_date(soup.select_one("article.post")) == datetime(
+            2024, 1, 15, tzinfo=UTC
+        )
+
+    def test_extract_author_returns_none_for_missing_or_empty_author(
+        self, sample_profile: ExtractionProfile
+    ) -> None:
+        adapter = PageAdapter(extraction_profile=sample_profile)
+        no_author = BeautifulSoup('<article class="post"></article>', "lxml")
+        empty_author = BeautifulSoup(
+            '<article class="post"><span class="author">  </span></article>',
+            "lxml",
+        )
+
+        assert adapter._extract_author(no_author.select_one("article.post")) is None
+        assert adapter._extract_author(empty_author.select_one("article.post")) is None
+
+    def test_extract_author_returns_none_without_selector(
+        self, sample_profile: ExtractionProfile
+    ) -> None:
+        profile = ExtractionProfile.from_dict(
+            {
+                **sample_profile.to_dict(),
+                "author_selector": None,
+            }
+        )
+        adapter = PageAdapter(extraction_profile=profile)
+        soup = BeautifulSoup('<article class="post"></article>', "lxml")
+
+        assert adapter._extract_author(soup.select_one("article.post")) is None
 
 
 class TestExtractionProfile:

--- a/tests/test_adapters/test_page.py
+++ b/tests/test_adapters/test_page.py
@@ -143,9 +143,7 @@ class TestPageAdapter:
         self, sample_profile: ExtractionProfile
     ) -> None:
         mock_client = MagicMock(spec=httpx.AsyncClient)
-        mock_client.get = AsyncMock(
-            side_effect=httpx.ConnectError("offline", request=MagicMock())
-        )
+        mock_client.get = AsyncMock(side_effect=httpx.ConnectError("offline", request=MagicMock()))
         adapter = PageAdapter(extraction_profile=sample_profile, http_client=mock_client)
 
         with pytest.raises(httpx.ConnectError, match="offline"):

--- a/tests/test_adapters/test_rss.py
+++ b/tests/test_adapters/test_rss.py
@@ -1,9 +1,11 @@
 from datetime import UTC, datetime
 
+import feedparser
 import httpx
 import pytest
 import respx
 
+from intelstream.adapters.base import ContentData
 from intelstream.adapters.rss import RSSAdapter
 
 SAMPLE_ATOM_FEED = """<?xml version="1.0" encoding="utf-8"?>
@@ -108,6 +110,19 @@ class TestRSSAdapter:
                 await adapter.fetch_latest("https://notfound.com/feed")
 
     @respx.mock
+    async def test_fetch_latest_request_error(self) -> None:
+        request = httpx.Request("GET", "https://offline.com/feed")
+        respx.get("https://offline.com/feed").mock(
+            side_effect=httpx.ConnectError("network unreachable", request=request)
+        )
+
+        async with httpx.AsyncClient() as client:
+            adapter = RSSAdapter(http_client=client)
+
+            with pytest.raises(httpx.ConnectError, match="network unreachable"):
+                await adapter.fetch_latest("https://offline.com/feed")
+
+    @respx.mock
     async def test_fetch_invalid_feed(self) -> None:
         respx.get("https://invalid.com/feed").mock(
             return_value=httpx.Response(200, text="<not valid xml>")
@@ -132,6 +147,60 @@ class TestRSSAdapter:
             )
 
         assert len(items) == 1
+
+    @respx.mock
+    async def test_fetch_latest_without_injected_client(self) -> None:
+        respx.get("https://rssblog.com/internal-client-feed").mock(
+            return_value=httpx.Response(200, text=SAMPLE_RSS_FEED)
+        )
+
+        adapter = RSSAdapter()
+        items = await adapter.fetch_latest("https://rssblog.com/internal-client-feed")
+
+        assert len(items) == 1
+        assert items[0].title == "RSS Article"
+
+    @respx.mock
+    async def test_fetch_latest_continues_after_entry_parse_error(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        two_item_feed = """<?xml version="1.0" encoding="UTF-8"?>
+        <rss version="2.0">
+          <channel>
+            <title>Recovering Feed</title>
+            <item><title>Bad</title><link>https://example.com/bad</link></item>
+            <item><title>Good</title><link>https://example.com/good</link></item>
+          </channel>
+        </rss>
+        """
+        respx.get("https://example.com/feed").mock(
+            return_value=httpx.Response(200, text=two_item_feed)
+        )
+        recovered = ContentData(
+            external_id="good",
+            title="Good",
+            original_url="https://example.com/good",
+            author="Author",
+            published_at=datetime(2024, 1, 1, tzinfo=UTC),
+        )
+        adapter = RSSAdapter()
+        calls = 0
+
+        def fake_parse_entry(
+            _entry: feedparser.FeedParserDict,
+            _feed: feedparser.FeedParserDict,
+        ) -> ContentData:
+            nonlocal calls
+            calls += 1
+            if calls == 1:
+                raise ValueError("bad entry")
+            return recovered
+
+        monkeypatch.setattr(adapter, "_parse_entry", fake_parse_entry)
+
+        items = await adapter.fetch_latest("https://example.com/feed")
+
+        assert items == [recovered]
 
     async def test_source_type(self) -> None:
         adapter = RSSAdapter()
@@ -161,3 +230,135 @@ class TestRSSAdapter:
 
         assert len(items) == 1
         assert items[0].author == "Feed Title as Author"
+
+    def test_extract_author_joins_multiple_entry_authors(self) -> None:
+        entry = feedparser.FeedParserDict(
+            {
+                "authors": [
+                    feedparser.FeedParserDict({"name": "Author One"}),
+                    feedparser.FeedParserDict({"name": "Author Two"}),
+                ]
+            }
+        )
+        feed = feedparser.FeedParserDict({"feed": feedparser.FeedParserDict()})
+
+        assert RSSAdapter()._extract_author(entry, feed) == "Author One, Author Two"
+
+    def test_extract_author_prefers_author_detail_name(self) -> None:
+        entry = feedparser.FeedParserDict(
+            {"author_detail": feedparser.FeedParserDict({"name": "Detail Author"})}
+        )
+        feed = feedparser.FeedParserDict({"feed": feedparser.FeedParserDict()})
+
+        assert RSSAdapter()._extract_author(entry, feed) == "Detail Author"
+
+    def test_extract_author_ignores_authors_without_names(self) -> None:
+        entry = feedparser.FeedParserDict(
+            {"authors": [feedparser.FeedParserDict({}), feedparser.FeedParserDict({"name": ""})]}
+        )
+        feed = feedparser.FeedParserDict({"feed": feedparser.FeedParserDict()})
+
+        assert RSSAdapter()._extract_author(entry, feed) == "Unknown Author"
+
+    def test_parse_entry_falls_back_to_unknown_author(self) -> None:
+        adapter = RSSAdapter()
+        feed = feedparser.parse(
+            """<?xml version="1.0" encoding="UTF-8"?>
+            <rss version="2.0">
+              <channel>
+                <item>
+                  <title>Untitled Publisher</title>
+                  <link>https://example.com/post</link>
+                </item>
+              </channel>
+            </rss>
+            """
+        )
+
+        item = adapter._parse_entry(feed.entries[0], feed)
+
+        assert item.author == "Unknown Author"
+
+    def test_extract_content_uses_first_non_empty_value_for_unknown_type(self) -> None:
+        entry = feedparser.FeedParserDict(
+            {"content": [{"type": "application/xhtml+xml", "value": "<section>Body</section>"}]}
+        )
+
+        assert RSSAdapter()._extract_content(entry) == "<section>Body</section>"
+
+    def test_extract_content_returns_none_for_empty_preferred_content(self) -> None:
+        entry = feedparser.FeedParserDict({"content": [{"type": "text/html", "value": ""}]})
+
+        assert RSSAdapter()._extract_content(entry) is None
+
+    def test_extract_content_uses_summary_detail(self) -> None:
+        entry = feedparser.FeedParserDict(
+            {"summary_detail": feedparser.FeedParserDict({"value": "Summary detail"})}
+        )
+
+        assert RSSAdapter()._extract_content(entry) == "Summary detail"
+
+    def test_extract_content_uses_summary_then_description(self) -> None:
+        adapter = RSSAdapter()
+        assert adapter._extract_content(feedparser.FeedParserDict({"summary": "Summary"})) == "Summary"
+        assert (
+            adapter._extract_content(feedparser.FeedParserDict({"description": "Description"}))
+            == "Description"
+        )
+
+    def test_extract_content_returns_none_when_missing(self) -> None:
+        assert RSSAdapter()._extract_content(feedparser.FeedParserDict()) is None
+
+    def test_extract_thumbnail_uses_media_content_image(self) -> None:
+        entry = feedparser.FeedParserDict(
+            {"media_content": [{"medium": "image", "url": "https://example.com/media.jpg"}]}
+        )
+
+        assert RSSAdapter()._extract_thumbnail(entry) == "https://example.com/media.jpg"
+
+    def test_extract_thumbnail_uses_media_content_image_type(self) -> None:
+        entry = feedparser.FeedParserDict(
+            {"media_content": [{"type": "image/jpeg", "url": "https://example.com/type.jpg"}]}
+        )
+
+        assert RSSAdapter()._extract_thumbnail(entry) == "https://example.com/type.jpg"
+
+    def test_extract_thumbnail_returns_none_for_image_media_without_url(self) -> None:
+        entry = feedparser.FeedParserDict({"media_content": [{"medium": "image"}]})
+
+        assert RSSAdapter()._extract_thumbnail(entry) is None
+
+    def test_extract_thumbnail_uses_media_thumbnail(self) -> None:
+        entry = feedparser.FeedParserDict(
+            {"media_thumbnail": [{"url": "https://example.com/thumb.jpg"}]}
+        )
+
+        assert RSSAdapter()._extract_thumbnail(entry) == "https://example.com/thumb.jpg"
+
+    def test_extract_thumbnail_uses_image_enclosure_href_and_url(self) -> None:
+        class Entry(dict):
+            def __getattr__(self, name: str) -> object:
+                return self[name]
+
+        adapter = RSSAdapter()
+        href_entry = Entry(
+            {"enclosures": [{"type": "image/png", "href": "https://example.com/href.png"}]}
+        )
+        url_entry = Entry(
+            {"enclosures": [{"type": "image/png", "url": "https://example.com/url.png"}]}
+        )
+
+        assert adapter._extract_thumbnail(href_entry) == "https://example.com/href.png"
+        assert adapter._extract_thumbnail(url_entry) == "https://example.com/url.png"
+
+    def test_extract_thumbnail_uses_link_image_fallback(self) -> None:
+        entry = feedparser.FeedParserDict(
+            {
+                "links": [
+                    {"type": "text/html", "href": "ignored"},
+                    {"type": "image/png", "href": "https://example.com/card.png"},
+                ]
+            }
+        )
+
+        assert RSSAdapter()._extract_thumbnail(entry) == "https://example.com/card.png"

--- a/tests/test_adapters/test_rss.py
+++ b/tests/test_adapters/test_rss.py
@@ -59,6 +59,16 @@ SAMPLE_RSS_MULTIPLE_AUTHORS = """<?xml version="1.0" encoding="UTF-8"?>
 """
 
 
+class AttributeEntry(dict):
+    def __getattr__(self, name: str) -> object:
+        return self[name]
+
+
+class TruthyEmptyList(list[object]):
+    def __bool__(self) -> bool:
+        return True
+
+
 class TestRSSAdapter:
     async def test_get_feed_url_returns_identifier(self) -> None:
         adapter = RSSAdapter()
@@ -286,6 +296,28 @@ class TestRSSAdapter:
 
         assert RSSAdapter()._extract_content(entry) == "<section>Body</section>"
 
+    def test_extract_content_falls_through_empty_content_list(self) -> None:
+        entry = feedparser.FeedParserDict(
+            {
+                "content": TruthyEmptyList(),
+                "summary_detail": feedparser.FeedParserDict({"value": "Summary detail"}),
+            }
+        )
+
+        assert RSSAdapter()._extract_content(entry) == "Summary detail"
+
+    def test_extract_content_skips_empty_unknown_content_value(self) -> None:
+        entry = feedparser.FeedParserDict(
+            {
+                "content": [
+                    {"type": "application/xhtml+xml", "value": ""},
+                    {"type": "text/plain", "value": "Plain body"},
+                ]
+            }
+        )
+
+        assert RSSAdapter()._extract_content(entry) == "Plain body"
+
     def test_extract_content_returns_none_for_empty_preferred_content(self) -> None:
         entry = feedparser.FeedParserDict({"content": [{"type": "text/html", "value": ""}]})
 
@@ -325,6 +357,16 @@ class TestRSSAdapter:
 
         assert RSSAdapter()._extract_thumbnail(entry) == "https://example.com/type.jpg"
 
+    def test_extract_thumbnail_skips_non_image_media_content(self) -> None:
+        entry = feedparser.FeedParserDict(
+            {
+                "media_content": [{"medium": "video", "url": "https://example.com/video.mp4"}],
+                "media_thumbnail": [{"url": "https://example.com/thumb.jpg"}],
+            }
+        )
+
+        assert RSSAdapter()._extract_thumbnail(entry) == "https://example.com/thumb.jpg"
+
     def test_extract_thumbnail_returns_none_for_image_media_without_url(self) -> None:
         entry = feedparser.FeedParserDict({"media_content": [{"medium": "image"}]})
 
@@ -337,21 +379,57 @@ class TestRSSAdapter:
 
         assert RSSAdapter()._extract_thumbnail(entry) == "https://example.com/thumb.jpg"
 
-    def test_extract_thumbnail_uses_image_enclosure_href_and_url(self) -> None:
-        class Entry(dict):
-            def __getattr__(self, name: str) -> object:
-                return self[name]
+    def test_extract_thumbnail_skips_empty_media_thumbnail_url(self) -> None:
+        entry = AttributeEntry(
+            {
+                "media_thumbnail": [{"url": ""}],
+                "enclosures": [{"type": "image/png", "url": "https://example.com/enclosed.png"}],
+            }
+        )
 
+        assert RSSAdapter()._extract_thumbnail(entry) == "https://example.com/enclosed.png"
+
+    def test_extract_thumbnail_falls_through_empty_media_thumbnail_list(self) -> None:
+        entry = AttributeEntry(
+            {
+                "media_thumbnail": TruthyEmptyList(),
+                "enclosures": [{"type": "image/png", "url": "https://example.com/enclosed.png"}],
+            }
+        )
+
+        assert RSSAdapter()._extract_thumbnail(entry) == "https://example.com/enclosed.png"
+
+    def test_extract_thumbnail_uses_image_enclosure_href_and_url(self) -> None:
         adapter = RSSAdapter()
-        href_entry = Entry(
+        href_entry = AttributeEntry(
             {"enclosures": [{"type": "image/png", "href": "https://example.com/href.png"}]}
         )
-        url_entry = Entry(
+        url_entry = AttributeEntry(
             {"enclosures": [{"type": "image/png", "url": "https://example.com/url.png"}]}
         )
 
         assert adapter._extract_thumbnail(href_entry) == "https://example.com/href.png"
         assert adapter._extract_thumbnail(url_entry) == "https://example.com/url.png"
+
+    def test_extract_thumbnail_skips_non_image_enclosure(self) -> None:
+        entry = AttributeEntry(
+            {
+                "enclosures": [{"type": "text/html", "href": "https://example.com/page"}],
+                "links": [{"type": "image/png", "href": "https://example.com/card.png"}],
+            }
+        )
+
+        assert RSSAdapter()._extract_thumbnail(entry) == "https://example.com/card.png"
+
+    def test_extract_thumbnail_falls_through_empty_enclosures_list(self) -> None:
+        entry = AttributeEntry(
+            {
+                "enclosures": TruthyEmptyList(),
+                "links": [{"type": "image/png", "href": "https://example.com/card.png"}],
+            }
+        )
+
+        assert RSSAdapter()._extract_thumbnail(entry) == "https://example.com/card.png"
 
     def test_extract_thumbnail_uses_link_image_fallback(self) -> None:
         entry = feedparser.FeedParserDict(
@@ -364,3 +442,13 @@ class TestRSSAdapter:
         )
 
         assert RSSAdapter()._extract_thumbnail(entry) == "https://example.com/card.png"
+
+    def test_extract_thumbnail_returns_none_when_links_are_not_images(self) -> None:
+        entry = AttributeEntry(
+            {"links": [{"type": "text/html", "href": "https://example.com/page"}]}
+        )
+
+        assert RSSAdapter()._extract_thumbnail(entry) is None
+
+    def test_extract_thumbnail_returns_none_when_no_thumbnail_fields(self) -> None:
+        assert RSSAdapter()._extract_thumbnail(AttributeEntry()) is None

--- a/tests/test_adapters/test_rss.py
+++ b/tests/test_adapters/test_rss.py
@@ -300,7 +300,9 @@ class TestRSSAdapter:
 
     def test_extract_content_uses_summary_then_description(self) -> None:
         adapter = RSSAdapter()
-        assert adapter._extract_content(feedparser.FeedParserDict({"summary": "Summary"})) == "Summary"
+        assert (
+            adapter._extract_content(feedparser.FeedParserDict({"summary": "Summary"})) == "Summary"
+        )
         assert (
             adapter._extract_content(feedparser.FeedParserDict({"description": "Description"}))
             == "Description"

--- a/tests/test_adapters/test_smart_blog.py
+++ b/tests/test_adapters/test_smart_blog.py
@@ -5,7 +5,8 @@ import httpx
 import pytest
 import respx
 
-from intelstream.adapters.smart_blog import SmartBlogAdapter
+from intelstream.adapters.base import ContentData
+from intelstream.adapters.smart_blog import UNKNOWN_DATE, AnalysisResult, SmartBlogAdapter
 from intelstream.adapters.strategies.base import DiscoveredPost, DiscoveryResult
 from intelstream.database.models import Source, SourceType
 from intelstream.database.repository import Repository
@@ -142,6 +143,33 @@ class TestSmartBlogAdapterAnalysis:
             assert result.success is False
             assert "Unable to find blog posts" in result.error
 
+    async def test_analyze_site_continues_after_strategy_exception(
+        self, adapter: SmartBlogAdapter
+    ):
+        with (
+            patch.object(adapter._strategies[0], "discover", new_callable=AsyncMock) as mock_rss,
+            patch.object(
+                adapter._strategies[1], "discover", new_callable=AsyncMock
+            ) as mock_sitemap,
+        ):
+            mock_rss.side_effect = RuntimeError("rss failed")
+            mock_sitemap.return_value = DiscoveryResult(
+                posts=[
+                    DiscoveredPost(url="https://example.com/post-1", title="Post 1"),
+                    DiscoveredPost(url="https://example.com/post-2", title="Post 2"),
+                ],
+                url_pattern="/post-*",
+            )
+
+            result = await adapter.analyze_site("https://example.com/")
+
+            assert result.success is True
+            assert result.strategy == "sitemap"
+            assert result.sample_posts == [
+                "https://example.com/post-1",
+                "https://example.com/post-2",
+            ]
+
 
 class TestSmartBlogAdapterFetchLatest:
     async def test_fetch_latest_source_not_found(self, adapter: SmartBlogAdapter, mock_repository):
@@ -165,6 +193,28 @@ class TestSmartBlogAdapterFetchLatest:
 
             assert result == []
 
+    async def test_fetch_latest_rss_success_resets_failure_count(
+        self, adapter: SmartBlogAdapter, mock_repository, sample_source
+    ):
+        mock_repository.get_source_by_identifier.return_value = sample_source
+        item = ContentData(
+            external_id="post",
+            title="Post",
+            original_url="https://example.com/post",
+            author="Author",
+            published_at=datetime(2024, 1, 1, tzinfo=UTC),
+        )
+
+        with patch("intelstream.adapters.rss.RSSAdapter") as MockRSS:
+            mock_rss_adapter = MagicMock()
+            mock_rss_adapter.fetch_latest = AsyncMock(return_value=[item])
+            MockRSS.return_value = mock_rss_adapter
+
+            result = await adapter.fetch_latest(sample_source.identifier)
+
+        assert result == [item]
+        mock_repository.reset_failure_count.assert_awaited_with(sample_source.id)
+
     async def test_fetch_latest_increments_failure_on_empty_result(
         self, adapter: SmartBlogAdapter, mock_repository, sample_source
     ):
@@ -180,6 +230,61 @@ class TestSmartBlogAdapterFetchLatest:
             await adapter.fetch_latest(sample_source.identifier)
 
             mock_repository.increment_failure_count.assert_called_once_with(sample_source.id)
+
+    async def test_fetch_latest_reanalyzes_after_failure_threshold(
+        self, adapter: SmartBlogAdapter, mock_repository, sample_source
+    ):
+        sample_source.discovery_strategy = "sitemap"
+        sample_source.feed_url = None
+        mock_repository.get_source_by_identifier.return_value = sample_source
+        mock_repository.increment_failure_count.return_value = 3
+        settings = MagicMock()
+        settings.max_consecutive_failures = 3
+
+        with (
+            patch.object(adapter, "_discover_with_fallback", new_callable=AsyncMock) as discover,
+            patch.object(adapter, "analyze_site", new_callable=AsyncMock) as analyze,
+            patch("intelstream.adapters.smart_blog.get_settings", return_value=settings),
+        ):
+            discover.return_value = None
+            analyze.return_value = AnalysisResult(
+                success=True,
+                strategy="rss",
+                feed_url="https://example.com/feed",
+                url_pattern=None,
+            )
+
+            assert await adapter.fetch_latest(sample_source.identifier) == []
+
+        mock_repository.update_source_discovery_strategy.assert_awaited_once_with(
+            source_id=sample_source.id,
+            discovery_strategy="rss",
+            feed_url="https://example.com/feed",
+            url_pattern=None,
+        )
+        mock_repository.reset_failure_count.assert_awaited_with(sample_source.id)
+
+    async def test_fetch_latest_reanalysis_failure_does_not_update_strategy(
+        self, adapter: SmartBlogAdapter, mock_repository, sample_source
+    ):
+        sample_source.discovery_strategy = "sitemap"
+        sample_source.feed_url = None
+        mock_repository.get_source_by_identifier.return_value = sample_source
+        mock_repository.increment_failure_count.return_value = 3
+        settings = MagicMock()
+        settings.max_consecutive_failures = 3
+
+        with (
+            patch.object(adapter, "_discover_with_fallback", new_callable=AsyncMock) as discover,
+            patch.object(adapter, "analyze_site", new_callable=AsyncMock) as analyze,
+            patch("intelstream.adapters.smart_blog.get_settings", return_value=settings),
+        ):
+            discover.return_value = DiscoveryResult(posts=[])
+            analyze.return_value = AnalysisResult(success=False, error="no posts")
+
+            assert await adapter.fetch_latest(sample_source.identifier) == []
+
+        mock_repository.update_source_discovery_strategy.assert_not_called()
 
     async def test_fetch_latest_resets_failure_on_success(
         self, adapter: SmartBlogAdapter, mock_repository, sample_source
@@ -254,6 +359,58 @@ class TestSmartBlogAdapterFetchLatest:
             assert len(result) == 1
             assert result[0].original_url == "https://example.com/new"
 
+    async def test_fetch_latest_returns_empty_when_all_posts_known(
+        self, adapter: SmartBlogAdapter, mock_repository, sample_source
+    ):
+        sample_source.discovery_strategy = "sitemap"
+        sample_source.feed_url = None
+        mock_repository.get_source_by_identifier.return_value = sample_source
+        mock_repository.content_item_exists = AsyncMock(return_value=True)
+        discovery_result = DiscoveryResult(
+            posts=[DiscoveredPost(url="https://example.com/old", title="Old")]
+        )
+
+        with patch.object(
+            adapter, "_discover_with_fallback", new_callable=AsyncMock
+        ) as mock_discover:
+            mock_discover.return_value = discovery_result
+
+            assert await adapter.fetch_latest(sample_source.identifier) == []
+
+    async def test_fetch_latest_uses_extraction_fallbacks_and_skips_failed_posts(
+        self, adapter: SmartBlogAdapter, mock_repository, sample_source
+    ):
+        sample_source.discovery_strategy = "sitemap"
+        sample_source.feed_url = None
+        sample_source.identifier = "https://www.example.com/blog"
+        mock_repository.get_source_by_identifier.return_value = sample_source
+        discovery_result = DiscoveryResult(
+            posts=[
+                DiscoveredPost(url="https://example.com/fail", title="Fail"),
+                DiscoveredPost(url="https://example.com/ok", title=None, published_at=None),
+            ]
+        )
+        extracted = MagicMock(text="", title="", author="", published_at=None)
+
+        with (
+            patch.object(
+                adapter, "_discover_with_fallback", new_callable=AsyncMock
+            ) as mock_discover,
+            patch.object(
+                adapter._content_extractor, "extract", new_callable=AsyncMock
+            ) as mock_extract,
+        ):
+            mock_discover.return_value = discovery_result
+            mock_extract.side_effect = [RuntimeError("extract failed"), extracted]
+
+            result = await adapter.fetch_latest(sample_source.identifier)
+
+        assert len(result) == 1
+        assert result[0].title == "Untitled"
+        assert result[0].author == "Example"
+        assert result[0].published_at == UNKNOWN_DATE
+        assert result[0].raw_content is None
+
 
 class TestSmartBlogAdapterFallback:
     async def test_discover_with_fallback_tries_cached_strategy_first(
@@ -298,7 +455,60 @@ class TestSmartBlogAdapterFallback:
             assert result is not None
             mock_repository.update_source_discovery_strategy.assert_called_once()
 
+    async def test_discover_with_fallback_continues_after_cached_strategy_error(
+        self, adapter: SmartBlogAdapter, mock_repository, sample_source
+    ):
+        with (
+            patch.object(adapter._strategies[0], "discover", new_callable=AsyncMock) as mock_rss,
+            patch.object(
+                adapter._strategies[1], "discover", new_callable=AsyncMock
+            ) as mock_sitemap,
+        ):
+            mock_rss.side_effect = RuntimeError("rss failed")
+            mock_sitemap.return_value = DiscoveryResult(
+                posts=[DiscoveredPost(url="https://example.com/post", title="Post")]
+            )
+
+            result = await adapter._discover_with_fallback(
+                url="https://example.com/",
+                cached_strategy="rss",
+                url_pattern="/posts/*",
+                source=sample_source,
+            )
+
+        assert result is not None
+        mock_sitemap.assert_awaited_once_with("https://example.com/", url_pattern="/posts/*")
+        mock_repository.update_source_discovery_strategy.assert_awaited_once()
+
+    async def test_discover_with_fallback_returns_none_after_empty_and_failed_strategies(
+        self, adapter: SmartBlogAdapter, mock_repository, sample_source
+    ):
+        with (
+            patch.object(adapter._strategies[0], "discover", new_callable=AsyncMock) as mock_rss,
+            patch.object(
+                adapter._strategies[1], "discover", new_callable=AsyncMock
+            ) as mock_sitemap,
+            patch.object(adapter._strategies[2], "discover", new_callable=AsyncMock) as mock_llm,
+        ):
+            mock_rss.return_value = DiscoveryResult(posts=[])
+            mock_sitemap.return_value = None
+            mock_llm.side_effect = RuntimeError("llm failed")
+
+            result = await adapter._discover_with_fallback(
+                url="https://example.com/",
+                cached_strategy="rss",
+                url_pattern=None,
+                source=sample_source,
+            )
+
+        assert result is None
+        mock_repository.update_source_discovery_strategy.assert_not_called()
+
+    def test_get_strategy_by_name_returns_none_for_unknown(self, adapter: SmartBlogAdapter):
+        assert adapter._get_strategy_by_name("missing") is None
+
     async def test_get_site_name_extracts_domain(self, adapter: SmartBlogAdapter):
         assert adapter._get_site_name("https://www.example.com/blog") == "Example"
         assert adapter._get_site_name("https://blog.openai.com/") == "Openai"
         assert adapter._get_site_name("https://anthropic.com/research") == "Anthropic"
+        assert adapter._get_site_name("http://localhost") == "Localhost"

--- a/tests/test_adapters/test_smart_blog.py
+++ b/tests/test_adapters/test_smart_blog.py
@@ -429,6 +429,49 @@ class TestSmartBlogAdapterFallback:
             assert result is not None
             mock_rss.assert_called_once()
 
+    async def test_discover_with_fallback_without_cached_strategy_uses_first_success(
+        self, adapter: SmartBlogAdapter, mock_repository, sample_source
+    ):
+        with patch.object(adapter._strategies[0], "discover", new_callable=AsyncMock) as mock_rss:
+            mock_rss.return_value = DiscoveryResult(
+                posts=[DiscoveredPost(url="https://example.com/post", title="Post")],
+                feed_url="https://example.com/feed",
+            )
+
+            result = await adapter._discover_with_fallback(
+                url="https://example.com/",
+                cached_strategy=None,
+                url_pattern=None,
+                source=sample_source,
+            )
+
+        assert result is not None
+        mock_repository.update_source_discovery_strategy.assert_awaited_once_with(
+            source_id=sample_source.id,
+            discovery_strategy="rss",
+            feed_url="https://example.com/feed",
+            url_pattern=None,
+        )
+
+    async def test_discover_with_fallback_ignores_unknown_cached_strategy(
+        self, adapter: SmartBlogAdapter, mock_repository, sample_source
+    ):
+        with patch.object(adapter._strategies[0], "discover", new_callable=AsyncMock) as mock_rss:
+            mock_rss.return_value = DiscoveryResult(
+                posts=[DiscoveredPost(url="https://example.com/post", title="Post")]
+            )
+
+            result = await adapter._discover_with_fallback(
+                url="https://example.com/",
+                cached_strategy="missing",
+                url_pattern="/posts/*",
+                source=sample_source,
+            )
+
+        assert result is not None
+        mock_rss.assert_awaited_once_with("https://example.com/", url_pattern="/posts/*")
+        mock_repository.update_source_discovery_strategy.assert_awaited_once()
+
     async def test_discover_with_fallback_tries_other_strategies(
         self, adapter: SmartBlogAdapter, mock_repository, sample_source
     ):
@@ -500,6 +543,28 @@ class TestSmartBlogAdapterFallback:
             )
 
         assert result is None
+        mock_repository.update_source_discovery_strategy.assert_not_called()
+
+    async def test_discover_with_fallback_can_return_without_strategy_update(
+        self, adapter: SmartBlogAdapter, mock_repository, sample_source
+    ):
+        strategy = MagicMock()
+        strategy.name = None
+        strategy.discover = AsyncMock(
+            return_value=DiscoveryResult(
+                posts=[DiscoveredPost(url="https://example.com/post", title="Post")]
+            )
+        )
+        adapter._strategies = [strategy]
+
+        result = await adapter._discover_with_fallback(
+            url="https://example.com/",
+            cached_strategy=None,
+            url_pattern=None,
+            source=sample_source,
+        )
+
+        assert result is not None
         mock_repository.update_source_discovery_strategy.assert_not_called()
 
     def test_get_strategy_by_name_returns_none_for_unknown(self, adapter: SmartBlogAdapter):

--- a/tests/test_adapters/test_smart_blog.py
+++ b/tests/test_adapters/test_smart_blog.py
@@ -143,9 +143,7 @@ class TestSmartBlogAdapterAnalysis:
             assert result.success is False
             assert "Unable to find blog posts" in result.error
 
-    async def test_analyze_site_continues_after_strategy_exception(
-        self, adapter: SmartBlogAdapter
-    ):
+    async def test_analyze_site_continues_after_strategy_exception(self, adapter: SmartBlogAdapter):
         with (
             patch.object(adapter._strategies[0], "discover", new_callable=AsyncMock) as mock_rss,
             patch.object(

--- a/tests/test_adapters/test_strategies/test_llm_extraction.py
+++ b/tests/test_adapters/test_strategies/test_llm_extraction.py
@@ -491,6 +491,51 @@ class TestLLMExtractionStrategy:
 
         assert "<article" not in cleaned
 
+    def test_clean_html_keeps_truncated_prefix_when_no_previous_open_tag(
+        self, llm_strategy: LLMExtractionStrategy
+    ):
+        class FakeSoup:
+            def find_all(self, *_args: object, **_kwargs: object) -> list[object]:
+                return []
+
+            def __str__(self) -> str:
+                return "<" + ("x" * 1200)
+
+        settings = MagicMock()
+        settings.max_html_length = 1100
+
+        with (
+            patch(
+                "intelstream.adapters.strategies.llm_extraction.BeautifulSoup",
+                return_value=FakeSoup(),
+            ),
+            patch(
+                "intelstream.adapters.strategies.llm_extraction.get_settings",
+                return_value=settings,
+            ),
+        ):
+            cleaned = llm_strategy._clean_html("<html></html>")
+
+        assert cleaned == "<" + ("x" * 1099)
+
+    async def test_extract_with_llm_ignores_blocks_without_text(
+        self, llm_strategy: LLMExtractionStrategy, mock_anthropic_client
+    ):
+        response = MagicMock()
+        response.content = [
+            object(),
+            MagicMock(text='[{"url": "https://example.com/post", "title": "Post"}]'),
+        ]
+        mock_anthropic_client.messages.create.return_value = response
+
+        posts = await llm_strategy._extract_with_llm(
+            "<html><body>Posts</body></html>",
+            "https://example.com/blog",
+        )
+
+        assert len(posts) == 1
+        assert posts[0].url == "https://example.com/post"
+
     async def test_extract_with_llm_skips_ssrf_blocked_urls(
         self, llm_strategy: LLMExtractionStrategy, mock_anthropic_client
     ):
@@ -513,6 +558,25 @@ class TestLLMExtractionStrategy:
         )
 
         assert [post.url for post in posts] == ["https://example.com/safe"]
+
+    def test_extract_json_falls_back_from_invalid_markdown_to_embedded_array(
+        self, llm_strategy: LLMExtractionStrategy
+    ):
+        text = (
+            '```json\n{"url": "https://example.com/not-a-list"}\n```\n'
+            'Fallback [{"url": "https://example.com/array", "title": "Array"}]'
+        )
+
+        result = llm_strategy._extract_json_from_response(text)
+
+        assert result == [{"url": "https://example.com/array", "title": "Array"}]
+
+    def test_extract_json_returns_empty_for_invalid_embedded_array(
+        self, llm_strategy: LLMExtractionStrategy
+    ):
+        result = llm_strategy._extract_json_from_response("Noisy [not json] response")
+
+        assert result == []
 
     async def test_extract_with_llm_handles_api_error(
         self, llm_strategy: LLMExtractionStrategy, mock_anthropic_client

--- a/tests/test_adapters/test_strategies/test_llm_extraction.py
+++ b/tests/test_adapters/test_strategies/test_llm_extraction.py
@@ -1,6 +1,7 @@
 import json
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
+import anthropic
 import httpx
 import pytest
 import respx
@@ -298,3 +299,137 @@ class TestLLMExtractionStrategy:
         assert len(result.posts) == 1
         assert result.posts[0].url == "https://example.com/valid"
         mock_anthropic_client.messages.create.assert_not_called()
+
+    @respx.mock
+    async def test_discover_ignores_invalid_cache_json_and_refreshes(
+        self, llm_strategy: LLMExtractionStrategy, mock_repository, mock_anthropic_client
+    ):
+        html = "<html><body>Content</body></html>"
+        cached = MagicMock(spec=ExtractionCache)
+        cached.content_hash = llm_strategy._get_content_hash(html)
+        cached.posts_json = "{not json"
+        mock_repository.get_extraction_cache.return_value = cached
+        llm_response = MagicMock()
+        llm_response.content = [
+            MagicMock(text='[{"url": "https://example.com/fresh", "title": "Fresh"}]')
+        ]
+        mock_anthropic_client.messages.create.return_value = llm_response
+        respx.get("https://example.com/").mock(return_value=httpx.Response(200, text=html))
+
+        result = await llm_strategy.discover("https://example.com/")
+
+        assert result is not None
+        assert result.posts[0].url == "https://example.com/fresh"
+        mock_repository.set_extraction_cache.assert_awaited_once()
+
+    @respx.mock
+    async def test_discover_ignores_cache_without_valid_posts(
+        self, llm_strategy: LLMExtractionStrategy, mock_repository, mock_anthropic_client
+    ):
+        html = "<html><body>Content</body></html>"
+        cached = MagicMock(spec=ExtractionCache)
+        cached.content_hash = llm_strategy._get_content_hash(html)
+        cached.posts_json = json.dumps([{"url": "", "title": "Empty"}])
+        mock_repository.get_extraction_cache.return_value = cached
+        llm_response = MagicMock()
+        llm_response.content = [
+            MagicMock(text='[{"url": "https://example.com/fresh", "title": "Fresh"}]')
+        ]
+        mock_anthropic_client.messages.create.return_value = llm_response
+        respx.get("https://example.com/").mock(return_value=httpx.Response(200, text=html))
+
+        result = await llm_strategy.discover("https://example.com/")
+
+        assert result is not None
+        assert result.posts[0].url == "https://example.com/fresh"
+
+    async def test_discover_caches_empty_result_after_timeout(
+        self, llm_strategy: LLMExtractionStrategy, mock_repository
+    ):
+        class TimeoutContext:
+            async def __aenter__(self) -> None:
+                raise TimeoutError
+
+            async def __aexit__(self, *_args: object) -> bool:
+                return False
+
+        with (
+            patch.object(llm_strategy, "_fetch_html", AsyncMock(return_value="<html>slow</html>")),
+            patch("intelstream.adapters.strategies.llm_extraction.asyncio.timeout") as timeout,
+        ):
+            timeout.return_value = TimeoutContext()
+            result = await llm_strategy.discover("https://example.com/")
+
+        assert result is None
+        mock_repository.set_extraction_cache.assert_awaited_once()
+        assert mock_repository.set_extraction_cache.call_args.args[2] == "[]"
+
+    def test_get_content_hash_falls_back_to_raw_html(self, llm_strategy: LLMExtractionStrategy):
+        assert llm_strategy._get_content_hash("") == (
+            "e3b0c44298fc1c149afbf4c8996fb924"
+            "27ae41e4649b934ca495991b7852b855"
+        )
+
+    def test_clean_html_truncates_at_recent_closing_tag(self, llm_strategy: LLMExtractionStrategy):
+        settings = MagicMock()
+        settings.max_html_length = 40
+        html = "<html><body><p>First</p><p>Second paragraph keeps going</p></body></html>"
+
+        with patch(
+            "intelstream.adapters.strategies.llm_extraction.get_settings",
+            return_value=settings,
+        ):
+            cleaned = llm_strategy._clean_html(html)
+
+        assert len(cleaned) <= 40
+        assert cleaned.endswith(">")
+
+    def test_clean_html_truncates_before_open_tag_when_no_recent_close(
+        self, llm_strategy: LLMExtractionStrategy
+    ):
+        settings = MagicMock()
+        settings.max_html_length = 1200
+        html = "<html><body><p>short</p>" + ("x" * 1100) + "<article" + ("y" * 200)
+
+        with patch(
+            "intelstream.adapters.strategies.llm_extraction.get_settings",
+            return_value=settings,
+        ):
+            cleaned = llm_strategy._clean_html(html)
+
+        assert "<article" not in cleaned
+
+    async def test_extract_with_llm_skips_ssrf_blocked_urls(
+        self, llm_strategy: LLMExtractionStrategy, mock_anthropic_client
+    ):
+        response = MagicMock()
+        response.content = [
+            MagicMock(
+                text=json.dumps(
+                    [
+                        {"url": "http://localhost/admin", "title": "Blocked"},
+                        {"url": "/safe", "title": "Safe"},
+                    ]
+                )
+            )
+        ]
+        mock_anthropic_client.messages.create.return_value = response
+
+        posts = await llm_strategy._extract_with_llm(
+            "<html><body>Posts</body></html>",
+            "https://example.com/blog",
+        )
+
+        assert [post.url for post in posts] == ["https://example.com/safe"]
+
+    async def test_extract_with_llm_handles_api_error(
+        self, llm_strategy: LLMExtractionStrategy, mock_anthropic_client
+    ):
+        request = httpx.Request("POST", "https://api.anthropic.com/v1/messages")
+        mock_anthropic_client.messages.create.side_effect = anthropic.APIError(
+            "api failed",
+            request,
+            body=None,
+        )
+
+        assert await llm_strategy._extract_with_llm("<html></html>", "https://example.com") == []

--- a/tests/test_adapters/test_strategies/test_llm_extraction.py
+++ b/tests/test_adapters/test_strategies/test_llm_extraction.py
@@ -343,6 +343,28 @@ class TestLLMExtractionStrategy:
         assert result is not None
         assert result.posts[0].url == "https://example.com/fresh"
 
+    @respx.mock
+    async def test_discover_ignores_non_list_cache_and_refreshes(
+        self, llm_strategy: LLMExtractionStrategy, mock_repository, mock_anthropic_client
+    ):
+        html = "<html><body>Content</body></html>"
+        cached = MagicMock(spec=ExtractionCache)
+        cached.content_hash = llm_strategy._get_content_hash(html)
+        cached.posts_json = json.dumps({"url": "https://example.com/not-a-list"})
+        mock_repository.get_extraction_cache.return_value = cached
+        llm_response = MagicMock()
+        llm_response.content = [
+            MagicMock(text='[{"url": "https://example.com/fresh", "title": "Fresh"}]')
+        ]
+        mock_anthropic_client.messages.create.return_value = llm_response
+        respx.get("https://example.com/").mock(return_value=httpx.Response(200, text=html))
+
+        result = await llm_strategy.discover("https://example.com/")
+
+        assert result is not None
+        assert result.posts[0].url == "https://example.com/fresh"
+        mock_repository.set_extraction_cache.assert_awaited_once()
+
     async def test_discover_caches_empty_result_after_timeout(
         self, llm_strategy: LLMExtractionStrategy, mock_repository
     ):
@@ -369,6 +391,62 @@ class TestLLMExtractionStrategy:
             "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
         )
 
+    def test_get_content_hash_strips_navigation_and_script_tags(
+        self, llm_strategy: LLMExtractionStrategy
+    ):
+        with_noise = llm_strategy._get_content_hash(
+            """
+            <html>
+                <body>
+                    <nav>Menu</nav>
+                    <script>analytics()</script>
+                    <main>Useful Article Text</main>
+                </body>
+            </html>
+            """
+        )
+        without_noise = llm_strategy._get_content_hash("<main>Useful Article Text</main>")
+
+        assert with_noise == without_noise
+
+    async def test_fetch_html_uses_injected_http_client(self, mock_repository):
+        client = MagicMock()
+        client.get = AsyncMock(
+            return_value=httpx.Response(
+                200,
+                text="<html>ok</html>",
+                request=httpx.Request("GET", "https://example.com/"),
+            )
+        )
+        strategy = LLMExtractionStrategy(
+            anthropic_client=MagicMock(),
+            repository=mock_repository,
+            http_client=client,
+        )
+
+        result = await strategy._fetch_html("https://example.com/")
+
+        assert result == "<html>ok</html>"
+        client.get.assert_awaited_once()
+
+    def test_clean_html_removes_noise_tags_and_unneeded_attrs(
+        self, llm_strategy: LLMExtractionStrategy
+    ):
+        html = """
+        <main data-extra="remove" href="/kept">
+            <svg><path d="M0 0" /></svg>
+            <article onclick="remove()" class="post" data-href="/post">Post</article>
+        </main>
+        """
+
+        cleaned = llm_strategy._clean_html(html)
+
+        assert "<svg" not in cleaned
+        assert "onclick" not in cleaned
+        assert "data-extra" not in cleaned
+        assert 'class="post"' in cleaned
+        assert 'data-href="/post"' in cleaned
+
     def test_clean_html_truncates_at_recent_closing_tag(self, llm_strategy: LLMExtractionStrategy):
         settings = MagicMock()
         settings.max_html_length = 40
@@ -382,6 +460,21 @@ class TestLLMExtractionStrategy:
 
         assert len(cleaned) <= 40
         assert cleaned.endswith(">")
+
+    def test_clean_html_truncates_to_previous_tag_when_close_is_stale(
+        self, llm_strategy: LLMExtractionStrategy
+    ):
+        settings = MagicMock()
+        settings.max_html_length = 1100
+        html = "<html><body>" + ("x" * 1200) + "<span>tail</span></body></html>"
+
+        with patch(
+            "intelstream.adapters.strategies.llm_extraction.get_settings",
+            return_value=settings,
+        ):
+            cleaned = llm_strategy._clean_html(html)
+
+        assert cleaned == "<html>"
 
     def test_clean_html_truncates_before_open_tag_when_no_recent_close(
         self, llm_strategy: LLMExtractionStrategy

--- a/tests/test_adapters/test_strategies/test_llm_extraction.py
+++ b/tests/test_adapters/test_strategies/test_llm_extraction.py
@@ -366,8 +366,7 @@ class TestLLMExtractionStrategy:
 
     def test_get_content_hash_falls_back_to_raw_html(self, llm_strategy: LLMExtractionStrategy):
         assert llm_strategy._get_content_hash("") == (
-            "e3b0c44298fc1c149afbf4c8996fb924"
-            "27ae41e4649b934ca495991b7852b855"
+            "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
         )
 
     def test_clean_html_truncates_at_recent_closing_tag(self, llm_strategy: LLMExtractionStrategy):

--- a/tests/test_adapters/test_strategies/test_rss_discovery.py
+++ b/tests/test_adapters/test_strategies/test_rss_discovery.py
@@ -1,3 +1,4 @@
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import httpx
@@ -228,6 +229,25 @@ class TestRSSDiscoveryStrategy:
 
         assert result == "https://example.com/safe-feed.xml"
 
+    def test_find_rss_in_html_skips_irrelevant_missing_and_blocked_links(self, rss_strategy):
+        html = """
+        <html><head>
+          <link rel="alternate" type="text/html" href="/not-a-feed">
+          <link rel="alternate" type="application/rss+xml">
+          <link rel="feed">
+          <link rel="feed" href="http://127.0.0.1/rss">
+          <link rel="feed" href="/safe-feed.xml">
+        </head></html>
+        """
+
+        with patch(
+            "intelstream.adapters.strategies.rss_discovery.validate_url_for_ssrf",
+            side_effect=[SSRFError("blocked"), None],
+        ):
+            result = rss_strategy._find_rss_in_html(html, "https://example.com")
+
+        assert result == "https://example.com/safe-feed.xml"
+
     async def test_probe_rss_paths_accepts_feed_validated_by_body(self):
         client = MagicMock()
         client.head = AsyncMock(
@@ -240,6 +260,20 @@ class TestRSSDiscoveryStrategy:
 
         assert result == "https://example.com/feed"
         strategy._is_valid_feed.assert_awaited_once_with("https://example.com/feed")
+
+    async def test_probe_rss_paths_rejects_200_non_feed_responses(self):
+        client = MagicMock()
+        client.head = AsyncMock(
+            return_value=httpx.Response(200, headers={"content-type": "text/html"})
+        )
+        strategy = RSSDiscoveryStrategy(http_client=client)
+        strategy._is_valid_feed = AsyncMock(return_value=False)
+
+        result = await strategy._probe_rss_paths("https://example.com")
+
+        assert result is None
+        assert client.head.await_count == 10
+        assert strategy._is_valid_feed.await_count == 10
 
     async def test_probe_rss_paths_ignores_http_errors(self):
         client = MagicMock()
@@ -264,6 +298,29 @@ class TestRSSDiscoveryStrategy:
         assert await strategy._is_valid_feed("https://example.com/feed") is False
         assert await strategy._is_valid_feed("https://example.com/feed") is False
 
+    @respx.mock
+    async def test_is_valid_feed_with_default_client_accepts_feed_with_entries(self):
+        rss_content = """<?xml version="1.0"?>
+        <rss version="2.0">
+          <channel>
+            <item>
+              <title>Post</title>
+              <link>https://example.com/post</link>
+            </item>
+          </channel>
+        </rss>
+        """
+        respx.get("https://example.com/feed").mock(
+            return_value=httpx.Response(
+                200,
+                text=rss_content,
+                headers={"content-type": "text/xml"},
+            )
+        )
+        strategy = RSSDiscoveryStrategy()
+
+        assert await strategy._is_valid_feed("https://example.com/feed") is True
+
     async def test_is_valid_feed_handles_http_error(self):
         client = MagicMock()
         client.get = AsyncMock(side_effect=httpx.ConnectError("offline"))
@@ -282,7 +339,11 @@ class TestRSSDiscoveryStrategy:
         )
         strategy = RSSDiscoveryStrategy(http_client=client)
 
-        assert await strategy._parse_feed("https://example.com/feed") is None
+        with patch(
+            "intelstream.adapters.strategies.rss_discovery.feedparser.parse",
+            return_value=SimpleNamespace(bozo=True, entries=[]),
+        ):
+            assert await strategy._parse_feed("https://example.com/feed") is None
 
     async def test_parse_feed_skips_entries_without_links(self):
         rss_content = """<?xml version="1.0"?>

--- a/tests/test_adapters/test_strategies/test_rss_discovery.py
+++ b/tests/test_adapters/test_strategies/test_rss_discovery.py
@@ -1,8 +1,11 @@
+from unittest.mock import AsyncMock, MagicMock, patch
+
 import httpx
 import pytest
 import respx
 
 from intelstream.adapters.strategies.rss_discovery import RSSDiscoveryStrategy
+from intelstream.utils.url_validation import SSRFError
 
 
 @pytest.fixture
@@ -198,3 +201,112 @@ class TestRSSDiscoveryStrategy:
         result = await rss_strategy.discover("https://example.com/")
 
         assert result is None
+
+    async def test_fetch_html_uses_injected_client_and_handles_http_error(self):
+        client = MagicMock()
+        client.get = AsyncMock(side_effect=httpx.ConnectError("offline"))
+        strategy = RSSDiscoveryStrategy(http_client=client)
+
+        result = await strategy._fetch_html("https://example.com")
+
+        assert result is None
+        client.get.assert_awaited_once()
+
+    def test_find_rss_in_html_skips_ssrf_blocked_links(self, rss_strategy):
+        html = """
+        <html><head>
+          <link rel="alternate" type="application/rss+xml" href="http://127.0.0.1/rss">
+          <link rel="feed" href="/safe-feed.xml">
+        </head></html>
+        """
+
+        with patch(
+            "intelstream.adapters.strategies.rss_discovery.validate_url_for_ssrf",
+            side_effect=[SSRFError("blocked"), None],
+        ):
+            result = rss_strategy._find_rss_in_html(html, "https://example.com")
+
+        assert result == "https://example.com/safe-feed.xml"
+
+    async def test_probe_rss_paths_accepts_feed_validated_by_body(self):
+        client = MagicMock()
+        client.head = AsyncMock(
+            return_value=httpx.Response(200, headers={"content-type": "text/html"})
+        )
+        strategy = RSSDiscoveryStrategy(http_client=client)
+        strategy._is_valid_feed = AsyncMock(return_value=True)
+
+        result = await strategy._probe_rss_paths("https://example.com")
+
+        assert result == "https://example.com/feed"
+        strategy._is_valid_feed.assert_awaited_once_with("https://example.com/feed")
+
+    async def test_probe_rss_paths_ignores_http_errors(self):
+        client = MagicMock()
+        client.head = AsyncMock(side_effect=httpx.ReadTimeout("timeout"))
+        strategy = RSSDiscoveryStrategy(http_client=client)
+
+        result = await strategy._probe_rss_paths("https://example.com")
+
+        assert result is None
+        assert client.head.await_count == 10
+
+    async def test_is_valid_feed_rejects_bad_status_and_content_type(self):
+        client = MagicMock()
+        client.get = AsyncMock(
+            side_effect=[
+                httpx.Response(404, text="missing"),
+                httpx.Response(200, text="<rss></rss>", headers={"content-type": "text/html"}),
+            ]
+        )
+        strategy = RSSDiscoveryStrategy(http_client=client)
+
+        assert await strategy._is_valid_feed("https://example.com/feed") is False
+        assert await strategy._is_valid_feed("https://example.com/feed") is False
+
+    async def test_is_valid_feed_handles_http_error(self):
+        client = MagicMock()
+        client.get = AsyncMock(side_effect=httpx.ConnectError("offline"))
+        strategy = RSSDiscoveryStrategy(http_client=client)
+
+        assert await strategy._is_valid_feed("https://example.com/feed") is False
+
+    async def test_parse_feed_returns_none_for_bozo_feed_without_entries(self):
+        client = MagicMock()
+        client.get = AsyncMock(
+            return_value=httpx.Response(
+                200,
+                text="<rss><channel><item>",
+                request=httpx.Request("GET", "https://example.com/feed"),
+            )
+        )
+        strategy = RSSDiscoveryStrategy(http_client=client)
+
+        assert await strategy._parse_feed("https://example.com/feed") is None
+
+    async def test_parse_feed_skips_entries_without_links(self):
+        rss_content = """<?xml version="1.0"?>
+        <rss version="2.0">
+          <channel>
+            <item><title>No link</title></item>
+          </channel>
+        </rss>
+        """
+        client = MagicMock()
+        client.get = AsyncMock(
+            return_value=httpx.Response(
+                200,
+                text=rss_content,
+                request=httpx.Request("GET", "https://example.com/feed"),
+            )
+        )
+        strategy = RSSDiscoveryStrategy(http_client=client)
+
+        assert await strategy._parse_feed("https://example.com/feed") is None
+
+    async def test_parse_feed_handles_http_error(self):
+        client = MagicMock()
+        client.get = AsyncMock(side_effect=httpx.ConnectError("offline"))
+        strategy = RSSDiscoveryStrategy(http_client=client)
+
+        assert await strategy._parse_feed("https://example.com/feed") is None

--- a/tests/test_adapters/test_strategies/test_sitemap_discovery.py
+++ b/tests/test_adapters/test_strategies/test_sitemap_discovery.py
@@ -244,6 +244,29 @@ class TestSitemapDiscoveryStrategy:
         assert result.posts[0].published_at == published
         assert result.posts[1].published_at is None
 
+    async def test_discover_skips_url_value_that_changes_after_filtering(self):
+        class FlakyUrlItem(dict):
+            def __init__(self) -> None:
+                super().__init__(lastmod=None)
+                self.url_reads = 0
+
+            def __getitem__(self, key: str) -> object:
+                if key == "url":
+                    self.url_reads += 1
+                    if self.url_reads <= 2:
+                        return "https://example.com/blog/post"
+                    return 123
+                return super().__getitem__(key)
+
+        strategy = SitemapDiscoveryStrategy()
+        strategy._find_sitemap = AsyncMock(return_value="https://example.com/sitemap.xml")
+        strategy._parse_sitemap = AsyncMock(return_value=[FlakyUrlItem()])
+
+        result = await strategy.discover("https://example.com/blog", url_pattern="/blog/")
+
+        assert result is not None
+        assert result.posts == []
+
     @respx.mock
     async def test_rejects_oversized_compressed_sitemap(
         self, sitemap_strategy: SitemapDiscoveryStrategy
@@ -378,6 +401,18 @@ class TestSitemapDiscoveryStrategy:
         ):
             assert await strategy._check_robots_txt("https://example.com") is None
 
+    async def test_check_robots_txt_returns_none_without_sitemap_directive(self):
+        client = MagicMock()
+        client.get = AsyncMock(
+            return_value=httpx.Response(
+                200,
+                text="User-agent: *\nAllow: /",
+            )
+        )
+        strategy = SitemapDiscoveryStrategy(http_client=client)
+
+        assert await strategy._check_robots_txt("https://example.com") is None
+
     async def test_is_valid_sitemap_accepts_sitemap_index_and_rejects_failures(self):
         client = MagicMock()
         client.get = AsyncMock(
@@ -413,6 +448,26 @@ class TestSitemapDiscoveryStrategy:
 
         assert await strategy._parse_sitemap("https://example.com/sitemap.xml.gz") == []
         assert await strategy._parse_sitemap("https://example.com/sitemap.xml") == []
+
+    async def test_parse_sitemap_accepts_valid_gzipped_sitemap(self):
+        xml = b"""<?xml version="1.0"?>
+        <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+            <url><loc>https://example.com/blog/post</loc></url>
+        </urlset>
+        """
+        client = MagicMock()
+        client.get = AsyncMock(
+            return_value=httpx.Response(
+                200,
+                content=gzip.compress(xml),
+                request=httpx.Request("GET", "https://example.com/sitemap.xml.gz"),
+            )
+        )
+        strategy = SitemapDiscoveryStrategy(http_client=client)
+
+        assert await strategy._parse_sitemap("https://example.com/sitemap.xml.gz") == [
+            {"url": "https://example.com/blog/post", "lastmod": None}
+        ]
 
     async def test_parse_sitemap_rejects_direct_oversized_compressed_payload(self):
         gzipped = gzip.compress(
@@ -499,6 +554,25 @@ class TestSitemapDiscoveryStrategy:
         assert result == [{"url": "https://example.com/blog/post", "lastmod": None}]
         strategy._parse_sitemap.assert_awaited_once_with("https://example.com/public.xml")
 
+    async def test_parse_sitemap_index_namespaced_skips_entries_without_loc(self):
+        root = ElementTree.fromstring(
+            """<sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+                <sitemap></sitemap>
+                <sitemap><loc></loc></sitemap>
+                <sitemap><loc>https://example.com/public.xml</loc></sitemap>
+            </sitemapindex>"""
+        )
+        strategy = SitemapDiscoveryStrategy()
+        strategy._parse_sitemap = AsyncMock(
+            return_value=[{"url": "https://example.com/blog/post", "lastmod": None}]
+        )
+
+        with patch("intelstream.adapters.strategies.sitemap_discovery.validate_url_for_ssrf"):
+            result = await strategy._parse_sitemap_index(root)
+
+        assert result == [{"url": "https://example.com/blog/post", "lastmod": None}]
+        strategy._parse_sitemap.assert_awaited_once_with("https://example.com/public.xml")
+
     async def test_parse_sitemap_index_namespaced_honors_sub_sitemap_limit(self):
         root = ElementTree.fromstring(
             """<sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
@@ -570,6 +644,25 @@ class TestSitemapDiscoveryStrategy:
         assert result == []
         strategy._parse_sitemap.assert_not_called()
 
+    async def test_parse_sitemap_index_non_namespaced_skips_entries_without_loc(self):
+        root = ElementTree.fromstring(
+            """<sitemapindex>
+                <sitemap></sitemap>
+                <sitemap><loc></loc></sitemap>
+                <sitemap><loc>https://example.com/posts.xml</loc></sitemap>
+            </sitemapindex>"""
+        )
+        strategy = SitemapDiscoveryStrategy()
+        strategy._parse_sitemap = AsyncMock(
+            return_value=[{"url": "https://example.com/blog/post", "lastmod": None}]
+        )
+
+        with patch("intelstream.adapters.strategies.sitemap_discovery.validate_url_for_ssrf"):
+            result = await strategy._parse_sitemap_index(root)
+
+        assert result == [{"url": "https://example.com/blog/post", "lastmod": None}]
+        strategy._parse_sitemap.assert_awaited_once_with("https://example.com/posts.xml")
+
     async def test_parse_sitemap_index_non_namespaced_truncates_after_max_urls(self):
         root = ElementTree.fromstring(
             """<sitemapindex>
@@ -601,6 +694,7 @@ class TestSitemapDiscoveryStrategy:
     def test_parse_urlset_handles_namespaced_urls(self, sitemap_strategy):
         root = ElementTree.fromstring(
             """<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+                <url><lastmod>2026-05-24</lastmod></url>
                 <url>
                     <loc>https://example.com/research/paper</loc>
                     <lastmod>2026-05-25T12:30:00+00:00</lastmod>
@@ -656,3 +750,16 @@ class TestSitemapDiscoveryStrategy:
         ]
 
         assert sitemap_strategy._infer_pattern("https://example.com/", all_urls) == "/insights/"
+
+    def test_infer_pattern_handles_misleading_string_subclasses(self, sitemap_strategy):
+        class MisleadingUrl(str):
+            def lower(self) -> str:
+                return "https://example.com/blog/from-lower"
+
+        all_urls = [
+            {"url": MisleadingUrl("https://example.com/actual-one"), "lastmod": None},
+            {"url": "https://example.com/about", "lastmod": None},
+            {"url": MisleadingUrl("https://example.com/actual-two"), "lastmod": None},
+        ]
+
+        assert sitemap_strategy._infer_pattern("https://example.com/", all_urls) is None

--- a/tests/test_adapters/test_strategies/test_sitemap_discovery.py
+++ b/tests/test_adapters/test_strategies/test_sitemap_discovery.py
@@ -1,4 +1,5 @@
 import gzip
+from datetime import UTC, datetime
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import httpx
@@ -72,7 +73,8 @@ class TestSitemapDiscoveryStrategy:
             return_value=httpx.Response(200, text=sitemap)
         )
 
-        result = await sitemap_strategy.discover("https://example.com/research")
+        with patch("intelstream.adapters.strategies.sitemap_discovery.validate_url_for_ssrf"):
+            result = await sitemap_strategy.discover("https://example.com/research")
 
         assert result is not None
         assert len(result.posts) == 1
@@ -123,7 +125,8 @@ class TestSitemapDiscoveryStrategy:
             return_value=httpx.Response(200, text=posts_sitemap)
         )
 
-        result = await sitemap_strategy.discover("https://example.com/articles")
+        with patch("intelstream.adapters.strategies.sitemap_discovery.validate_url_for_ssrf"):
+            result = await sitemap_strategy.discover("https://example.com/articles")
 
         assert result is not None
         assert len(result.posts) == 2
@@ -204,6 +207,28 @@ class TestSitemapDiscoveryStrategy:
         result = await sitemap_strategy.discover("https://example.com/random-path")
 
         assert result is None
+
+    async def test_discover_ignores_non_string_urls_and_non_datetime_lastmod(self):
+        strategy = SitemapDiscoveryStrategy()
+        published = datetime(2026, 5, 25, 12, 0, tzinfo=UTC)
+        strategy._find_sitemap = AsyncMock(return_value="https://example.com/sitemap.xml")
+        strategy._parse_sitemap = AsyncMock(
+            return_value=[
+                {"url": "https://example.com/blog/dated", "lastmod": published},
+                {"url": "https://example.com/blog/raw-date", "lastmod": "2026-05-25"},
+                {"url": 123, "lastmod": published},
+            ]
+        )
+
+        result = await strategy.discover("https://example.com/blog", url_pattern="/blog/")
+
+        assert result is not None
+        assert [post.url for post in result.posts] == [
+            "https://example.com/blog/dated",
+            "https://example.com/blog/raw-date",
+        ]
+        assert result.posts[0].published_at == published
+        assert result.posts[1].published_at is None
 
     @respx.mock
     async def test_rejects_oversized_compressed_sitemap(
@@ -403,6 +428,83 @@ class TestSitemapDiscoveryStrategy:
         assert result == [{"url": "https://example.com/blog/post", "lastmod": None}]
         strategy._parse_sitemap.assert_awaited_once_with("https://example.com/public.xml")
 
+    async def test_parse_sitemap_index_namespaced_honors_sub_sitemap_limit(self):
+        root = ElementTree.fromstring(
+            """<sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+                <sitemap><loc>https://example.com/one.xml</loc></sitemap>
+                <sitemap><loc>https://example.com/two.xml</loc></sitemap>
+                <sitemap><loc>https://example.com/three.xml</loc></sitemap>
+            </sitemapindex>"""
+        )
+        strategy = SitemapDiscoveryStrategy()
+        strategy._parse_sitemap = AsyncMock(
+            side_effect=[
+                [{"url": "https://example.com/blog/one", "lastmod": None}],
+                [{"url": "https://example.com/blog/two", "lastmod": None}],
+            ]
+        )
+
+        with (
+            patch("intelstream.adapters.strategies.sitemap_discovery.validate_url_for_ssrf"),
+            patch.object(sitemap_discovery, "MAX_SUB_SITEMAPS", 2),
+        ):
+            result = await strategy._parse_sitemap_index(root)
+
+        assert [item["url"] for item in result] == [
+            "https://example.com/blog/one",
+            "https://example.com/blog/two",
+        ]
+        assert strategy._parse_sitemap.await_count == 2
+
+    async def test_parse_sitemap_index_truncates_after_max_urls(self):
+        root = ElementTree.fromstring(
+            """<sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+                <sitemap><loc>https://example.com/posts.xml</loc></sitemap>
+                <sitemap><loc>https://example.com/more.xml</loc></sitemap>
+            </sitemapindex>"""
+        )
+        strategy = SitemapDiscoveryStrategy()
+        strategy._parse_sitemap = AsyncMock(
+            return_value=[
+                {"url": "https://example.com/blog/one", "lastmod": None},
+                {"url": "https://example.com/blog/two", "lastmod": None},
+                {"url": "https://example.com/blog/three", "lastmod": None},
+            ]
+        )
+
+        with (
+            patch("intelstream.adapters.strategies.sitemap_discovery.validate_url_for_ssrf"),
+            patch.object(sitemap_discovery, "MAX_SITEMAP_URLS", 2),
+        ):
+            result = await strategy._parse_sitemap_index(root)
+
+        assert [item["url"] for item in result] == [
+            "https://example.com/blog/one",
+            "https://example.com/blog/two",
+        ]
+        strategy._parse_sitemap.assert_awaited_once_with("https://example.com/posts.xml")
+
+    def test_parse_urlset_handles_namespaced_urls(self, sitemap_strategy):
+        root = ElementTree.fromstring(
+            """<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+                <url>
+                    <loc>https://example.com/research/paper</loc>
+                    <lastmod>2026-05-25T12:30:00+00:00</lastmod>
+                </url>
+                <url><loc>https://example.com/research/no-date</loc></url>
+            </urlset>"""
+        )
+
+        result = sitemap_strategy._parse_urlset(root)
+
+        assert result == [
+            {
+                "url": "https://example.com/research/paper",
+                "lastmod": datetime(2026, 5, 25, 12, 30, tzinfo=UTC),
+            },
+            {"url": "https://example.com/research/no-date", "lastmod": None},
+        ]
+
     def test_parse_urlset_handles_non_namespaced_urls_and_invalid_lastmod(self, sitemap_strategy):
         root = ElementTree.fromstring(
             """<urlset>
@@ -425,6 +527,12 @@ class TestSitemapDiscoveryStrategy:
 
         assert parsed is not None
         assert parsed.tzinfo is not None
+
+    def test_parse_lastmod_handles_date_only_and_explicit_zulu(self, sitemap_strategy):
+        assert sitemap_strategy._parse_lastmod("2026-05-25") == datetime(2026, 5, 25, tzinfo=UTC)
+        assert sitemap_strategy._parse_lastmod("2026-05-25T12:30:00Z") == datetime(
+            2026, 5, 25, 12, 30, tzinfo=UTC
+        )
 
     def test_infer_pattern_from_repeated_sitemap_urls(self, sitemap_strategy):
         all_urls = [

--- a/tests/test_adapters/test_strategies/test_sitemap_discovery.py
+++ b/tests/test_adapters/test_strategies/test_sitemap_discovery.py
@@ -1,12 +1,14 @@
 import gzip
-from unittest.mock import patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import httpx
 import pytest
 import respx
+from defusedxml import ElementTree
 
 from intelstream.adapters.strategies import sitemap_discovery
 from intelstream.adapters.strategies.sitemap_discovery import SitemapDiscoveryStrategy
+from intelstream.utils.url_validation import SSRFError
 
 
 @pytest.fixture
@@ -307,3 +309,128 @@ class TestSitemapDiscoveryStrategy:
         assert result is not None
         assert len(result.posts) == 1
         assert result.posts[0].url == "https://example.com/blog/post"
+
+    async def test_check_robots_txt_ignores_non_200_and_http_error(self):
+        client = MagicMock()
+        client.get = AsyncMock(
+            side_effect=[
+                httpx.Response(404, text="missing"),
+                httpx.ConnectError("offline"),
+            ]
+        )
+        strategy = SitemapDiscoveryStrategy(http_client=client)
+
+        assert await strategy._check_robots_txt("https://example.com") is None
+        assert await strategy._check_robots_txt("https://example.com") is None
+
+    async def test_check_robots_txt_skips_ssrf_blocked_sitemap(self):
+        client = MagicMock()
+        client.get = AsyncMock(
+            return_value=httpx.Response(
+                200,
+                text="Sitemap: http://127.0.0.1/sitemap.xml",
+            )
+        )
+        strategy = SitemapDiscoveryStrategy(http_client=client)
+
+        with patch(
+            "intelstream.adapters.strategies.sitemap_discovery.validate_url_for_ssrf",
+            side_effect=SSRFError("blocked"),
+        ):
+            assert await strategy._check_robots_txt("https://example.com") is None
+
+    async def test_is_valid_sitemap_accepts_sitemap_index_and_rejects_failures(self):
+        client = MagicMock()
+        client.get = AsyncMock(
+            side_effect=[
+                httpx.Response(200, text="<sitemapindex></sitemapindex>"),
+                httpx.Response(500, text="error"),
+                httpx.ConnectError("offline"),
+            ]
+        )
+        strategy = SitemapDiscoveryStrategy(http_client=client)
+
+        assert await strategy._is_valid_sitemap("https://example.com/sitemap.xml") is True
+        assert await strategy._is_valid_sitemap("https://example.com/sitemap.xml") is False
+        assert await strategy._is_valid_sitemap("https://example.com/sitemap.xml") is False
+
+    async def test_parse_sitemap_handles_bad_gzip_and_invalid_xml(self):
+        client = MagicMock()
+        client.get = AsyncMock(
+            side_effect=[
+                httpx.Response(
+                    200,
+                    content=b"\x1f\x8bnot-a-real-gzip",
+                    request=httpx.Request("GET", "https://example.com/sitemap.xml.gz"),
+                ),
+                httpx.Response(
+                    200,
+                    text="<urlset><url>",
+                    request=httpx.Request("GET", "https://example.com/sitemap.xml"),
+                ),
+            ]
+        )
+        strategy = SitemapDiscoveryStrategy(http_client=client)
+
+        assert await strategy._parse_sitemap("https://example.com/sitemap.xml.gz") == []
+        assert await strategy._parse_sitemap("https://example.com/sitemap.xml") == []
+
+    async def test_parse_sitemap_handles_http_error(self):
+        client = MagicMock()
+        client.get = AsyncMock(side_effect=httpx.ConnectError("offline"))
+        strategy = SitemapDiscoveryStrategy(http_client=client)
+
+        assert await strategy._parse_sitemap("https://example.com/sitemap.xml") == []
+
+    async def test_parse_sitemap_index_non_namespaced_skips_blocked_children(self):
+        root = ElementTree.fromstring(
+            """<sitemapindex>
+                <sitemap><loc>http://127.0.0.1/private.xml</loc></sitemap>
+                <sitemap><loc>https://example.com/public.xml</loc></sitemap>
+            </sitemapindex>"""
+        )
+        strategy = SitemapDiscoveryStrategy()
+        strategy._parse_sitemap = AsyncMock(
+            return_value=[{"url": "https://example.com/blog/post", "lastmod": None}]
+        )
+
+        with patch(
+            "intelstream.adapters.strategies.sitemap_discovery.validate_url_for_ssrf",
+            side_effect=[SSRFError("blocked"), None],
+        ):
+            result = await strategy._parse_sitemap_index(root)
+
+        assert result == [{"url": "https://example.com/blog/post", "lastmod": None}]
+        strategy._parse_sitemap.assert_awaited_once_with("https://example.com/public.xml")
+
+    def test_parse_urlset_handles_non_namespaced_urls_and_invalid_lastmod(self, sitemap_strategy):
+        root = ElementTree.fromstring(
+            """<urlset>
+                <url>
+                    <loc>https://example.com/blog/post</loc>
+                    <lastmod>not-a-date</lastmod>
+                </url>
+                <url><lastmod>2026-05-25</lastmod></url>
+            </urlset>"""
+        )
+
+        result = sitemap_strategy._parse_urlset(root)
+
+        assert result == [{"url": "https://example.com/blog/post", "lastmod": None}]
+
+    def test_parse_lastmod_handles_none_and_naive_datetime(self, sitemap_strategy):
+        assert sitemap_strategy._parse_lastmod(None) is None
+
+        parsed = sitemap_strategy._parse_lastmod("2026-05-25T12:30:00")
+
+        assert parsed is not None
+        assert parsed.tzinfo is not None
+
+    def test_infer_pattern_from_repeated_sitemap_urls(self, sitemap_strategy):
+        all_urls = [
+            {"url": "https://example.com/insights/one", "lastmod": None},
+            {"url": "https://example.com/Insights/two", "lastmod": None},
+            {"url": "https://example.com/about", "lastmod": None},
+        ]
+
+        assert sitemap_strategy._infer_pattern("https://example.com/", all_urls) == "/insights/"

--- a/tests/test_adapters/test_strategies/test_sitemap_discovery.py
+++ b/tests/test_adapters/test_strategies/test_sitemap_discovery.py
@@ -208,6 +208,20 @@ class TestSitemapDiscoveryStrategy:
 
         assert result is None
 
+    async def test_discover_returns_none_when_provided_pattern_has_no_matches(self):
+        strategy = SitemapDiscoveryStrategy()
+        strategy._find_sitemap = AsyncMock(return_value="https://example.com/sitemap.xml")
+        strategy._parse_sitemap = AsyncMock(
+            return_value=[
+                {"url": "https://example.com/about", "lastmod": None},
+                {"url": "https://example.com/contact", "lastmod": None},
+            ]
+        )
+
+        result = await strategy.discover("https://example.com/blog", url_pattern="/blog/")
+
+        assert result is None
+
     async def test_discover_ignores_non_string_urls_and_non_datetime_lastmod(self):
         strategy = SitemapDiscoveryStrategy()
         published = datetime(2026, 5, 25, 12, 0, tzinfo=UTC)
@@ -400,6 +414,42 @@ class TestSitemapDiscoveryStrategy:
         assert await strategy._parse_sitemap("https://example.com/sitemap.xml.gz") == []
         assert await strategy._parse_sitemap("https://example.com/sitemap.xml") == []
 
+    async def test_parse_sitemap_rejects_direct_oversized_compressed_payload(self):
+        gzipped = gzip.compress(
+            b"<urlset><url><loc>https://example.com/blog/post</loc></url></urlset>"
+        )
+        client = MagicMock()
+        client.get = AsyncMock(
+            return_value=httpx.Response(
+                200,
+                content=gzipped,
+                request=httpx.Request("GET", "https://example.com/sitemap.xml.gz"),
+            )
+        )
+        strategy = SitemapDiscoveryStrategy(http_client=client)
+
+        with patch.object(sitemap_discovery, "MAX_COMPRESSED_SIZE", len(gzipped) - 1):
+            result = await strategy._parse_sitemap("https://example.com/sitemap.xml.gz")
+
+        assert result == []
+
+    async def test_parse_sitemap_rejects_direct_oversized_decompressed_payload(self):
+        xml = b"<urlset><url><loc>https://example.com/blog/post</loc></url></urlset>"
+        client = MagicMock()
+        client.get = AsyncMock(
+            return_value=httpx.Response(
+                200,
+                content=gzip.compress(xml),
+                request=httpx.Request("GET", "https://example.com/sitemap.xml.gz"),
+            )
+        )
+        strategy = SitemapDiscoveryStrategy(http_client=client)
+
+        with patch.object(sitemap_discovery, "MAX_DECOMPRESSED_SIZE", len(xml) - 1):
+            result = await strategy._parse_sitemap("https://example.com/sitemap.xml.gz")
+
+        assert result == []
+
     async def test_parse_sitemap_handles_http_error(self):
         client = MagicMock()
         client.get = AsyncMock(side_effect=httpx.ConnectError("offline"))
@@ -410,6 +460,27 @@ class TestSitemapDiscoveryStrategy:
     async def test_parse_sitemap_index_non_namespaced_skips_blocked_children(self):
         root = ElementTree.fromstring(
             """<sitemapindex>
+                <sitemap><loc>http://127.0.0.1/private.xml</loc></sitemap>
+                <sitemap><loc>https://example.com/public.xml</loc></sitemap>
+            </sitemapindex>"""
+        )
+        strategy = SitemapDiscoveryStrategy()
+        strategy._parse_sitemap = AsyncMock(
+            return_value=[{"url": "https://example.com/blog/post", "lastmod": None}]
+        )
+
+        with patch(
+            "intelstream.adapters.strategies.sitemap_discovery.validate_url_for_ssrf",
+            side_effect=[SSRFError("blocked"), None],
+        ):
+            result = await strategy._parse_sitemap_index(root)
+
+        assert result == [{"url": "https://example.com/blog/post", "lastmod": None}]
+        strategy._parse_sitemap.assert_awaited_once_with("https://example.com/public.xml")
+
+    async def test_parse_sitemap_index_namespaced_skips_blocked_children(self):
+        root = ElementTree.fromstring(
+            """<sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
                 <sitemap><loc>http://127.0.0.1/private.xml</loc></sitemap>
                 <sitemap><loc>https://example.com/public.xml</loc></sitemap>
             </sitemapindex>"""
@@ -459,6 +530,49 @@ class TestSitemapDiscoveryStrategy:
     async def test_parse_sitemap_index_truncates_after_max_urls(self):
         root = ElementTree.fromstring(
             """<sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+                <sitemap><loc>https://example.com/posts.xml</loc></sitemap>
+                <sitemap><loc>https://example.com/more.xml</loc></sitemap>
+            </sitemapindex>"""
+        )
+        strategy = SitemapDiscoveryStrategy()
+        strategy._parse_sitemap = AsyncMock(
+            return_value=[
+                {"url": "https://example.com/blog/one", "lastmod": None},
+                {"url": "https://example.com/blog/two", "lastmod": None},
+                {"url": "https://example.com/blog/three", "lastmod": None},
+            ]
+        )
+
+        with (
+            patch("intelstream.adapters.strategies.sitemap_discovery.validate_url_for_ssrf"),
+            patch.object(sitemap_discovery, "MAX_SITEMAP_URLS", 2),
+        ):
+            result = await strategy._parse_sitemap_index(root)
+
+        assert [item["url"] for item in result] == [
+            "https://example.com/blog/one",
+            "https://example.com/blog/two",
+        ]
+        strategy._parse_sitemap.assert_awaited_once_with("https://example.com/posts.xml")
+
+    async def test_parse_sitemap_index_non_namespaced_honors_zero_sub_sitemap_limit(self):
+        root = ElementTree.fromstring(
+            """<sitemapindex>
+                <sitemap><loc>https://example.com/posts.xml</loc></sitemap>
+            </sitemapindex>"""
+        )
+        strategy = SitemapDiscoveryStrategy()
+        strategy._parse_sitemap = AsyncMock()
+
+        with patch.object(sitemap_discovery, "MAX_SUB_SITEMAPS", 0):
+            result = await strategy._parse_sitemap_index(root)
+
+        assert result == []
+        strategy._parse_sitemap.assert_not_called()
+
+    async def test_parse_sitemap_index_non_namespaced_truncates_after_max_urls(self):
+        root = ElementTree.fromstring(
+            """<sitemapindex>
                 <sitemap><loc>https://example.com/posts.xml</loc></sitemap>
                 <sitemap><loc>https://example.com/more.xml</loc></sitemap>
             </sitemapindex>"""

--- a/tests/test_adapters/test_substack.py
+++ b/tests/test_adapters/test_substack.py
@@ -268,6 +268,16 @@ class TestSubstackAdapter:
 
         assert SubstackAdapter()._extract_thumbnail(entry) == "https://example.com/media.png"
 
+    def test_extract_thumbnail_skips_non_image_media_content(self) -> None:
+        entry = feedparser.FeedParserDict(
+            {
+                "media_content": [{"medium": "video", "url": "https://example.com/video.mp4"}],
+                "media_thumbnail": [{"url": "https://example.com/thumb.jpg"}],
+            }
+        )
+
+        assert SubstackAdapter()._extract_thumbnail(entry) == "https://example.com/thumb.jpg"
+
     def test_extract_thumbnail_returns_none_when_image_media_has_no_url(self) -> None:
         entry = feedparser.FeedParserDict({"media_content": [{"medium": "image"}]})
 
@@ -314,6 +324,13 @@ class TestSubstackAdapter:
         )
 
         assert SubstackAdapter()._extract_thumbnail(entry) == "https://example.com/hero.jpg"
+
+    def test_extract_thumbnail_returns_none_when_enclosures_have_no_images(self) -> None:
+        entry = AttrEntry(
+            {"enclosures": [{"type": "application/pdf", "url": "https://example.com/paper.pdf"}]}
+        )
+
+        assert SubstackAdapter()._extract_thumbnail(entry) is None
 
     def test_extract_thumbnail_returns_none_when_image_enclosure_has_no_url(self) -> None:
         entry = AttrEntry({"enclosures": [{"type": "image/jpeg"}]})

--- a/tests/test_adapters/test_substack.py
+++ b/tests/test_adapters/test_substack.py
@@ -1,9 +1,12 @@
 from datetime import UTC, datetime
+from unittest.mock import patch
 
+import feedparser
 import httpx
 import pytest
 import respx
 
+from intelstream.adapters.base import ContentData
 from intelstream.adapters.substack import SubstackAdapter
 
 SAMPLE_RSS_FEED = """<?xml version="1.0" encoding="UTF-8"?>
@@ -36,6 +39,11 @@ SAMPLE_RSS_FEED = """<?xml version="1.0" encoding="UTF-8"?>
 """
 
 
+class AttrEntry(dict):
+    def __getattr__(self, name: str):
+        return self.get(name)
+
+
 class TestSubstackAdapter:
     async def test_get_feed_url_from_identifier(self) -> None:
         adapter = SubstackAdapter()
@@ -51,6 +59,13 @@ class TestSubstackAdapter:
         adapter = SubstackAdapter()
         url = await adapter.get_feed_url("https://testblog.substack.com/feed")
         assert url == "https://testblog.substack.com/feed"
+
+    async def test_get_feed_url_trims_and_lowercases_identifier(self) -> None:
+        adapter = SubstackAdapter()
+
+        url = await adapter.get_feed_url("  MixedCase  ")
+
+        assert url == "https://mixedcase.substack.com/feed"
 
     @respx.mock
     async def test_fetch_latest_success(self) -> None:
@@ -102,6 +117,31 @@ class TestSubstackAdapter:
                 await adapter.fetch_latest("notfound")
 
     @respx.mock
+    async def test_fetch_latest_request_error(self) -> None:
+        request = httpx.Request("GET", "https://offline.substack.com/feed")
+        respx.get("https://offline.substack.com/feed").mock(
+            side_effect=httpx.ReadError("socket closed", request=request)
+        )
+
+        async with httpx.AsyncClient() as client:
+            adapter = SubstackAdapter(http_client=client)
+
+            with pytest.raises(httpx.ReadError, match="socket closed"):
+                await adapter.fetch_latest("offline")
+
+    @respx.mock
+    async def test_fetch_latest_invalid_feed_returns_empty(self) -> None:
+        respx.get("https://broken.substack.com/feed").mock(
+            return_value=httpx.Response(200, text="<rss><broken>")
+        )
+
+        async with httpx.AsyncClient() as client:
+            adapter = SubstackAdapter(http_client=client)
+            items = await adapter.fetch_latest("broken")
+
+        assert items == []
+
+    @respx.mock
     async def test_fetch_latest_with_provided_feed_url(self) -> None:
         respx.get("https://custom.example.com/rss").mock(
             return_value=httpx.Response(200, text=SAMPLE_RSS_FEED)
@@ -113,6 +153,169 @@ class TestSubstackAdapter:
 
         assert len(items) == 2
 
+    @respx.mock
+    async def test_fetch_latest_without_http_client(self) -> None:
+        respx.get("https://test.substack.com/feed").mock(
+            return_value=httpx.Response(200, text=SAMPLE_RSS_FEED)
+        )
+
+        items = await SubstackAdapter().fetch_latest("test")
+
+        assert len(items) == 2
+
+    @respx.mock
+    async def test_fetch_latest_continues_after_entry_parse_error(self) -> None:
+        respx.get("https://test.substack.com/feed").mock(
+            return_value=httpx.Response(200, text=SAMPLE_RSS_FEED)
+        )
+        recovered = ContentData(
+            external_id="recovered",
+            title="Recovered",
+            original_url="https://test.substack.com/p/recovered",
+            author="Author",
+            published_at=datetime(2024, 1, 1, tzinfo=UTC),
+            raw_content="Recovered content",
+            thumbnail_url=None,
+        )
+
+        async with httpx.AsyncClient() as client:
+            adapter = SubstackAdapter(http_client=client)
+            with patch.object(
+                adapter,
+                "_parse_entry",
+                side_effect=[RuntimeError("bad entry"), recovered],
+            ):
+                items = await adapter.fetch_latest("test")
+
+        assert items == [recovered]
+
     async def test_source_type(self) -> None:
         adapter = SubstackAdapter()
         assert adapter.source_type == "substack"
+
+    def test_parse_entry_falls_back_to_feed_title_for_author(self) -> None:
+        feed = feedparser.parse(
+            """<?xml version="1.0" encoding="UTF-8"?>
+            <rss version="2.0">
+              <channel>
+                <title>Publisher Name</title>
+                <item>
+                  <title>No Byline</title>
+                  <link>https://publisher.substack.com/p/no-byline</link>
+                </item>
+              </channel>
+            </rss>
+            """
+        )
+
+        item = SubstackAdapter()._parse_entry(feed.entries[0], feed)
+
+        assert item.author == "Publisher Name"
+
+    def test_parse_entry_uses_unknown_author_when_feed_has_no_title(self) -> None:
+        entry = feedparser.FeedParserDict({"title": "No Author", "link": "https://example.com"})
+        feed = feedparser.FeedParserDict({"feed": {}})
+
+        item = SubstackAdapter()._parse_entry(entry, feed)
+
+        assert item.author == "Unknown Author"
+
+    def test_extract_content_uses_supported_content_value(self) -> None:
+        entry = feedparser.FeedParserDict(
+            {
+                "content": [
+                    {"type": "application/json", "value": "{}"},
+                    {"type": "text/plain", "value": "Plain text content"},
+                ]
+            }
+        )
+
+        assert SubstackAdapter()._extract_content(entry) == "Plain text content"
+
+    def test_extract_content_returns_none_for_empty_supported_content_value(self) -> None:
+        entry = feedparser.FeedParserDict(
+            {"content": [{"type": "text/html", "value": ""}], "summary": "ignored"}
+        )
+
+        assert SubstackAdapter()._extract_content(entry) is None
+
+    def test_extract_content_falls_back_to_summary_after_unsupported_content(self) -> None:
+        entry = feedparser.FeedParserDict(
+            {"content": [{"type": "application/json", "value": "{}"}], "summary": "Summary text"}
+        )
+
+        assert SubstackAdapter()._extract_content(entry) == "Summary text"
+
+    def test_extract_content_falls_back_to_description(self) -> None:
+        entry = feedparser.FeedParserDict({"description": "Short description"})
+
+        assert SubstackAdapter()._extract_content(entry) == "Short description"
+
+    def test_extract_content_returns_none_without_candidates(self) -> None:
+        assert SubstackAdapter()._extract_content(feedparser.FeedParserDict({})) is None
+
+    def test_extract_thumbnail_uses_media_content_image_url(self) -> None:
+        entry = feedparser.FeedParserDict(
+            {"media_content": [{"medium": "image", "url": "https://example.com/media.jpg"}]}
+        )
+
+        assert SubstackAdapter()._extract_thumbnail(entry) == "https://example.com/media.jpg"
+
+    def test_extract_thumbnail_uses_media_content_image_type(self) -> None:
+        entry = feedparser.FeedParserDict(
+            {"media_content": [{"type": "image/png", "url": "https://example.com/media.png"}]}
+        )
+
+        assert SubstackAdapter()._extract_thumbnail(entry) == "https://example.com/media.png"
+
+    def test_extract_thumbnail_returns_none_when_image_media_has_no_url(self) -> None:
+        entry = feedparser.FeedParserDict({"media_content": [{"medium": "image"}]})
+
+        assert SubstackAdapter()._extract_thumbnail(entry) is None
+
+    def test_extract_thumbnail_uses_media_thumbnail_url(self) -> None:
+        entry = feedparser.FeedParserDict(
+            {"media_thumbnail": [{"url": "https://example.com/thumb.jpg"}]}
+        )
+
+        assert SubstackAdapter()._extract_thumbnail(entry) == "https://example.com/thumb.jpg"
+
+    def test_extract_thumbnail_skips_empty_media_thumbnail_url(self) -> None:
+        entry = feedparser.FeedParserDict({"media_thumbnail": [{}]})
+
+        assert SubstackAdapter()._extract_thumbnail(entry) is None
+
+    def test_extract_thumbnail_uses_image_enclosure_href(self) -> None:
+        feed = feedparser.parse(
+            """<?xml version="1.0" encoding="UTF-8"?>
+            <rss version="2.0">
+              <channel>
+                <item>
+                  <title>With Image</title>
+                  <enclosure url="https://example.com/hero.jpg" type="image/jpeg" />
+                </item>
+              </channel>
+            </rss>
+            """
+        )
+
+        assert (
+            SubstackAdapter()._extract_thumbnail(feed.entries[0]) == "https://example.com/hero.jpg"
+        )
+
+    def test_extract_thumbnail_uses_image_enclosure_href_fallback(self) -> None:
+        entry = AttrEntry(
+            {
+                "enclosures": [
+                    {"type": "application/pdf", "url": "https://example.com/paper.pdf"},
+                    {"type": "image/jpeg", "href": "https://example.com/hero.jpg"},
+                ]
+            }
+        )
+
+        assert SubstackAdapter()._extract_thumbnail(entry) == "https://example.com/hero.jpg"
+
+    def test_extract_thumbnail_returns_none_when_image_enclosure_has_no_url(self) -> None:
+        entry = AttrEntry({"enclosures": [{"type": "image/jpeg"}]})
+
+        assert SubstackAdapter()._extract_thumbnail(entry) is None

--- a/tests/test_adapters/test_twitter.py
+++ b/tests/test_adapters/test_twitter.py
@@ -269,6 +269,35 @@ class TestTwitterAdapter:
 
         assert result is None
 
+    def test_get_quoted_tweet_text_skips_missing_expanded_quote(self) -> None:
+        adapter = TwitterAdapter(bearer_token="test-token")
+
+        result = adapter._get_quoted_tweet_text(
+            {
+                "referenced_tweets": [
+                    {"type": "quoted", "id": "missing"},
+                    {"type": "quoted", "id": "present"},
+                ]
+            },
+            {"present": {"text": "expanded quote"}},
+        )
+
+        assert result == "expanded quote"
+
+    def test_get_thumbnail_url_skips_media_without_url(self) -> None:
+        adapter = TwitterAdapter(bearer_token="test-token")
+
+        result = adapter._get_thumbnail_url(
+            {"attachments": {"media_keys": ["empty", "video"]}},
+            {
+                "empty": {},
+                "video": {"preview_image_url": "https://pbs.twimg.com/media/video.jpg"},
+            },
+            profile_pic="https://pbs.twimg.com/profile.jpg",
+        )
+
+        assert result == "https://pbs.twimg.com/media/video.jpg"
+
     @respx.mock
     async def test_fetch_sends_correct_auth_header(self) -> None:
         user_route = respx.get("https://api.x.com/2/users/by/username/testuser").mock(

--- a/tests/test_adapters/test_twitter.py
+++ b/tests/test_adapters/test_twitter.py
@@ -187,6 +187,47 @@ class TestTwitterAdapter:
 
         assert len(items) == 0
 
+    @respx.mock
+    async def test_fetch_latest_user_lookup_without_data_returns_empty(self) -> None:
+        respx.get("https://api.x.com/2/users/by/username/testuser").mock(
+            return_value=httpx.Response(200, json={})
+        )
+
+        async with httpx.AsyncClient() as client:
+            adapter = TwitterAdapter(bearer_token="test-token", http_client=client)
+            items = await adapter.fetch_latest("testuser")
+
+        assert items == []
+
+    @respx.mock
+    async def test_fetch_latest_continues_after_tweet_parse_error(self) -> None:
+        response_with_bad_tweet = {
+            "data": [
+                {"text": "Missing ID", "author_id": "2244994945"},
+                {
+                    "id": "12345",
+                    "text": "Valid tweet after bad one",
+                    "created_at": "2024-12-10T07:00:30.000Z",
+                    "author_id": "2244994945",
+                },
+            ],
+            "includes": SAMPLE_TWEETS_RESPONSE["includes"],
+            "meta": {"result_count": 2},
+        }
+        respx.get("https://api.x.com/2/users/by/username/testuser").mock(
+            return_value=httpx.Response(200, json=SAMPLE_USER_RESPONSE)
+        )
+        respx.get("https://api.x.com/2/users/2244994945/tweets").mock(
+            return_value=httpx.Response(200, json=response_with_bad_tweet)
+        )
+
+        async with httpx.AsyncClient() as client:
+            adapter = TwitterAdapter(bearer_token="test-token", http_client=client)
+            items = await adapter.fetch_latest("testuser")
+
+        assert len(items) == 1
+        assert items[0].external_id == "12345"
+
     def test_make_title_short_text(self) -> None:
         adapter = TwitterAdapter(bearer_token="test-token")
         assert adapter._make_title("Short tweet") == "Short tweet"
@@ -217,6 +258,16 @@ class TestTwitterAdapter:
         adapter = TwitterAdapter(bearer_token="test-token")
         result = adapter._parse_iso_date("not-a-date")
         assert result.tzinfo is not None
+
+    def test_get_quoted_tweet_text_ignores_non_quote_references(self) -> None:
+        adapter = TwitterAdapter(bearer_token="test-token")
+
+        result = adapter._get_quoted_tweet_text(
+            {"referenced_tweets": [{"type": "replied_to", "id": "99999"}]},
+            {"99999": {"text": "reply text"}},
+        )
+
+        assert result is None
 
     @respx.mock
     async def test_fetch_sends_correct_auth_header(self) -> None:

--- a/tests/test_adapters/test_youtube.py
+++ b/tests/test_adapters/test_youtube.py
@@ -67,6 +67,18 @@ class TestYouTubeAdapter:
 
         assert channel_id == "UChandleurl1234567890123"
 
+    async def test_extract_channel_id_from_empty_handle_url_raises(self) -> None:
+        adapter = YouTubeAdapter(api_key="test-key")
+
+        with pytest.raises(ValueError, match="Could not extract channel ID"):
+            await adapter._extract_channel_id_from_url("https://www.youtube.com/@")
+
+    async def test_extract_channel_id_from_empty_custom_url_raises(self) -> None:
+        adapter = YouTubeAdapter(api_key="test-key")
+
+        with pytest.raises(ValueError, match="Could not extract channel ID"):
+            await adapter._extract_channel_id_from_url("https://www.youtube.com/c/")
+
     async def test_resolve_channel_id_not_found_raises(self) -> None:
         self.mock_youtube.channels().list().execute.return_value = {"items": []}
         self.mock_youtube.search().list().execute.return_value = {"items": []}
@@ -503,6 +515,27 @@ class TestYouTubeAdapter:
 
         assert adapter._fetch_transcript_sync("video123") == "Translated"
         transcript.translate.assert_called_once_with("en")
+
+    @patch("intelstream.adapters.youtube.YouTubeTranscriptApi")
+    def test_fetch_transcript_sync_uses_first_available_english_transcript(
+        self, mock_transcript_api: MagicMock
+    ) -> None:
+        transcript = MagicMock()
+        transcript.language_code = "en"
+        transcript.fetch.return_value = [MagicMock(text="Already English")]
+        transcript_list = MagicMock()
+        transcript_list.find_manually_created_transcript.side_effect = NoTranscriptFound(
+            "video123", ["en"], transcript_list
+        )
+        transcript_list.find_generated_transcript.side_effect = NoTranscriptFound(
+            "video123", ["en"], transcript_list
+        )
+        transcript_list.__iter__.return_value = iter([transcript])
+        mock_transcript_api.return_value.list.return_value = transcript_list
+        adapter = YouTubeAdapter(api_key="test-key")
+
+        assert adapter._fetch_transcript_sync("video123") == "Already English"
+        transcript.translate.assert_not_called()
 
     @patch("intelstream.adapters.youtube.YouTubeTranscriptApi")
     def test_fetch_transcript_sync_returns_none_without_any_transcripts(

--- a/tests/test_adapters/test_youtube.py
+++ b/tests/test_adapters/test_youtube.py
@@ -1,9 +1,12 @@
 from datetime import UTC, datetime
-from unittest.mock import MagicMock, patch
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from googleapiclient.errors import HttpError
+from youtube_transcript_api._errors import NoTranscriptFound, VideoUnavailable
 
+from intelstream.adapters.base import ContentData
 from intelstream.adapters.youtube import YouTubeAdapter
 
 
@@ -73,6 +76,11 @@ class TestYouTubeAdapter:
         with pytest.raises(ValueError, match="Could not find YouTube channel"):
             await adapter._resolve_channel_id("nonexistent")
 
+    async def test_resolve_channel_id_returns_unrecognized_uc_identifier(self) -> None:
+        adapter = YouTubeAdapter(api_key="test-key")
+
+        assert await adapter._resolve_channel_id("UCshort") == "UCshort"
+
     @patch("intelstream.adapters.youtube.YouTubeTranscriptApi")
     async def test_fetch_latest_success(self, mock_transcript_api: MagicMock) -> None:
         self.mock_youtube.channels().list().execute.side_effect = [
@@ -123,6 +131,50 @@ class TestYouTubeAdapter:
         assert item.raw_content == "Hello World"
         assert item.thumbnail_url == "https://img.youtube.com/vi/video123/hq.jpg"
 
+    async def test_fetch_latest_uses_explicit_max_results(self) -> None:
+        self.mock_youtube.channels().list().execute.side_effect = [
+            {"items": [{"id": "UCtest123456789012345AB"}]},
+            {
+                "items": [
+                    {"contentDetails": {"relatedPlaylists": {"uploads": "UUtest123456789012345AB"}}}
+                ]
+            },
+        ]
+        self.mock_youtube.playlistItems().list().execute.return_value = {"items": []}
+        adapter = YouTubeAdapter(api_key="test-key")
+
+        await adapter.fetch_latest("@testchannel", max_results=3)
+
+        playlist_call = self.mock_youtube.playlistItems().list.call_args.kwargs
+        assert playlist_call["maxResults"] == 3
+
+    async def test_fetch_latest_continues_after_video_processing_error(self) -> None:
+        self.mock_youtube.channels().list().execute.side_effect = [
+            {"items": [{"id": "UCtest123456789012345AB"}]},
+            {
+                "items": [
+                    {"contentDetails": {"relatedPlaylists": {"uploads": "UUtest123456789012345AB"}}}
+                ]
+            },
+        ]
+        self.mock_youtube.playlistItems().list().execute.return_value = {
+            "items": [
+                {"snippet": {"resourceId": {"videoId": "bad"}}},
+                {"snippet": {"resourceId": {"videoId": "good"}}},
+            ]
+        }
+        recovered = ContentData(
+            external_id="good",
+            title="Good",
+            original_url="https://www.youtube.com/watch?v=good",
+            author="Channel",
+            published_at=datetime(2024, 1, 1, tzinfo=UTC),
+        )
+        adapter = YouTubeAdapter(api_key="test-key")
+        adapter._create_content_data = AsyncMock(side_effect=[ValueError("bad"), recovered])
+
+        assert await adapter.fetch_latest("@testchannel") == [recovered]
+
     @patch("intelstream.adapters.youtube.YouTubeTranscriptApi")
     async def test_fetch_latest_no_transcript(self, mock_transcript_api: MagicMock) -> None:
         self.mock_youtube.channels().list().execute.side_effect = [
@@ -165,6 +217,13 @@ class TestYouTubeAdapter:
         adapter = YouTubeAdapter(api_key="test-key")
 
         with pytest.raises(HttpError):
+            await adapter.fetch_latest("@testchannel")
+
+    async def test_fetch_latest_reraises_generic_error(self) -> None:
+        adapter = YouTubeAdapter(api_key="test-key")
+        adapter._resolve_channel_id = AsyncMock(side_effect=RuntimeError("broken"))
+
+        with pytest.raises(RuntimeError, match="broken"):
             await adapter.fetch_latest("@testchannel")
 
     async def test_parse_datetime_valid(self) -> None:
@@ -221,6 +280,18 @@ class TestYouTubeAdapter:
 
         assert result is None
 
+    async def test_get_best_thumbnail_returns_none_for_empty_best_url(self) -> None:
+        adapter = YouTubeAdapter(api_key="test-key")
+
+        result = adapter._get_best_thumbnail(
+            {
+                "maxres": {},
+                "default": {"url": "https://example.com/default.jpg"},
+            }
+        )
+
+        assert result is None
+
     async def test_extract_channel_id_from_c_url(self) -> None:
         self.mock_youtube.channels().list().execute.return_value = {
             "items": [{"id": "UCcustom12345678901234AB"}]
@@ -244,6 +315,12 @@ class TestYouTubeAdapter:
         )
 
         assert channel_id == "UCusername1234567890123AB"
+
+    async def test_extract_channel_id_from_channel_url_with_bad_id_raises(self) -> None:
+        adapter = YouTubeAdapter(api_key="test-key")
+
+        with pytest.raises(ValueError, match="Could not extract channel ID"):
+            await adapter._extract_channel_id_from_url("https://www.youtube.com/channel/not-a-uc")
 
     async def test_extract_channel_id_invalid_url_raises(self) -> None:
         adapter = YouTubeAdapter(api_key="test-key")
@@ -289,3 +366,157 @@ class TestYouTubeAdapter:
         assert items[0].raw_content is None
         assert items[0].title == "Test Video"
         assert items[0].original_url == "https://www.youtube.com/watch?v=video123"
+
+    async def test_get_channel_id_falls_back_to_username_lookup(self) -> None:
+        self.mock_youtube.channels().list().execute.side_effect = [
+            {"items": []},
+            {"items": [{"id": "UCusername1234567890123AB"}]},
+        ]
+
+        adapter = YouTubeAdapter(api_key="test-key")
+
+        assert await adapter._get_channel_id_by_handle_or_username("legacyname") == (
+            "UCusername1234567890123AB"
+        )
+
+    async def test_get_channel_id_falls_back_to_search_lookup(self) -> None:
+        self.mock_youtube.channels().list().execute.side_effect = [{"items": []}, {"items": []}]
+        self.mock_youtube.search().list().execute.return_value = {
+            "items": [{"snippet": {"channelId": "UCsearch12345678901234AB"}}]
+        }
+
+        adapter = YouTubeAdapter(api_key="test-key")
+
+        assert await adapter._get_channel_id_by_handle_or_username("@searchname") == (
+            "UCsearch12345678901234AB"
+        )
+
+    async def test_get_uploads_playlist_id_raises_when_channel_missing(self) -> None:
+        self.mock_youtube.channels().list().execute.return_value = {"items": []}
+        adapter = YouTubeAdapter(api_key="test-key")
+
+        with pytest.raises(ValueError, match="Channel not found"):
+            await adapter._get_uploads_playlist_id("UCmissing12345678901234")
+
+    async def test_get_playlist_videos_returns_empty_list_without_items(self) -> None:
+        self.mock_youtube.playlistItems().list().execute.return_value = {}
+        adapter = YouTubeAdapter(api_key="test-key")
+
+        assert await adapter._get_playlist_videos("UUplaylist", 5) == []
+
+    async def test_create_content_data_uses_content_details_video_id_and_defaults(
+        self,
+    ) -> None:
+        adapter = YouTubeAdapter(api_key="test-key")
+        adapter._fetch_transcript = AsyncMock(return_value="Transcript")
+        video = {
+            "snippet": {
+                "publishedAt": None,
+                "thumbnails": {},
+            },
+            "contentDetails": {
+                "videoId": "contentVideo",
+                "videoPublishedAt": "2024-02-03T04:05:06Z",
+            },
+        }
+
+        item = await adapter._create_content_data(video)
+
+        assert item.external_id == "contentVideo"
+        assert item.title == "Untitled"
+        assert item.author == "Unknown Channel"
+        assert item.published_at == datetime(2024, 2, 3, 4, 5, 6, tzinfo=UTC)
+        assert item.raw_content == "Transcript"
+        assert item.thumbnail_url is None
+
+    async def test_create_content_data_raises_without_video_id(self) -> None:
+        adapter = YouTubeAdapter(api_key="test-key")
+
+        with pytest.raises(ValueError, match="Could not extract video ID"):
+            await adapter._create_content_data({"snippet": {}, "contentDetails": {}})
+
+    async def test_fetch_transcript_timeout_returns_none(self) -> None:
+        adapter = YouTubeAdapter(api_key="test-key")
+
+        async def fake_wait_for(awaitable: Any, **_kwargs: object) -> None:
+            awaitable.close()
+            raise TimeoutError
+
+        with patch("intelstream.adapters.youtube.asyncio.wait_for", side_effect=fake_wait_for):
+            assert await adapter._fetch_transcript("video123") is None
+
+    async def test_fetch_transcript_video_unavailable_returns_none(self) -> None:
+        adapter = YouTubeAdapter(api_key="test-key")
+
+        async def fake_wait_for(awaitable: Any, **_kwargs: object) -> None:
+            awaitable.close()
+            raise VideoUnavailable("video123")
+
+        with patch("intelstream.adapters.youtube.asyncio.wait_for", side_effect=fake_wait_for):
+            assert await adapter._fetch_transcript("video123") is None
+
+    async def test_fetch_transcript_generic_error_returns_none(self) -> None:
+        adapter = YouTubeAdapter(api_key="test-key")
+
+        async def fake_wait_for(awaitable: Any, **_kwargs: object) -> None:
+            awaitable.close()
+            raise RuntimeError("api failed")
+
+        with patch("intelstream.adapters.youtube.asyncio.wait_for", side_effect=fake_wait_for):
+            assert await adapter._fetch_transcript("video123") is None
+
+    @patch("intelstream.adapters.youtube.YouTubeTranscriptApi")
+    def test_fetch_transcript_sync_falls_back_to_generated_transcript(
+        self, mock_transcript_api: MagicMock
+    ) -> None:
+        transcript = MagicMock()
+        transcript.fetch.return_value = [MagicMock(text="Generated"), MagicMock(text="Text")]
+        transcript_list = MagicMock()
+        transcript_list.find_manually_created_transcript.side_effect = NoTranscriptFound(
+            "video123", ["en"], transcript_list
+        )
+        transcript_list.find_generated_transcript.return_value = transcript
+        mock_transcript_api.return_value.list.return_value = transcript_list
+        adapter = YouTubeAdapter(api_key="test-key")
+
+        assert adapter._fetch_transcript_sync("video123") == "Generated Text"
+
+    @patch("intelstream.adapters.youtube.YouTubeTranscriptApi")
+    def test_fetch_transcript_sync_translates_first_available_transcript(
+        self, mock_transcript_api: MagicMock
+    ) -> None:
+        translated = MagicMock()
+        translated.fetch.return_value = [MagicMock(text="Translated")]
+        transcript = MagicMock()
+        transcript.language_code = "es"
+        transcript.translate.return_value = translated
+        transcript_list = MagicMock()
+        transcript_list.find_manually_created_transcript.side_effect = NoTranscriptFound(
+            "video123", ["en"], transcript_list
+        )
+        transcript_list.find_generated_transcript.side_effect = NoTranscriptFound(
+            "video123", ["en"], transcript_list
+        )
+        transcript_list.__iter__.return_value = iter([transcript])
+        mock_transcript_api.return_value.list.return_value = transcript_list
+        adapter = YouTubeAdapter(api_key="test-key")
+
+        assert adapter._fetch_transcript_sync("video123") == "Translated"
+        transcript.translate.assert_called_once_with("en")
+
+    @patch("intelstream.adapters.youtube.YouTubeTranscriptApi")
+    def test_fetch_transcript_sync_returns_none_without_any_transcripts(
+        self, mock_transcript_api: MagicMock
+    ) -> None:
+        transcript_list = MagicMock()
+        transcript_list.find_manually_created_transcript.side_effect = NoTranscriptFound(
+            "video123", ["en"], transcript_list
+        )
+        transcript_list.find_generated_transcript.side_effect = NoTranscriptFound(
+            "video123", ["en"], transcript_list
+        )
+        transcript_list.__iter__.return_value = iter([])
+        mock_transcript_api.return_value.list.return_value = transcript_list
+        adapter = YouTubeAdapter(api_key="test-key")
+
+        assert adapter._fetch_transcript_sync("video123") is None

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -131,6 +131,21 @@ class TestSettings:
         settings = Settings(_env_file=None)
         assert settings.llm_api_key == "sk-openai-test"
 
+    def test_llm_api_key_raises_if_configured_key_is_later_cleared(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("DISCORD_BOT_TOKEN", "test_token")
+        monkeypatch.setenv("DISCORD_GUILD_ID", "123456789")
+        monkeypatch.setenv("DISCORD_OWNER_ID", "111222333")
+        monkeypatch.setenv("LLM_PROVIDER", "openai")
+        monkeypatch.setenv("OPENAI_API_KEY", "sk-openai-test")
+
+        settings = Settings(_env_file=None)
+        settings.openai_api_key = None
+
+        with pytest.raises(ValueError, match="No API key configured"):
+            _ = settings.llm_api_key
+
     def test_llm_api_key_raises_when_key_missing(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setenv("DISCORD_BOT_TOKEN", "test_token")
         monkeypatch.setenv("DISCORD_GUILD_ID", "123456789")
@@ -177,6 +192,16 @@ class TestSettings:
         monkeypatch.delenv("GEMINI_API_KEY", raising=False)
 
         with pytest.raises(ValidationError, match="No API key configured"):
+            Settings(_env_file=None)
+
+    def test_empty_sqlite_database_url_rejected(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("DISCORD_BOT_TOKEN", "test_token")
+        monkeypatch.setenv("DISCORD_GUILD_ID", "123456789")
+        monkeypatch.setenv("DISCORD_OWNER_ID", "111222333")
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-test")
+        monkeypatch.setenv("DATABASE_URL", "sqlite+aiosqlite:///")
+
+        with pytest.raises(ValidationError, match="SQLite database path cannot be empty"):
             Settings(_env_file=None)
 
     def test_summarization_delay_minimum(self, monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -40,6 +40,34 @@ class TestSettings:
 
         assert settings.youtube_api_key == "yt-api-key"
 
+    def test_settings_accepts_lowercase_env_and_optional_legacy_channel(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        for key in (
+            "DISCORD_BOT_TOKEN",
+            "DISCORD_GUILD_ID",
+            "DISCORD_CHANNEL_ID",
+            "DISCORD_OWNER_ID",
+            "ANTHROPIC_API_KEY",
+            "LLM_PROVIDER",
+        ):
+            monkeypatch.delenv(key, raising=False)
+
+        monkeypatch.setenv("discord_bot_token", "test_token")
+        monkeypatch.setenv("discord_guild_id", "123456789")
+        monkeypatch.setenv("discord_owner_id", "111222333")
+        monkeypatch.setenv("anthropic_api_key", "sk-ant-test")
+        monkeypatch.setenv("llm_provider", "anthropic")
+
+        settings = Settings(_env_file=None)
+
+        assert settings.discord_bot_token == "test_token"
+        assert settings.discord_guild_id == 123456789
+        assert settings.discord_channel_id is None
+        assert settings.discord_owner_id == 111222333
+        assert settings.llm_provider == "anthropic"
+        assert settings.llm_api_key == "sk-ant-test"
+
     def test_settings_poll_interval_bounds(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setenv("DISCORD_BOT_TOKEN", "test_token")
         monkeypatch.setenv("DISCORD_GUILD_ID", "123456789")
@@ -47,6 +75,29 @@ class TestSettings:
         monkeypatch.setenv("DISCORD_OWNER_ID", "111222333")
         monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-test")
         monkeypatch.setenv("DEFAULT_POLL_INTERVAL_MINUTES", "0")
+
+        with pytest.raises(ValidationError):
+            Settings(_env_file=None)
+
+    @pytest.mark.parametrize(
+        ("env_name", "env_value"),
+        [
+            ("GITHUB_POLL_INTERVAL_MINUTES", "61"),
+            ("CONTENT_POLL_INTERVAL_MINUTES", "0"),
+            ("DISCORD_MAX_MESSAGE_LENGTH", "2001"),
+            ("ARTICLE_SEARCH_MIN_RELEVANCE_SCORE", "1.1"),
+            ("ARTICLE_CHUNK_OVERLAP_CHARS", "1001"),
+            ("LORE_CHUNK_MAX_MESSAGES", "4"),
+        ],
+    )
+    def test_numeric_bounds_reject_invalid_feature_knobs(
+        self, monkeypatch: pytest.MonkeyPatch, env_name: str, env_value: str
+    ) -> None:
+        monkeypatch.setenv("DISCORD_BOT_TOKEN", "test_token")
+        monkeypatch.setenv("DISCORD_GUILD_ID", "123456789")
+        monkeypatch.setenv("DISCORD_OWNER_ID", "111222333")
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-test")
+        monkeypatch.setenv(env_name, env_value)
 
         with pytest.raises(ValidationError):
             Settings(_env_file=None)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -204,6 +204,17 @@ class TestSettings:
         with pytest.raises(ValidationError, match="SQLite database path cannot be empty"):
             Settings(_env_file=None)
 
+    def test_non_sqlite_database_url_accepted(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("DISCORD_BOT_TOKEN", "test_token")
+        monkeypatch.setenv("DISCORD_GUILD_ID", "123456789")
+        monkeypatch.setenv("DISCORD_OWNER_ID", "111222333")
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-test")
+        monkeypatch.setenv("DATABASE_URL", "postgresql+asyncpg://user:pass@localhost/db")
+
+        settings = Settings(_env_file=None)
+
+        assert settings.database_url == "postgresql+asyncpg://user:pass@localhost/db"
+
     def test_summarization_delay_minimum(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setenv("DISCORD_BOT_TOKEN", "test_token")
         monkeypatch.setenv("DISCORD_GUILD_ID", "123456789")
@@ -281,6 +292,22 @@ class TestProviderAwareModelDefaults:
         settings = Settings(_env_file=None)
         assert settings.summary_model == "my-custom-model"
         assert settings.summary_model_interactive == "gpt-4o"
+
+    def test_unknown_provider_default_lookup_leaves_models_unchanged(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        self._base_env(monkeypatch)
+        monkeypatch.setenv("LLM_PROVIDER", "anthropic")
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-test")
+        settings = Settings(_env_file=None)
+        settings.llm_provider = "unknown"  # type: ignore[assignment]
+        settings.summary_model = ""
+        settings.summary_model_interactive = ""
+
+        settings.set_provider_model_defaults()
+
+        assert settings.summary_model == ""
+        assert settings.summary_model_interactive == ""
 
 
 class TestGetPollInterval:

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -10,7 +10,20 @@ from intelstream.database.exceptions import (
     DuplicateSourceError,
     SourceNotFoundError,
 )
-from intelstream.database.models import MessageChunkMeta, PauseReason, SourceType
+from intelstream.database.models import (
+    ArticleChunkMeta,
+    ContentItem,
+    DiscordConfig,
+    ExtractionCache,
+    ForwardingRule,
+    GitHubRepo,
+    IngestionProgress,
+    MessageChunkMeta,
+    PauseReason,
+    Source,
+    SourceType,
+    SuckBoobsStats,
+)
 from intelstream.database.repository import Repository
 
 
@@ -20,6 +33,113 @@ async def repository():
     await repo.initialize()
     yield repo
     await repo.close()
+
+
+class TestModelReprs:
+    def test_source_repr(self) -> None:
+        source = Source(name="Feed", type=SourceType.RSS, identifier="feed")
+
+        assert repr(source) == "<Source(name='Feed', type='rss')>"
+
+    def test_content_item_repr(self) -> None:
+        item = ContentItem(
+            source_id="source-1",
+            external_id="external-1",
+            title="Article",
+            original_url="https://example.com/article",
+            author="Author",
+            published_at=datetime(2024, 1, 1, tzinfo=UTC),
+        )
+
+        assert repr(item) == "<ContentItem(title='Article', source_id='source-1')>"
+
+    def test_article_chunk_meta_repr(self) -> None:
+        chunk = ArticleChunkMeta(
+            id="chunk-1",
+            content_item_id="content-1",
+            chunk_index=2,
+            text="Chunk text",
+        )
+
+        assert repr(chunk) == ("<ArticleChunkMeta(content_item_id='content-1', chunk_index=2)>")
+
+    def test_discord_config_repr(self) -> None:
+        config = DiscordConfig(guild_id="guild-1", channel_id="channel-1")
+
+        assert repr(config) == ("<DiscordConfig(guild_id='guild-1', channel_id='channel-1')>")
+
+    def test_extraction_cache_repr(self) -> None:
+        cached_at = datetime(2024, 1, 1, 12, 0, tzinfo=UTC)
+        cache = ExtractionCache(
+            url="https://example.com",
+            content_hash="hash",
+            posts_json="[]",
+            cached_at=cached_at,
+        )
+
+        assert repr(cache) == (
+            f"<ExtractionCache(url='https://example.com', cached_at={cached_at!r})>"
+        )
+
+    def test_forwarding_rule_repr(self) -> None:
+        rule = ForwardingRule(
+            guild_id="guild-1",
+            source_channel_id="source-channel",
+            source_type="all",
+            destination_channel_id="dest-channel",
+            destination_type="channel",
+        )
+
+        assert repr(rule) == ("<ForwardingRule(source='source-channel', dest='dest-channel')>")
+
+    def test_suck_boobs_stats_repr(self) -> None:
+        stats = SuckBoobsStats(
+            guild_id="guild-1",
+            user_id="user-1",
+            times_used=3,
+            times_pinged=4,
+        )
+
+        assert repr(stats) == "<SuckBoobsStats(user_id='user-1', used=3, pinged=4)>"
+
+    def test_message_chunk_meta_repr(self) -> None:
+        now = datetime(2024, 1, 1, tzinfo=UTC)
+        meta = MessageChunkMeta(
+            id="chunk-1",
+            guild_id="guild-1",
+            channel_id="channel-1",
+            channel_name="general",
+            start_message_id="message-1",
+            end_message_id="message-2",
+            start_timestamp=now,
+            end_timestamp=now,
+            authors="Alice",
+            message_count=5,
+            text="hello",
+        )
+
+        assert repr(meta) == "<MessageChunkMeta(id='chunk-1', channel='general', msgs=5)>"
+
+    def test_ingestion_progress_repr(self) -> None:
+        progress = IngestionProgress(
+            guild_id="guild-1",
+            channel_id="channel-1",
+            status="completed",
+        )
+
+        assert repr(progress) == (
+            "<IngestionProgress(guild='guild-1', channel='channel-1', status='completed')>"
+        )
+
+    def test_github_repo_repr(self) -> None:
+        repo = GitHubRepo(
+            guild_id="guild-1",
+            channel_id="channel-1",
+            owner="owner",
+            repo="project",
+        )
+
+        assert repr(repo) == "<GitHubRepo(owner='owner', repo='project')>"
 
 
 class TestRepositoryInitialization:

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -619,6 +619,68 @@ class TestContentItemOperations:
         assert len(unposted) == 1
         assert unposted[0].external_id == "post-2"
 
+    async def test_get_unposted_content_items_orders_by_published_at_and_limits(
+        self, repository: Repository
+    ) -> None:
+        source = await repository.add_source(
+            source_type=SourceType.RSS,
+            name="Ordered Queue",
+            identifier="ordered-queue",
+        )
+        newest = await repository.add_content_item(
+            source_id=source.id,
+            external_id="newest-unposted",
+            title="Newest",
+            original_url="https://example.com/newest",
+            author="Author",
+            published_at=datetime(2024, 1, 3),
+        )
+        oldest = await repository.add_content_item(
+            source_id=source.id,
+            external_id="oldest-unposted",
+            title="Oldest",
+            original_url="https://example.com/oldest",
+            author="Author",
+            published_at=datetime(2024, 1, 1),
+        )
+        middle = await repository.add_content_item(
+            source_id=source.id,
+            external_id="middle-unposted",
+            title="Middle",
+            original_url="https://example.com/middle",
+            author="Author",
+            published_at=datetime(2024, 1, 2),
+        )
+        unsummarized = await repository.add_content_item(
+            source_id=source.id,
+            external_id="unsummarized-older",
+            title="Unsummarized",
+            original_url="https://example.com/unsummarized",
+            author="Author",
+            published_at=datetime(2023, 12, 31),
+        )
+        already_posted = await repository.add_content_item(
+            source_id=source.id,
+            external_id="already-posted-older",
+            title="Already Posted",
+            original_url="https://example.com/posted",
+            author="Author",
+            published_at=datetime(2023, 12, 30),
+        )
+
+        for content in (newest, oldest, middle, already_posted):
+            await repository.update_content_item_summary(content.id, f"Summary for {content.title}")
+        await repository.mark_content_item_posted(already_posted.id, "message-1")
+
+        unposted = await repository.get_unposted_content_items(limit=2)
+
+        assert [item.external_id for item in unposted] == [
+            "oldest-unposted",
+            "middle-unposted",
+        ]
+        assert unsummarized.id not in {item.id for item in unposted}
+        assert already_posted.id not in {item.id for item in unposted}
+
     async def test_get_unsummarized_and_latest_content_items(self, repository: Repository) -> None:
         source = await repository.add_source(
             source_type=SourceType.RSS,
@@ -715,6 +777,66 @@ class TestContentItemOperations:
         assert await repository.count_summarized_content_items() == 1
         items = await repository.get_summarized_content_items(offset=0, limit=10)
         assert [item.external_id for item in items] == ["summarized"]
+
+    async def test_get_summarized_content_items_paginates_by_created_at(
+        self, repository: Repository
+    ) -> None:
+        source = await repository.add_source(
+            source_type=SourceType.RSS,
+            name="Paged Summaries",
+            identifier="paged-summaries",
+        )
+        first = await repository.add_content_item(
+            source_id=source.id,
+            external_id="first-summary",
+            title="First",
+            original_url="https://example.com/first-summary",
+            author="Author",
+            published_at=datetime(2024, 1, 1),
+        )
+        second = await repository.add_content_item(
+            source_id=source.id,
+            external_id="second-summary",
+            title="Second",
+            original_url="https://example.com/second-summary",
+            author="Author",
+            published_at=datetime(2024, 1, 2),
+        )
+        third = await repository.add_content_item(
+            source_id=source.id,
+            external_id="third-summary",
+            title="Third",
+            original_url="https://example.com/third-summary",
+            author="Author",
+            published_at=datetime(2024, 1, 3),
+        )
+        unsummarized = await repository.add_content_item(
+            source_id=source.id,
+            external_id="unsummarized-summary-page",
+            title="Unsummarized",
+            original_url="https://example.com/unsummarized-summary-page",
+            author="Author",
+            published_at=datetime(2024, 1, 4),
+        )
+
+        for content in (first, second, third):
+            await repository.update_content_item_summary(content.id, f"Summary for {content.title}")
+
+        async with repository.session() as session:
+            for item_id, created_at in (
+                (first.id, datetime(2024, 1, 1, tzinfo=UTC)),
+                (second.id, datetime(2024, 1, 2, tzinfo=UTC)),
+                (third.id, datetime(2024, 1, 3, tzinfo=UTC)),
+                (unsummarized.id, datetime(2023, 12, 31, tzinfo=UTC)),
+            ):
+                result = await session.execute(select(ContentItem).where(ContentItem.id == item_id))
+                item = result.scalar_one()
+                item.created_at = created_at
+            await session.commit()
+
+        page = await repository.get_summarized_content_items(offset=1, limit=1)
+
+        assert [item.external_id for item in page] == ["second-summary"]
 
     async def test_missing_content_updates_return_false(self, repository: Repository) -> None:
         assert await repository.update_content_item_summary("missing", "summary") is False
@@ -1672,6 +1794,62 @@ class TestArticleChunkMetaOperations:
         deleted_ids = await repository.delete_article_chunk_metas_for_content_item(content.id)
         assert deleted_ids == [f"{content.id}__0000", f"{content.id}__0001"]
         assert await repository.count_article_chunk_metas() == 0
+
+    async def test_article_chunk_unique_constraint_is_per_content_item(
+        self, repository: Repository
+    ) -> None:
+        source = await repository.add_source(
+            source_type=SourceType.RSS,
+            name="Unique Chunk Source",
+            identifier="unique-chunk-source",
+        )
+        first = await repository.add_content_item(
+            source_id=source.id,
+            external_id="unique-article-one",
+            title="First Article",
+            original_url="https://example.com/unique-one",
+            author="Author",
+            published_at=datetime.now(UTC),
+        )
+        second = await repository.add_content_item(
+            source_id=source.id,
+            external_id="unique-article-two",
+            title="Second Article",
+            original_url="https://example.com/unique-two",
+            author="Author",
+            published_at=datetime.now(UTC),
+        )
+
+        await repository.add_article_chunk_metas_batch(
+            [
+                ArticleChunkMeta(
+                    id=f"{first.id}__0000",
+                    content_item_id=first.id,
+                    chunk_index=0,
+                    text="First article chunk",
+                ),
+                ArticleChunkMeta(
+                    id=f"{second.id}__0000",
+                    content_item_id=second.id,
+                    chunk_index=0,
+                    text="Second article chunk",
+                ),
+            ]
+        )
+
+        with pytest.raises(IntegrityError):
+            await repository.add_article_chunk_metas_batch(
+                [
+                    ArticleChunkMeta(
+                        id=f"{first.id}__duplicate",
+                        content_item_id=first.id,
+                        chunk_index=0,
+                        text="Duplicate first article chunk",
+                    )
+                ]
+            )
+
+        assert await repository.count_article_chunk_metas() == 2
 
     async def test_delete_all_article_chunk_metas(self, repository: Repository) -> None:
         source = await repository.add_source(

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -3,9 +3,11 @@ from datetime import UTC, datetime, timedelta
 
 import pytest
 from sqlalchemy import select, text
+from sqlalchemy.exc import IntegrityError, OperationalError
 from sqlalchemy.ext.asyncio import create_async_engine
 
 from intelstream.database.exceptions import (
+    DatabaseConnectionError,
     DuplicateContentError,
     DuplicateSourceError,
     SourceNotFoundError,
@@ -299,6 +301,33 @@ class TestSourceOperations:
         all_sources = await repository.get_all_sources()
         assert len(all_sources) == 3
 
+    async def test_get_sources_for_guild_returns_active_sources_only(
+        self, repository: Repository
+    ) -> None:
+        active = await repository.add_source(
+            source_type=SourceType.RSS,
+            name="Guild Active",
+            identifier="guild-active",
+            guild_id="guild-a",
+        )
+        inactive = await repository.add_source(
+            source_type=SourceType.RSS,
+            name="Guild Inactive",
+            identifier="guild-inactive",
+            guild_id="guild-a",
+        )
+        await repository.add_source(
+            source_type=SourceType.RSS,
+            name="Other Guild",
+            identifier="other-guild",
+            guild_id="guild-b",
+        )
+        await repository.set_source_active(inactive.identifier, False)
+
+        sources = await repository.get_sources_for_guild("guild-a")
+
+        assert [source.id for source in sources] == [active.id]
+
     async def test_set_source_active(self, repository: Repository) -> None:
         await repository.add_source(
             source_type=SourceType.RSS,
@@ -316,6 +345,27 @@ class TestSourceOperations:
         all_sources = await repository.get_all_sources(active_only=False)
         assert len(all_sources) == 1
 
+    async def test_set_source_active_missing_source_raises(self, repository: Repository) -> None:
+        with pytest.raises(SourceNotFoundError):
+            await repository.set_source_active("missing-source", True)
+
+    async def test_set_source_active_wraps_operational_error(
+        self, repository: Repository, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        await repository.add_source(
+            source_type=SourceType.RSS,
+            name="Operational",
+            identifier="operational",
+        )
+
+        async def fail_commit(*_args: object, **_kwargs: object) -> None:
+            raise OperationalError("commit", {}, Exception("database locked"))
+
+        monkeypatch.setattr("sqlalchemy.ext.asyncio.AsyncSession.commit", fail_commit)
+
+        with pytest.raises(DatabaseConnectionError, match="Failed to update source"):
+            await repository.set_source_active("operational", False)
+
     async def test_delete_source(self, repository: Repository) -> None:
         await repository.add_source(
             source_type=SourceType.SUBSTACK,
@@ -332,6 +382,23 @@ class TestSourceOperations:
     async def test_delete_source_not_found(self, repository: Repository) -> None:
         with pytest.raises(SourceNotFoundError):
             await repository.delete_source("nonexistent")
+
+    async def test_delete_source_wraps_operational_error(
+        self, repository: Repository, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        await repository.add_source(
+            source_type=SourceType.SUBSTACK,
+            name="Delete Error",
+            identifier="delete-error",
+        )
+
+        async def fail_commit(*_args: object, **_kwargs: object) -> None:
+            raise OperationalError("commit", {}, Exception("database locked"))
+
+        monkeypatch.setattr("sqlalchemy.ext.asyncio.AsyncSession.commit", fail_commit)
+
+        with pytest.raises(DatabaseConnectionError, match="Failed to delete source"):
+            await repository.delete_source("delete-error")
 
     async def test_source_lookup_helpers(self, repository: Repository) -> None:
         source_a = await repository.add_source(
@@ -398,6 +465,7 @@ class TestSourceOperations:
             feed_url="https://example.com/feed",
             url_pattern="/posts/*",
         )
+        assert await repository.update_source_discovery_strategy(source.id, "sitemap") is True
         assert await repository.update_source_discovery_strategy("missing", "rss") is False
         assert await repository.update_source_content_hash(source.id, "abc123") is True
         assert await repository.update_source_content_hash("missing", "abc123") is False
@@ -406,11 +474,12 @@ class TestSourceOperations:
         assert await repository.increment_failure_count(source.id) == 2
         assert await repository.increment_failure_count("missing") == 0
         assert await repository.reset_failure_count(source.id) is True
+        assert await repository.reset_failure_count(source.id) is True
         assert await repository.reset_failure_count("missing") is False
 
         updated = await repository.get_source_by_id(source.id)
         assert updated is not None
-        assert updated.discovery_strategy == "rss"
+        assert updated.discovery_strategy == "sitemap"
         assert updated.feed_url == "https://example.com/feed"
         assert updated.url_pattern == "/posts/*"
         assert updated.last_content_hash == "abc123"
@@ -549,6 +618,38 @@ class TestContentItemOperations:
         unposted = await repository.get_unposted_content_items()
         assert len(unposted) == 1
         assert unposted[0].external_id == "post-2"
+
+    async def test_get_unsummarized_and_latest_content_items(self, repository: Repository) -> None:
+        source = await repository.add_source(
+            source_type=SourceType.RSS,
+            name="Queue Source",
+            identifier="queue-source",
+        )
+        old_item = await repository.add_content_item(
+            source_id=source.id,
+            external_id="old-item",
+            title="Old Item",
+            original_url="https://example.com/old",
+            author="Author",
+            published_at=datetime(2024, 1, 1),
+        )
+        latest_item = await repository.add_content_item(
+            source_id=source.id,
+            external_id="latest-item",
+            title="Latest Item",
+            original_url="https://example.com/latest",
+            author="Author",
+            published_at=datetime(2024, 1, 2),
+        )
+        await repository.update_content_item_summary(old_item.id, "Already summarized")
+
+        unsummarized = await repository.get_unsummarized_content_items()
+        latest = await repository.get_latest_content_for_source(source.id)
+
+        assert [item.id for item in unsummarized] == [latest_item.id]
+        assert latest is not None
+        assert latest.id == latest_item.id
+        assert await repository.get_latest_content_for_source("missing-source") is None
 
     async def test_content_lookup_count_and_known_urls(self, repository: Repository) -> None:
         source = await repository.add_source(
@@ -905,6 +1006,9 @@ class TestFirstPostingOperations:
         latest = await repository.get_last_posted_content("guild-a")
         assert latest is not None
         assert latest.external_id == "real-post"
+        global_latest = await repository.get_last_posted_content()
+        assert global_latest is not None
+        assert global_latest.external_id == "real-post"
         assert await repository.get_last_posted_content("missing") is None
 
 
@@ -959,6 +1063,43 @@ class TestDiscordConfigOperations:
         assert results[0].id == results[1].id == results[2].id
 
         await repository.close()
+
+    async def test_get_or_create_discord_config_raises_after_retry_exhaustion(
+        self, repository: Repository, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        class EmptyResult:
+            def scalar_one_or_none(self) -> None:
+                return None
+
+        class AlwaysConflictingSession:
+            def __init__(self) -> None:
+                self.rollbacks = 0
+
+            async def __aenter__(self) -> "AlwaysConflictingSession":
+                return self
+
+            async def __aexit__(self, *_args: object) -> None:
+                return None
+
+            async def execute(self, *_args: object, **_kwargs: object) -> EmptyResult:
+                return EmptyResult()
+
+            def add(self, _config: DiscordConfig) -> None:
+                return None
+
+            async def commit(self) -> None:
+                raise IntegrityError("insert", {}, Exception("conflict"))
+
+            async def rollback(self) -> None:
+                self.rollbacks += 1
+
+        session = AlwaysConflictingSession()
+        monkeypatch.setattr(repository, "session", lambda: session)
+
+        with pytest.raises(RuntimeError, match="Failed to get or create discord config"):
+            await repository.get_or_create_discord_config("guild-a", "channel-a")
+
+        assert session.rollbacks == 3
 
 
 class TestMigrations:
@@ -1147,6 +1288,7 @@ class TestForwardingRuleOperations:
 
         await repository.increment_forwarding_count(rule.id)
         await repository.increment_forwarding_count(rule.id)
+        assert await repository.increment_forwarding_count("missing-rule") is False
 
         rules = await repository.get_forwarding_rules_for_source("source-456")
         assert len(rules) == 1
@@ -1340,6 +1482,7 @@ class TestGitHubRepoOperations:
         assert found.last_pr_number == 42
         assert found.last_issue_number == 10
         assert found.last_polled_at is not None
+        assert await repository.update_github_repo_state(repo.id) is True
 
     async def test_increment_and_reset_github_failure(self, repository: Repository) -> None:
         repo = await repository.add_github_repo(
@@ -1360,6 +1503,7 @@ class TestGitHubRepoOperations:
         found = await repository.get_github_repo("guild-123", "owner", "repo")
         assert found is not None
         assert found.consecutive_failures == 0
+        assert await repository.reset_github_failure(repo.id) is True
 
     async def test_set_github_repo_active(self, repository: Repository) -> None:
         repo = await repository.add_github_repo(
@@ -1627,6 +1771,8 @@ class TestMessageChunkMetaOperations:
             limit=10,
         )
         assert [chunk.id for chunk in guild_a_chunks] == ["chunk-a", "chunk-b"]
+        all_chunks = await repository.get_message_chunk_metas_batch(limit=10)
+        assert [chunk.id for chunk in all_chunks] == ["chunk-a", "chunk-b", "chunk-c"]
 
         by_ids = await repository.get_message_chunk_metas_by_ids(["chunk-b", "missing", "chunk-a"])
         assert {chunk.id for chunk in by_ids} == {"chunk-a", "chunk-b"}
@@ -1672,6 +1818,15 @@ class TestIngestionProgressOperations:
         assert await repository.update_ingestion_progress(
             "guild-a",
             "channel-a",
+            total_fetched=26,
+        )
+        [without_status_change] = await repository.get_ingestion_progress_for_guild("guild-a")
+        assert without_status_change.total_fetched == 26
+        assert without_status_change.status == "in_progress"
+
+        assert await repository.update_ingestion_progress(
+            "guild-a",
+            "channel-a",
             status="completed",
         )
         [completed] = await repository.get_ingestion_progress_for_guild("guild-a")
@@ -1686,6 +1841,60 @@ class TestIngestionProgressOperations:
 
         assert len(in_progress) == 1
         assert in_progress[0].status == "paused"
+
+    async def test_get_or_create_ingestion_progress_recovers_from_integrity_race(
+        self, repository: Repository, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        recovered = IngestionProgress(guild_id="guild-a", channel_id="channel-a")
+
+        class MissingProgressResult:
+            def scalar_one_or_none(self) -> None:
+                return None
+
+        class RecoveredProgressResult:
+            def scalar_one(self) -> IngestionProgress:
+                return recovered
+
+        class RacingSession:
+            def __init__(self) -> None:
+                self.execute_count = 0
+                self.rolled_back = False
+                self.refreshed: IngestionProgress | None = None
+
+            async def __aenter__(self) -> "RacingSession":
+                return self
+
+            async def __aexit__(self, *_args: object) -> None:
+                return None
+
+            async def execute(
+                self, *_args: object, **_kwargs: object
+            ) -> MissingProgressResult | RecoveredProgressResult:
+                self.execute_count += 1
+                if self.execute_count == 1:
+                    return MissingProgressResult()
+                return RecoveredProgressResult()
+
+            def add(self, _progress: IngestionProgress) -> None:
+                return None
+
+            async def commit(self) -> None:
+                raise IntegrityError("insert", {}, Exception("conflict"))
+
+            async def rollback(self) -> None:
+                self.rolled_back = True
+
+            async def refresh(self, progress: IngestionProgress) -> None:
+                self.refreshed = progress
+
+        session = RacingSession()
+        monkeypatch.setattr(repository, "session", lambda: session)
+
+        progress = await repository.get_or_create_ingestion_progress("guild-a", "channel-a")
+
+        assert progress is recovered
+        assert session.rolled_back is True
+        assert session.refreshed is recovered
 
 
 class TestSuckBoobsStats:

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -10,7 +10,7 @@ from intelstream.database.exceptions import (
     DuplicateSourceError,
     SourceNotFoundError,
 )
-from intelstream.database.models import SourceType
+from intelstream.database.models import MessageChunkMeta, PauseReason, SourceType
 from intelstream.database.repository import Repository
 
 
@@ -213,6 +213,89 @@ class TestSourceOperations:
         with pytest.raises(SourceNotFoundError):
             await repository.delete_source("nonexistent")
 
+    async def test_source_lookup_helpers(self, repository: Repository) -> None:
+        source_a = await repository.add_source(
+            source_type=SourceType.RSS,
+            name="Lookup A",
+            identifier="lookup-a",
+        )
+        source_b = await repository.add_source(
+            source_type=SourceType.YOUTUBE,
+            name="Lookup B",
+            identifier="lookup-b",
+        )
+
+        by_id = await repository.get_source_by_id(source_a.id)
+        assert by_id is not None
+        assert by_id.id == source_a.id
+        assert await repository.get_source_by_id("missing") is None
+
+        sources = await repository.get_sources_by_ids({source_b.id, source_a.id, "missing"})
+        assert set(sources) == {source_a.id, source_b.id}
+        assert sources[source_a.id].identifier == "lookup-a"
+        assert await repository.get_sources_by_ids(set()) == {}
+
+        by_name = await repository.get_source_by_name("Lookup B")
+        assert by_name is not None
+        assert by_name.id == source_b.id
+        assert await repository.get_source_by_name("Missing") is None
+
+    async def test_update_source_polling_and_pause_reason(self, repository: Repository) -> None:
+        source = await repository.add_source(
+            source_type=SourceType.RSS,
+            name="Pollable",
+            identifier="pollable",
+        )
+
+        assert await repository.update_source_last_polled(source.id) is True
+        updated = await repository.get_source_by_identifier("pollable")
+        assert updated is not None
+        assert updated.last_polled_at is not None
+        assert await repository.update_source_last_polled("missing") is False
+
+        paused = await repository.set_source_active(
+            "pollable",
+            False,
+            pause_reason=PauseReason.CONSECUTIVE_FAILURES,
+        )
+        assert paused.is_active is False
+        assert paused.pause_reason == PauseReason.CONSECUTIVE_FAILURES.value
+
+        resumed = await repository.set_source_active("pollable", True)
+        assert resumed.is_active is True
+        assert resumed.pause_reason == PauseReason.NONE.value
+
+    async def test_source_strategy_hash_and_failure_helpers(self, repository: Repository) -> None:
+        source = await repository.add_source(
+            source_type=SourceType.BLOG,
+            name="Smart Blog",
+            identifier="smart-blog",
+        )
+
+        assert await repository.update_source_discovery_strategy(
+            source.id,
+            "rss",
+            feed_url="https://example.com/feed",
+            url_pattern="/posts/*",
+        )
+        assert await repository.update_source_discovery_strategy("missing", "rss") is False
+        assert await repository.update_source_content_hash(source.id, "abc123") is True
+        assert await repository.update_source_content_hash("missing", "abc123") is False
+
+        assert await repository.increment_failure_count(source.id) == 1
+        assert await repository.increment_failure_count(source.id) == 2
+        assert await repository.increment_failure_count("missing") == 0
+        assert await repository.reset_failure_count(source.id) is True
+        assert await repository.reset_failure_count("missing") is False
+
+        updated = await repository.get_source_by_id(source.id)
+        assert updated is not None
+        assert updated.discovery_strategy == "rss"
+        assert updated.feed_url == "https://example.com/feed"
+        assert updated.url_pattern == "/posts/*"
+        assert updated.last_content_hash == "abc123"
+        assert updated.consecutive_failures == 0
+
 
 class TestContentItemOperations:
     async def test_add_content_item(self, repository: Repository) -> None:
@@ -346,6 +429,75 @@ class TestContentItemOperations:
         unposted = await repository.get_unposted_content_items()
         assert len(unposted) == 1
         assert unposted[0].external_id == "post-2"
+
+    async def test_content_lookup_count_and_known_urls(self, repository: Repository) -> None:
+        source = await repository.add_source(
+            source_type=SourceType.RSS,
+            name="Lookup Source",
+            identifier="lookup-source",
+        )
+        first = await repository.add_content_item(
+            source_id=source.id,
+            external_id="first",
+            title="First",
+            original_url="https://example.com/first",
+            author="Author",
+            published_at=datetime(2024, 1, 1),
+        )
+        second = await repository.add_content_item(
+            source_id=source.id,
+            external_id="second",
+            title="Second",
+            original_url="https://example.com/second",
+            author="Author",
+            published_at=datetime(2024, 1, 2),
+        )
+
+        assert await repository.get_content_count_for_source(source.id) == 2
+        assert await repository.get_known_urls_for_source(source.id) == {
+            "https://example.com/first",
+            "https://example.com/second",
+        }
+
+        ordered = await repository.get_content_items_by_ids([second.id, "missing", first.id])
+        assert [item.id for item in ordered] == [second.id, first.id]
+        assert await repository.get_content_items_by_ids([]) == []
+
+    async def test_summarized_content_items_exclude_empty_summaries(
+        self, repository: Repository
+    ) -> None:
+        source = await repository.add_source(
+            source_type=SourceType.SUBSTACK,
+            name="Summary Source",
+            identifier="summary-source",
+        )
+        summarized = await repository.add_content_item(
+            source_id=source.id,
+            external_id="summarized",
+            title="Summarized",
+            original_url="https://example.com/summarized",
+            author="Author",
+            published_at=datetime(2024, 1, 1),
+        )
+        empty_summary = await repository.add_content_item(
+            source_id=source.id,
+            external_id="empty-summary",
+            title="Empty",
+            original_url="https://example.com/empty",
+            author="Author",
+            published_at=datetime(2024, 1, 2),
+        )
+
+        await repository.update_content_item_summary(summarized.id, "Useful summary")
+        await repository.update_content_item_summary(empty_summary.id, "")
+
+        assert await repository.count_summarized_content_items() == 1
+        items = await repository.get_summarized_content_items(offset=0, limit=10)
+        assert [item.external_id for item in items] == ["summarized"]
+
+    async def test_missing_content_updates_return_false(self, repository: Repository) -> None:
+        assert await repository.update_content_item_summary("missing", "summary") is False
+        assert await repository.mark_content_item_posted("missing", "message-id") is False
 
 
 class TestFirstPostingOperations:
@@ -557,6 +709,83 @@ class TestFirstPostingOperations:
         item1 = await repository.get_content_item_by_external_id("already-posted")
         assert item1 is not None
         assert item1.discord_message_id == "real-msg-123"
+
+    async def test_content_stats_filter_by_guild(self, repository: Repository) -> None:
+        source_a = await repository.add_source(
+            source_type=SourceType.RSS,
+            name="Guild A",
+            identifier="guild-a-source",
+            guild_id="guild-a",
+        )
+        source_b = await repository.add_source(
+            source_type=SourceType.RSS,
+            name="Guild B",
+            identifier="guild-b-source",
+            guild_id="guild-b",
+        )
+        posted = await repository.add_content_item(
+            source_id=source_a.id,
+            external_id="posted",
+            title="Posted",
+            original_url="https://example.com/posted",
+            author="Author",
+            published_at=datetime(2024, 1, 1),
+        )
+        await repository.add_content_item(
+            source_id=source_b.id,
+            external_id="unposted",
+            title="Unposted",
+            original_url="https://example.com/unposted",
+            author="Author",
+            published_at=datetime(2024, 1, 2),
+        )
+        await repository.mark_content_item_posted(posted.id, "message-1")
+
+        assert await repository.get_content_stats() == {
+            "total_fetched": 2,
+            "total_posted": 1,
+        }
+        assert await repository.get_content_stats("guild-a") == {
+            "total_fetched": 1,
+            "total_posted": 1,
+        }
+        assert await repository.get_content_stats("missing") == {
+            "total_fetched": 0,
+            "total_posted": 0,
+        }
+
+    async def test_get_last_posted_content_ignores_backfilled_items(
+        self, repository: Repository
+    ) -> None:
+        source = await repository.add_source(
+            source_type=SourceType.RSS,
+            name="Guild Source",
+            identifier="guild-source",
+            guild_id="guild-a",
+        )
+        real_post = await repository.add_content_item(
+            source_id=source.id,
+            external_id="real-post",
+            title="Real Post",
+            original_url="https://example.com/real",
+            author="Author",
+            published_at=datetime(2024, 1, 1),
+        )
+        backfilled = await repository.add_content_item(
+            source_id=source.id,
+            external_id="backfilled-post",
+            title="Backfilled Post",
+            original_url="https://example.com/backfilled",
+            author="Author",
+            published_at=datetime(2024, 1, 2),
+        )
+        await repository.mark_content_item_posted(real_post.id, "message-real")
+        await repository.mark_content_item_posted(backfilled.id, "backfilled")
+
+        latest = await repository.get_last_posted_content("guild-a")
+        assert latest is not None
+        assert latest.external_id == "real-post"
+        assert await repository.get_last_posted_content("missing") is None
 
 
 class TestDiscordConfigOperations:
@@ -1032,8 +1261,58 @@ class TestGitHubRepoOperations:
         assert found is not None
         assert found.is_active is True
 
+    async def test_get_github_repos_for_guild(self, repository: Repository) -> None:
+        await repository.add_github_repo(
+            guild_id="guild-123",
+            channel_id="channel-1",
+            owner="owner1",
+            repo="repo1",
+        )
+        await repository.add_github_repo(
+            guild_id="guild-123",
+            channel_id="channel-2",
+            owner="owner2",
+            repo="repo2",
+        )
+        await repository.add_github_repo(
+            guild_id="other-guild",
+            channel_id="channel-3",
+            owner="owner3",
+            repo="repo3",
+        )
+
+        repos = await repository.get_github_repos_for_guild("guild-123")
+
+        assert {repo.owner for repo in repos} == {"owner1", "owner2"}
+
+    async def test_github_repo_missing_updates_return_false_or_zero(
+        self, repository: Repository
+    ) -> None:
+        assert await repository.update_github_repo_state("missing", last_commit_sha="sha") is False
+        assert await repository.increment_github_failure("missing") == 0
+        assert await repository.reset_github_failure("missing") is False
+        assert await repository.set_github_repo_active("missing", False) is False
+
 
 class TestExtractionCacheCleanup:
+    async def test_set_extraction_cache_updates_existing_entry(
+        self, repository: Repository
+    ) -> None:
+        first = await repository.set_extraction_cache(
+            url="https://example.com/page",
+            content_hash="hash1",
+            posts_json='[{"title": "old"}]',
+        )
+        second = await repository.set_extraction_cache(
+            url="https://example.com/page",
+            content_hash="hash2",
+            posts_json='[{"title": "new"}]',
+        )
+
+        assert second.id == first.id
+        assert second.content_hash == "hash2"
+        assert second.posts_json == '[{"title": "new"}]'
+
     async def test_cleanup_removes_old_entries(self, repository: Repository) -> None:
         await repository.set_extraction_cache(
             url="https://example.com/old",
@@ -1129,3 +1408,180 @@ class TestArticleChunkMetaOperations:
         deleted_ids = await repository.delete_article_chunk_metas_for_content_item(content.id)
         assert deleted_ids == [f"{content.id}__0000", f"{content.id}__0001"]
         assert await repository.count_article_chunk_metas() == 0
+
+    async def test_delete_all_article_chunk_metas(self, repository: Repository) -> None:
+        source = await repository.add_source(
+            source_type=SourceType.RSS,
+            name="Bulk Delete Source",
+            identifier="bulk-delete-source",
+        )
+        content = await repository.add_content_item(
+            source_id=source.id,
+            external_id="bulk-article",
+            title="Bulk Article",
+            original_url="https://example.com/bulk",
+            author="Author",
+            published_at=datetime.now(UTC),
+        )
+
+        from intelstream.database.models import ArticleChunkMeta
+
+        await repository.add_article_chunk_metas_batch([])
+        await repository.add_article_chunk_metas_batch(
+            [
+                ArticleChunkMeta(
+                    id=f"{content.id}__0000",
+                    content_item_id=content.id,
+                    chunk_index=0,
+                    text="Chunk one",
+                ),
+                ArticleChunkMeta(
+                    id=f"{content.id}__0001",
+                    content_item_id=content.id,
+                    chunk_index=1,
+                    text="Chunk two",
+                ),
+            ]
+        )
+
+        assert await repository.delete_all_article_chunk_metas() == 2
+        assert await repository.delete_all_article_chunk_metas() == 0
+        assert await repository.get_article_chunk_metas_for_content_item(content.id) == []
+
+
+class TestMessageChunkMetaOperations:
+    async def test_message_chunk_queries_and_delete_by_channel(
+        self, repository: Repository
+    ) -> None:
+        base_time = datetime(2024, 1, 1, 12, 0, tzinfo=UTC)
+        chunk_a = MessageChunkMeta(
+            id="chunk-a",
+            guild_id="guild-a",
+            channel_id="channel-a",
+            channel_name="general",
+            start_message_id="1",
+            end_message_id="2",
+            start_timestamp=base_time,
+            end_timestamp=base_time + timedelta(minutes=1),
+            authors="alice",
+            message_count=2,
+            text="First chunk",
+        )
+        chunk_b = MessageChunkMeta(
+            id="chunk-b",
+            guild_id="guild-a",
+            channel_id="channel-a",
+            channel_name="general",
+            start_message_id="3",
+            end_message_id="4",
+            start_timestamp=base_time + timedelta(minutes=2),
+            end_timestamp=base_time + timedelta(minutes=3),
+            authors="bob",
+            message_count=2,
+            text="Second chunk",
+        )
+        chunk_c = MessageChunkMeta(
+            id="chunk-c",
+            guild_id="guild-b",
+            channel_id="channel-b",
+            channel_name="random",
+            start_message_id="5",
+            end_message_id="6",
+            start_timestamp=base_time + timedelta(minutes=4),
+            end_timestamp=base_time + timedelta(minutes=5),
+            authors="carol",
+            message_count=2,
+            text="Third chunk",
+        )
+
+        assert await repository.add_message_chunk_meta(chunk_a) == chunk_a
+        await repository.add_message_chunk_metas_batch([chunk_b, chunk_c])
+        await repository.add_message_chunk_metas_batch([])
+
+        assert await repository.count_message_chunk_metas() == 3
+        assert await repository.count_message_chunk_metas("guild-a") == 2
+        assert await repository.get_message_chunk_guild_ids() == ["guild-a", "guild-b"]
+
+        guild_a_chunks = await repository.get_message_chunk_metas_batch(
+            guild_id="guild-a",
+            limit=10,
+        )
+        assert [chunk.id for chunk in guild_a_chunks] == ["chunk-a", "chunk-b"]
+
+        by_ids = await repository.get_message_chunk_metas_by_ids(["chunk-b", "missing", "chunk-a"])
+        assert {chunk.id for chunk in by_ids} == {"chunk-a", "chunk-b"}
+        assert await repository.get_message_chunk_metas_by_ids([]) == []
+
+        channel_chunks = await repository.get_message_chunk_metas_for_channel(
+            "guild-a",
+            "channel-a",
+        )
+        assert [chunk.id for chunk in channel_chunks] == ["chunk-a", "chunk-b"]
+
+        deleted_ids = await repository.delete_message_chunk_metas_for_channel(
+            "guild-a",
+            "channel-a",
+        )
+        assert set(deleted_ids) == {"chunk-a", "chunk-b"}
+        assert await repository.count_message_chunk_metas() == 1
+
+
+class TestIngestionProgressOperations:
+    async def test_create_update_and_query_ingestion_progress(self, repository: Repository) -> None:
+        progress = await repository.get_or_create_ingestion_progress("guild-a", "channel-a")
+        same_progress = await repository.get_or_create_ingestion_progress("guild-a", "channel-a")
+        assert same_progress.id == progress.id
+        assert same_progress.status == "pending"
+
+        assert await repository.update_ingestion_progress("guild-a", "missing") is False
+        assert await repository.update_ingestion_progress(
+            "guild-a",
+            "channel-a",
+            last_message_id="123",
+            total_fetched=25,
+            status="in_progress",
+        )
+
+        [updated] = await repository.get_ingestion_progress_for_guild("guild-a")
+        assert updated.last_message_id == "123"
+        assert updated.total_fetched == 25
+        assert updated.status == "in_progress"
+        assert updated.started_at is not None
+        assert [item.id for item in await repository.get_in_progress_ingestions()] == [updated.id]
+
+        assert await repository.update_ingestion_progress(
+            "guild-a",
+            "channel-a",
+            status="completed",
+        )
+        [completed] = await repository.get_ingestion_progress_for_guild("guild-a")
+        assert completed.completed_at is not None
+        assert await repository.get_in_progress_ingestions() == []
+
+    async def test_paused_ingestions_count_as_in_progress(self, repository: Repository) -> None:
+        await repository.get_or_create_ingestion_progress("guild-a", "channel-a")
+        await repository.update_ingestion_progress("guild-a", "channel-a", status="paused")
+
+        in_progress = await repository.get_in_progress_ingestions()
+
+        assert len(in_progress) == 1
+        assert in_progress[0].status == "paused"
+
+
+class TestSuckBoobsStats:
+    async def test_records_usage_and_pinged_leaderboards(self, repository: Repository) -> None:
+        await repository.record_suck_boobs_usage("guild-a", "user-1", "user-2")
+        await repository.record_suck_boobs_usage("guild-a", "user-1", "user-2")
+        await repository.record_suck_boobs_usage("guild-a", "user-2", "user-1")
+        await repository.record_suck_boobs_usage("guild-b", "user-3", "user-1")
+
+        top_users, top_pinged = await repository.get_suck_boobs_leaderboard("guild-a", limit=2)
+
+        assert [(stat.user_id, stat.times_used) for stat in top_users] == [
+            ("user-1", 2),
+            ("user-2", 1),
+        ]
+        assert [(stat.user_id, stat.times_pinged) for stat in top_pinged] == [
+            ("user-2", 2),
+            ("user-1", 1),
+        ]

--- a/tests/test_discord/test_bot.py
+++ b/tests/test_discord/test_bot.py
@@ -1,11 +1,14 @@
-from unittest.mock import AsyncMock, MagicMock, patch
+from datetime import UTC, datetime, timedelta
+from unittest.mock import AsyncMock, MagicMock, PropertyMock, patch
 
 import discord
 import pytest
 from discord import app_commands
+from discord.ext import commands
 
-from intelstream.bot import IntelStreamBot, RestrictedCommandTree, create_bot
+from intelstream.bot import CoreCommands, IntelStreamBot, RestrictedCommandTree, create_bot, run_bot
 from intelstream.config import Settings
+from intelstream.database.models import PauseReason, SourceType
 
 
 @pytest.fixture
@@ -22,6 +25,16 @@ def mock_settings() -> Settings:
         },
     ):
         return Settings()
+
+
+def make_command_interaction(guild_id: int | None = 123456789) -> MagicMock:
+    interaction = MagicMock(spec=discord.Interaction)
+    interaction.user = MagicMock()
+    interaction.user.id = 12345
+    interaction.guild_id = guild_id
+    interaction.response = MagicMock()
+    interaction.response.send_message = AsyncMock()
+    return interaction
 
 
 class TestIntelStreamBot:
@@ -51,6 +64,368 @@ class TestIntelStreamBot:
         bot.fetch_user = AsyncMock(side_effect=error)
 
         await bot.notify_owner("Test message")
+
+        await bot.repository.close()
+
+    async def test_notify_owner_fetches_owner_and_sends_alert(
+        self, mock_settings: Settings
+    ) -> None:
+        bot = await create_bot(mock_settings)
+        mock_owner = MagicMock(spec=discord.User)
+        mock_owner.send = AsyncMock()
+        bot.fetch_user = AsyncMock(return_value=mock_owner)
+
+        await bot.notify_owner("Important message")
+
+        bot.fetch_user.assert_awaited_once_with(mock_settings.discord_owner_id)
+        mock_owner.send.assert_awaited_once_with("**IntelStream Alert**\nImportant message")
+
+        await bot.repository.close()
+
+    async def test_notify_owner_truncates_long_message(self, mock_settings: Settings) -> None:
+        bot = await create_bot(mock_settings)
+        mock_owner = MagicMock(spec=discord.User)
+        mock_owner.send = AsyncMock()
+        bot._owner = mock_owner
+
+        await bot.notify_owner("x" * 2500)
+
+        sent_message = mock_owner.send.await_args.args[0]
+        assert sent_message.startswith("**IntelStream Alert**\n")
+        assert sent_message.endswith("... (truncated)")
+        assert len(sent_message) < 2000
+
+        await bot.repository.close()
+
+    async def test_notify_owner_resets_cached_owner_on_not_found(
+        self, mock_settings: Settings
+    ) -> None:
+        bot = await create_bot(mock_settings)
+        mock_owner = MagicMock(spec=discord.User)
+        mock_response = MagicMock()
+        mock_response.status = 404
+        mock_owner.send = AsyncMock(side_effect=discord.NotFound(mock_response, "missing"))
+        bot._owner = mock_owner
+
+        await bot.notify_owner("hello")
+
+        assert bot._owner is None
+
+        await bot.repository.close()
+
+    async def test_notify_owner_handles_forbidden_and_http_exception(
+        self, mock_settings: Settings
+    ) -> None:
+        bot = await create_bot(mock_settings)
+        mock_response = MagicMock()
+        mock_response.status = 403
+
+        forbidden_owner = MagicMock(spec=discord.User)
+        forbidden_owner.send = AsyncMock(side_effect=discord.Forbidden(mock_response, "forbidden"))
+        bot._owner = forbidden_owner
+        await bot.notify_owner("forbidden")
+
+        http_owner = MagicMock(spec=discord.User)
+        mock_response.status = 500
+        http_owner.send = AsyncMock(side_effect=discord.HTTPException(mock_response, "http"))
+        bot._owner = http_owner
+        await bot.notify_owner("http")
+
+        forbidden_owner.send.assert_awaited_once()
+        http_owner.send.assert_awaited_once()
+
+        await bot.repository.close()
+
+    async def test_setup_search_initializes_search_services(self, mock_settings: Settings) -> None:
+        bot = await create_bot(mock_settings)
+        bot.add_cog = AsyncMock()
+
+        with (
+            patch("intelstream.services.embedding_service.EmbeddingService") as embedding_cls,
+            patch("intelstream.database.vector_store.VectorStore") as vector_store_cls,
+            patch("intelstream.discord.cogs.search.Search", return_value="search-cog"),
+            patch("intelstream.discord.cogs.lore.Lore", return_value="lore-cog"),
+        ):
+            embedding = embedding_cls.return_value
+            embedding.initialize = AsyncMock()
+            vector_store = vector_store_cls.return_value
+            vector_store.initialize = AsyncMock()
+
+            await bot._setup_search()
+
+        assert bot.embedding_service == embedding
+        assert bot.vector_store == vector_store
+        embedding.initialize.assert_awaited_once()
+        vector_store.initialize.assert_awaited_once()
+        assert [call.args[0] for call in bot.add_cog.await_args_list] == [
+            "search-cog",
+            "lore-cog",
+        ]
+
+        await bot.repository.close()
+
+    async def test_setup_search_clears_services_when_initialization_fails(
+        self, mock_settings: Settings
+    ) -> None:
+        bot = await create_bot(mock_settings)
+        bot.add_cog = AsyncMock()
+
+        with patch("intelstream.services.embedding_service.EmbeddingService") as embedding_cls:
+            embedding_cls.return_value.initialize = AsyncMock(side_effect=RuntimeError("boom"))
+
+            await bot._setup_search()
+
+        assert bot.embedding_service is None
+        assert bot.vector_store is None
+        bot.add_cog.assert_not_awaited()
+
+        await bot.repository.close()
+
+    async def test_setup_hook_initializes_repository_registers_cogs_and_syncs(
+        self, mock_settings: Settings, tmp_path
+    ) -> None:
+        repository = MagicMock()
+        repository.initialize = AsyncMock()
+        repository.migrate_sources_to_channel = AsyncMock(return_value=2)
+        bot = IntelStreamBot(mock_settings, repository)
+        bot.add_cog = AsyncMock()
+        bot._setup_search = AsyncMock()
+        bot.tree.copy_global_to = MagicMock()
+        bot.tree.sync = AsyncMock()
+
+        with (
+            patch("intelstream.bot.get_database_directory", return_value=tmp_path / "db"),
+            patch("intelstream.discord.cogs.SourceManagement", return_value="source-cog"),
+            patch("intelstream.discord.cogs.ConfigManagement", return_value="config-cog"),
+            patch("intelstream.discord.cogs.ContentPosting", return_value="posting-cog"),
+            patch("intelstream.discord.cogs.Summarize", return_value="summarize-cog"),
+            patch("intelstream.discord.cogs.ChannelSummary", return_value="summary-cog"),
+            patch("intelstream.discord.cogs.SuckBoobs", return_value="suck-cog"),
+            patch("intelstream.discord.cogs.github.GitHubCommands", return_value="github-cog"),
+            patch(
+                "intelstream.discord.cogs.github_polling.GitHubPolling",
+                return_value="github-polling-cog",
+            ),
+            patch(
+                "intelstream.discord.cogs.message_forwarding.MessageForwarding",
+                return_value="forward-cog",
+            ),
+        ):
+            await bot.setup_hook()
+
+        repository.initialize.assert_awaited_once()
+        repository.migrate_sources_to_channel.assert_awaited_once_with(
+            guild_id=str(mock_settings.discord_guild_id),
+            channel_id=str(mock_settings.discord_channel_id),
+        )
+        bot._setup_search.assert_awaited_once()
+        assert len(bot.add_cog.await_args_list) == 10
+        assert (tmp_path / "db").exists()
+        bot.tree.copy_global_to.assert_called_once()
+        bot.tree.sync.assert_awaited_once()
+
+        await commands.Bot.close(bot)
+
+    async def test_setup_hook_skips_migration_and_search_when_disabled(
+        self, mock_settings: Settings
+    ) -> None:
+        settings = mock_settings.model_copy(
+            update={"discord_channel_id": None, "search_enabled": False}
+        )
+        repository = MagicMock()
+        repository.initialize = AsyncMock()
+        repository.migrate_sources_to_channel = AsyncMock()
+        bot = IntelStreamBot(settings, repository)
+        bot.add_cog = AsyncMock()
+        bot._setup_search = AsyncMock()
+        bot.tree.copy_global_to = MagicMock()
+        bot.tree.sync = AsyncMock()
+
+        with (
+            patch("intelstream.bot.get_database_directory", return_value=None),
+            patch("intelstream.discord.cogs.SourceManagement", return_value="source-cog"),
+            patch("intelstream.discord.cogs.ConfigManagement", return_value="config-cog"),
+            patch("intelstream.discord.cogs.ContentPosting", return_value="posting-cog"),
+            patch("intelstream.discord.cogs.Summarize", return_value="summarize-cog"),
+            patch("intelstream.discord.cogs.ChannelSummary", return_value="summary-cog"),
+            patch("intelstream.discord.cogs.SuckBoobs", return_value="suck-cog"),
+            patch("intelstream.discord.cogs.github.GitHubCommands", return_value="github-cog"),
+            patch(
+                "intelstream.discord.cogs.github_polling.GitHubPolling",
+                return_value="github-polling-cog",
+            ),
+            patch(
+                "intelstream.discord.cogs.message_forwarding.MessageForwarding",
+                return_value="forward-cog",
+            ),
+        ):
+            await bot.setup_hook()
+
+        repository.migrate_sources_to_channel.assert_not_called()
+        bot._setup_search.assert_not_called()
+
+        await commands.Bot.close(bot)
+
+    async def test_on_ready_sets_owner_and_starts_lore_ingestion(
+        self, mock_settings: Settings
+    ) -> None:
+        bot = MagicMock()
+        bot.user = MagicMock()
+        bot.user.id = 555
+        bot.settings = mock_settings
+        owner = MagicMock(spec=discord.User)
+        bot.fetch_user = AsyncMock(return_value=owner)
+        lore_cog = MagicMock()
+        lore_cog.auto_start_ingestion = AsyncMock()
+        bot.cogs = {"Lore": lore_cog}
+        bot._owner = None
+        bot.start_time = None
+
+        await IntelStreamBot.on_ready(bot)
+
+        assert bot.start_time is not None
+        assert bot._owner is owner
+        lore_cog.auto_start_ingestion.assert_awaited_once()
+
+    async def test_on_ready_handles_missing_owner_and_lore_start_failure(
+        self, mock_settings: Settings
+    ) -> None:
+        bot = MagicMock()
+        bot.user = None
+        bot.settings = mock_settings
+        response = MagicMock()
+        response.status = 404
+        bot.fetch_user = AsyncMock(side_effect=discord.NotFound(response, "missing"))
+        lore_cog = MagicMock()
+        lore_cog.auto_start_ingestion = AsyncMock(side_effect=RuntimeError("boom"))
+        bot.cogs = {"Lore": lore_cog}
+        bot._owner = None
+        bot.start_time = None
+
+        await IntelStreamBot.on_ready(bot)
+
+        assert bot.start_time is not None
+        assert bot._owner is None
+        lore_cog.auto_start_ingestion.assert_awaited_once()
+
+    async def test_on_error_notifies_owner(self) -> None:
+        bot = MagicMock()
+        bot.notify_owner = AsyncMock()
+
+        await IntelStreamBot.on_error(bot, "on_message")
+
+        bot.notify_owner.assert_awaited_once_with(
+            "Error in on_message. Check logs for details."
+        )
+
+    async def test_close_unloads_cogs_and_closes_resources(self, mock_settings: Settings) -> None:
+        repository = MagicMock()
+        repository.close = AsyncMock(side_effect=RuntimeError("repo close failed"))
+        bot = IntelStreamBot(mock_settings, repository)
+        bot.remove_cog = AsyncMock(
+            side_effect=[None, TimeoutError(), RuntimeError("remove failed")]
+        )
+        bot.vector_store = MagicMock()
+        bot.vector_store.close = AsyncMock(side_effect=TimeoutError())
+
+        with (
+            patch.object(
+                IntelStreamBot,
+                "cogs",
+                new_callable=PropertyMock,
+                return_value={"a": object(), "b": object(), "c": object()},
+            ),
+            patch.object(commands.Bot, "close", AsyncMock()) as super_close,
+        ):
+            await bot.close()
+
+        assert bot.remove_cog.await_count == 3
+        bot.vector_store.close.assert_awaited_once()
+        repository.close.assert_awaited_once()
+        super_close.assert_awaited_once()
+
+    async def test_close_continues_when_total_cog_unload_times_out(
+        self, mock_settings: Settings
+    ) -> None:
+        repository = MagicMock()
+        repository.close = AsyncMock()
+        bot = IntelStreamBot(mock_settings, repository)
+        bot.vector_store = None
+
+        async def fake_wait_for(awaitable, **kwargs):
+            timeout = kwargs["timeout"]
+            if timeout == 30.0:
+                awaitable.close()
+                raise TimeoutError
+            return await awaitable
+
+        with (
+            patch("intelstream.bot.asyncio.wait_for", side_effect=fake_wait_for),
+            patch.object(commands.Bot, "close", AsyncMock()) as super_close,
+        ):
+            await bot.close()
+
+        repository.close.assert_awaited_once()
+        super_close.assert_awaited_once()
+
+    async def test_run_bot_starts_and_closes_bot(self, mock_settings: Settings) -> None:
+        bot = MagicMock()
+        bot.start = AsyncMock()
+        bot.close = AsyncMock()
+
+        with patch("intelstream.bot.create_bot", AsyncMock(return_value=bot)):
+            await run_bot(mock_settings)
+
+        bot.start.assert_awaited_once_with(mock_settings.discord_bot_token)
+        bot.close.assert_awaited_once()
+
+    async def test_run_bot_closes_bot_when_start_fails(self, mock_settings: Settings) -> None:
+        bot = MagicMock()
+        bot.start = AsyncMock(side_effect=RuntimeError("login failed"))
+        bot.close = AsyncMock()
+
+        with (
+            patch("intelstream.bot.create_bot", AsyncMock(return_value=bot)),
+            pytest.raises(RuntimeError, match="login failed"),
+        ):
+            await run_bot(mock_settings)
+
+        bot.close.assert_awaited_once()
+
+
+class TestRestrictedCommandTreeInteractionCheck:
+    async def test_rejects_when_client_is_not_intelstream_bot(self) -> None:
+        tree = MagicMock()
+        tree.client = object()
+
+        assert await RestrictedCommandTree.interaction_check(tree, MagicMock()) is False
+
+    async def test_rejects_commands_outside_allowed_channel(self, mock_settings: Settings) -> None:
+        bot = await create_bot(mock_settings)
+        interaction = MagicMock(spec=discord.Interaction)
+        interaction.channel_id = mock_settings.discord_channel_id + 1
+        interaction.response.send_message = AsyncMock()
+
+        allowed = await bot.tree.interaction_check(interaction)
+
+        assert allowed is False
+        interaction.response.send_message.assert_awaited_once_with(
+            f"Commands can only be used in <#{mock_settings.discord_channel_id}>",
+            ephemeral=True,
+        )
+
+        await bot.repository.close()
+
+    async def test_allows_commands_in_allowed_channel(self, mock_settings: Settings) -> None:
+        bot = await create_bot(mock_settings)
+        interaction = MagicMock(spec=discord.Interaction)
+        interaction.channel_id = mock_settings.discord_channel_id
+        interaction.response.send_message = AsyncMock()
+
+        allowed = await bot.tree.interaction_check(interaction)
+
+        assert allowed is True
+        interaction.response.send_message.assert_not_called()
 
         await bot.repository.close()
 
@@ -156,3 +531,187 @@ class TestRestrictedCommandTreeErrorHandler:
             "Test error message", ephemeral=True
         )
         mock_interaction.followup.send.assert_not_called()
+
+    async def test_send_error_response_swallows_http_exception(
+        self, mock_interaction: MagicMock
+    ) -> None:
+        mock_response = MagicMock()
+        mock_response.status = 500
+        mock_interaction.response.send_message = AsyncMock(
+            side_effect=discord.HTTPException(mock_response, "send failed")
+        )
+
+        await RestrictedCommandTree._send_error_response(
+            MagicMock(), mock_interaction, "Test error message"
+        )
+
+        mock_interaction.response.send_message.assert_awaited_once()
+
+
+class TestCoreCommandsHelpers:
+    def test_format_uptime_unknown_without_start_time(self) -> None:
+        bot = MagicMock()
+        bot.start_time = None
+        core = CoreCommands(bot)
+
+        assert core._format_uptime() == "Unknown"
+
+    def test_format_uptime_uses_elapsed_time(self) -> None:
+        bot = MagicMock()
+        bot.start_time = datetime.now(UTC) - timedelta(hours=1, minutes=2, seconds=3)
+        core = CoreCommands(bot)
+
+        assert core._format_uptime().startswith("1h 2m")
+
+    def test_format_relative_time_handles_naive_datetime(self) -> None:
+        bot = MagicMock(spec=IntelStreamBot)
+        core = CoreCommands(bot)
+
+        assert core._format_relative_time(discord.utils.utcnow().replace(tzinfo=None)) == "just now"
+
+    @pytest.mark.parametrize(
+        ("delta", "expected_suffix"),
+        [
+            (timedelta(minutes=5), "m ago"),
+            (timedelta(hours=2), "h ago"),
+            (timedelta(days=3), "d ago"),
+        ],
+    )
+    def test_format_relative_time_ranges(
+        self, delta: timedelta, expected_suffix: str
+    ) -> None:
+        bot = MagicMock(spec=IntelStreamBot)
+        core = CoreCommands(bot)
+
+        assert core._format_relative_time(datetime.now(UTC) - delta).endswith(expected_suffix)
+
+    @pytest.mark.parametrize(
+        ("is_active", "pause_reason", "failures", "expected"),
+        [
+            (True, PauseReason.NONE.value, 0, "+"),
+            (True, PauseReason.NONE.value, 2, "!"),
+            (False, PauseReason.CONSECUTIVE_FAILURES.value, 5, "X"),
+            (False, PauseReason.USER_PAUSED.value, 0, "-"),
+        ],
+    )
+    def test_source_status_icons(
+        self,
+        is_active: bool,
+        pause_reason: str,
+        failures: int,
+        expected: str,
+    ) -> None:
+        bot = MagicMock(spec=IntelStreamBot)
+        core = CoreCommands(bot)
+        source = MagicMock()
+        source.is_active = is_active
+        source.pause_reason = pause_reason
+        source.consecutive_failures = failures
+        source.type = SourceType.RSS
+
+        assert core._get_source_status_icon(source) == expected
+
+
+class TestCoreCommandsCommands:
+    def _make_source(
+        self,
+        index: int,
+        *,
+        is_active: bool = True,
+        failures: int = 0,
+        channel_id: str | None = "222",
+    ) -> MagicMock:
+        source = MagicMock()
+        source.name = f"Source {index}"
+        source.type = SourceType.RSS
+        source.channel_id = channel_id
+        source.is_active = is_active
+        source.consecutive_failures = failures
+        source.pause_reason = PauseReason.NONE.value
+        return source
+
+    def _make_rule(self, index: int, *, is_active: bool = True) -> MagicMock:
+        rule = MagicMock()
+        rule.is_active = is_active
+        rule.source_channel_id = str(100 + index)
+        rule.destination_channel_id = str(200 + index)
+        rule.messages_forwarded = index
+        return rule
+
+    async def test_status_builds_full_embed_with_sources_rules_and_default_config(self) -> None:
+        bot = MagicMock()
+        bot.latency = 0.123
+        bot.start_time = datetime.now(UTC) - timedelta(minutes=5)
+        bot.settings.content_poll_interval_minutes = 7
+        repository = AsyncMock()
+        sources = [
+            self._make_source(i, failures=1 if i == 0 else 0)
+            for i in range(9)
+        ]
+        sources[1].is_active = False
+        sources[1].pause_reason = PauseReason.USER_PAUSED.value
+        repository.get_all_sources = AsyncMock(return_value=sources)
+        repository.get_content_stats = AsyncMock(
+            return_value={"total_fetched": 12, "total_posted": 8}
+        )
+        repository.get_last_posted_content = AsyncMock(
+            return_value=MagicMock(created_at=datetime.now(UTC) - timedelta(hours=2))
+        )
+        repository.get_forwarding_rules_for_guild = AsyncMock(
+            return_value=[self._make_rule(i, is_active=i % 2 == 0) for i in range(6)]
+        )
+        repository.get_discord_config = AsyncMock(return_value=MagicMock(channel_id="999"))
+        bot.repository = repository
+        core = CoreCommands(bot)
+        interaction = make_command_interaction()
+
+        await core.status.callback(core, interaction)
+
+        embed = interaction.response.send_message.await_args.kwargs["embed"]
+        assert embed.title == "IntelStream Status"
+        field_names = [field.name for field in embed.fields]
+        assert "System" in field_names
+        assert "Content" in field_names
+        assert "Configured Sources" in field_names
+        assert "Forwarding Rules (3 active)" in field_names
+        assert "Default Output" in field_names
+        configured = next(field.value for field in embed.fields if field.name == "Configured Sources")
+        assert "*... and 1 more*" in configured
+        forwarding = next(field.value for field in embed.fields if field.name.startswith("Forwarding"))
+        assert "*... and 1 more*" in forwarding
+        repository.get_content_stats.assert_awaited_once_with(str(interaction.guild_id))
+
+    async def test_status_handles_dm_with_no_optional_sections(self) -> None:
+        bot = MagicMock()
+        bot.latency = 0
+        bot.start_time = None
+        bot.settings.content_poll_interval_minutes = 5
+        repository = AsyncMock()
+        repository.get_all_sources = AsyncMock(return_value=[])
+        repository.get_content_stats = AsyncMock(
+            return_value={"total_fetched": 0, "total_posted": 0}
+        )
+        repository.get_last_posted_content = AsyncMock(return_value=None)
+        repository.get_forwarding_rules_for_guild = AsyncMock()
+        repository.get_discord_config = AsyncMock()
+        bot.repository = repository
+        core = CoreCommands(bot)
+        interaction = make_command_interaction(guild_id=None)
+
+        await core.status.callback(core, interaction)
+
+        embed = interaction.response.send_message.await_args.kwargs["embed"]
+        assert embed.title == "IntelStream Status"
+        assert all(field.name != "Configured Sources" for field in embed.fields)
+        repository.get_forwarding_rules_for_guild.assert_not_called()
+        repository.get_discord_config.assert_not_called()
+
+    async def test_ping_sends_latency(self) -> None:
+        bot = MagicMock(spec=IntelStreamBot)
+        bot.latency = 0.045
+        core = CoreCommands(bot)
+        interaction = make_command_interaction()
+
+        await core.ping.callback(core, interaction)
+
+        interaction.response.send_message.assert_awaited_once_with("Pong! Latency: 45ms")

--- a/tests/test_discord/test_bot.py
+++ b/tests/test_discord/test_bot.py
@@ -266,6 +266,43 @@ class TestIntelStreamBot:
 
         await commands.Bot.close(bot)
 
+    async def test_setup_hook_migrates_zero_sources_without_logging_branch(
+        self, mock_settings: Settings
+    ) -> None:
+        repository = MagicMock()
+        repository.initialize = AsyncMock()
+        repository.migrate_sources_to_channel = AsyncMock(return_value=0)
+        bot = IntelStreamBot(mock_settings, repository)
+        bot.add_cog = AsyncMock()
+        bot._setup_search = AsyncMock()
+        bot.tree.copy_global_to = MagicMock()
+        bot.tree.sync = AsyncMock()
+
+        with (
+            patch("intelstream.bot.get_database_directory", return_value=None),
+            patch("intelstream.discord.cogs.SourceManagement", return_value="source-cog"),
+            patch("intelstream.discord.cogs.ConfigManagement", return_value="config-cog"),
+            patch("intelstream.discord.cogs.ContentPosting", return_value="posting-cog"),
+            patch("intelstream.discord.cogs.Summarize", return_value="summarize-cog"),
+            patch("intelstream.discord.cogs.ChannelSummary", return_value="summary-cog"),
+            patch("intelstream.discord.cogs.SuckBoobs", return_value="suck-cog"),
+            patch("intelstream.discord.cogs.github.GitHubCommands", return_value="github-cog"),
+            patch(
+                "intelstream.discord.cogs.github_polling.GitHubPolling",
+                return_value="github-polling-cog",
+            ),
+            patch(
+                "intelstream.discord.cogs.message_forwarding.MessageForwarding",
+                return_value="forward-cog",
+            ),
+        ):
+            await bot.setup_hook()
+
+        repository.migrate_sources_to_channel.assert_awaited_once()
+        bot._setup_search.assert_awaited_once()
+
+        await commands.Bot.close(bot)
+
     async def test_on_ready_sets_owner_and_starts_lore_ingestion(
         self, mock_settings: Settings
     ) -> None:
@@ -307,6 +344,22 @@ class TestIntelStreamBot:
         assert bot.start_time is not None
         assert bot._owner is None
         lore_cog.auto_start_ingestion.assert_awaited_once()
+
+    async def test_on_ready_without_lore_cog_only_sets_owner(self, mock_settings: Settings) -> None:
+        bot = MagicMock()
+        bot.user = MagicMock()
+        bot.user.id = 555
+        bot.settings = mock_settings
+        owner = MagicMock(spec=discord.User)
+        bot.fetch_user = AsyncMock(return_value=owner)
+        bot.cogs = {}
+        bot._owner = None
+        bot.start_time = None
+
+        await IntelStreamBot.on_ready(bot)
+
+        assert bot.start_time is not None
+        assert bot._owner is owner
 
     async def test_on_error_notifies_owner(self) -> None:
         bot = MagicMock()
@@ -363,6 +416,22 @@ class TestIntelStreamBot:
         ):
             await bot.close()
 
+        repository.close.assert_awaited_once()
+        super_close.assert_awaited_once()
+
+    async def test_close_logs_vector_error_and_repository_timeout(
+        self, mock_settings: Settings
+    ) -> None:
+        repository = MagicMock()
+        repository.close = AsyncMock(side_effect=TimeoutError())
+        bot = IntelStreamBot(mock_settings, repository)
+        bot.vector_store = MagicMock()
+        bot.vector_store.close = AsyncMock(side_effect=RuntimeError("vector failed"))
+
+        with patch.object(commands.Bot, "close", AsyncMock()) as super_close:
+            await bot.close()
+
+        bot.vector_store.close.assert_awaited_once()
         repository.close.assert_awaited_once()
         super_close.assert_awaited_once()
 
@@ -501,6 +570,17 @@ class TestRestrictedCommandTreeErrorHandler:
 
         mock_self._send_error_response.assert_called_once()
         args = mock_self._send_error_response.call_args[0]
+        assert args[0] == mock_interaction
+        assert "unexpected error" in args[1]
+
+    async def test_handles_direct_app_command_error(self, mock_interaction: MagicMock) -> None:
+        error = app_commands.AppCommandError("direct error")
+        mock_self = MagicMock()
+        mock_self._send_error_response = AsyncMock()
+
+        await RestrictedCommandTree.on_error(mock_self, mock_interaction, error)
+
+        args = mock_self._send_error_response.call_args.args
         assert args[0] == mock_interaction
         assert "unexpected error" in args[1]
 
@@ -702,6 +782,35 @@ class TestCoreCommandsCommands:
         assert all(field.name != "Configured Sources" for field in embed.fields)
         repository.get_forwarding_rules_for_guild.assert_not_called()
         repository.get_discord_config.assert_not_called()
+
+    async def test_status_single_source_and_rule_has_no_overflow_rows(self) -> None:
+        bot = MagicMock()
+        bot.latency = 0
+        bot.start_time = datetime.now(UTC)
+        bot.settings.content_poll_interval_minutes = 5
+        repository = AsyncMock()
+        repository.get_all_sources = AsyncMock(return_value=[self._make_source(1)])
+        repository.get_content_stats = AsyncMock(
+            return_value={"total_fetched": 1, "total_posted": 1}
+        )
+        repository.get_last_posted_content = AsyncMock(return_value=None)
+        repository.get_forwarding_rules_for_guild = AsyncMock(return_value=[self._make_rule(1)])
+        repository.get_discord_config = AsyncMock(return_value=None)
+        bot.repository = repository
+        core = CoreCommands(bot)
+        interaction = make_command_interaction()
+
+        await core.status.callback(core, interaction)
+
+        embed = interaction.response.send_message.await_args.kwargs["embed"]
+        configured = next(
+            field.value for field in embed.fields if field.name == "Configured Sources"
+        )
+        forwarding = next(
+            field.value for field in embed.fields if field.name.startswith("Forwarding")
+        )
+        assert "*... and" not in configured
+        assert "*... and" not in forwarding
 
     async def test_ping_sends_latency(self) -> None:
         bot = MagicMock(spec=IntelStreamBot)

--- a/tests/test_discord/test_bot.py
+++ b/tests/test_discord/test_bot.py
@@ -314,9 +314,7 @@ class TestIntelStreamBot:
 
         await IntelStreamBot.on_error(bot, "on_message")
 
-        bot.notify_owner.assert_awaited_once_with(
-            "Error in on_message. Check logs for details."
-        )
+        bot.notify_owner.assert_awaited_once_with("Error in on_message. Check logs for details.")
 
     async def test_close_unloads_cogs_and_closes_resources(self, mock_settings: Settings) -> None:
         repository = MagicMock()
@@ -577,9 +575,7 @@ class TestCoreCommandsHelpers:
             (timedelta(days=3), "d ago"),
         ],
     )
-    def test_format_relative_time_ranges(
-        self, delta: timedelta, expected_suffix: str
-    ) -> None:
+    def test_format_relative_time_ranges(self, delta: timedelta, expected_suffix: str) -> None:
         bot = MagicMock(spec=IntelStreamBot)
         core = CoreCommands(bot)
 
@@ -644,10 +640,7 @@ class TestCoreCommandsCommands:
         bot.start_time = datetime.now(UTC) - timedelta(minutes=5)
         bot.settings.content_poll_interval_minutes = 7
         repository = AsyncMock()
-        sources = [
-            self._make_source(i, failures=1 if i == 0 else 0)
-            for i in range(9)
-        ]
+        sources = [self._make_source(i, failures=1 if i == 0 else 0) for i in range(9)]
         sources[1].is_active = False
         sources[1].pause_reason = PauseReason.USER_PAUSED.value
         repository.get_all_sources = AsyncMock(return_value=sources)
@@ -675,9 +668,13 @@ class TestCoreCommandsCommands:
         assert "Configured Sources" in field_names
         assert "Forwarding Rules (3 active)" in field_names
         assert "Default Output" in field_names
-        configured = next(field.value for field in embed.fields if field.name == "Configured Sources")
+        configured = next(
+            field.value for field in embed.fields if field.name == "Configured Sources"
+        )
         assert "*... and 1 more*" in configured
-        forwarding = next(field.value for field in embed.fields if field.name.startswith("Forwarding"))
+        forwarding = next(
+            field.value for field in embed.fields if field.name.startswith("Forwarding")
+        )
         assert "*... and 1 more*" in forwarding
         repository.get_content_stats.assert_awaited_once_with(str(interaction.guild_id))
 

--- a/tests/test_discord/test_channel_summary.py
+++ b/tests/test_discord/test_channel_summary.py
@@ -3,7 +3,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import discord
 import pytest
-from discord import MessageType
+from discord import MessageType, app_commands
 
 from intelstream.discord.cogs.channel_summary import ChannelSummary
 from intelstream.services.summarizer import SummarizationError
@@ -66,6 +66,7 @@ def mock_interaction():
     interaction = MagicMock(spec=discord.Interaction)
     interaction.response = MagicMock()
     interaction.response.defer = AsyncMock()
+    interaction.response.send_message = AsyncMock()
     interaction.followup = MagicMock()
     interaction.followup.send = AsyncMock()
     interaction.user = MagicMock()
@@ -241,6 +242,16 @@ class TestSummaryCommand:
         assert len(sent_text) <= 2000
         assert sent_text.endswith("...")
 
+    async def test_summary_rejects_non_text_channel(self, cog, mock_interaction):
+        mock_interaction.channel = MagicMock(spec=discord.VoiceChannel)
+
+        await cog.summary.callback(cog, mock_interaction, count=200, channel=None)
+
+        cog._summarizer.summarize_chat.assert_not_called()
+        mock_interaction.followup.send.assert_called_once_with(
+            "This command can only be used in text channels.", ephemeral=True
+        )
+
 
 class TestFormatMessages:
     def test_format_basic_messages(self, cog):
@@ -276,6 +287,16 @@ class TestFormatMessages:
 
         result = cog._format_messages([msg])
         assert "1 embed(s)" in result
+
+    def test_format_with_only_attachments_and_embeds(self, cog):
+        attachment = MagicMock()
+        attachment.filename = "notes.txt"
+        embed = MagicMock()
+        msg = _make_message("", "alice", attachments=[attachment], embeds=[embed])
+
+        result = cog._format_messages([msg])
+
+        assert "alice: [1 attachment(s): notes.txt] [1 embed(s)]" in result
 
 
 class TestCogLoad:
@@ -318,6 +339,42 @@ class TestCogUnload:
         await cog.cog_unload()
 
         mock_summarizer.close.assert_called_once()
+
+    async def test_cog_unload_allows_missing_summarizer(self, mock_bot):
+        cog = ChannelSummary(mock_bot)
+
+        await cog.cog_unload()
+
+        assert cog._summarizer is None
+
+
+class TestSummaryError:
+    async def test_summary_error_reports_cooldown_retry_seconds(self, cog, mock_interaction):
+        error = app_commands.CommandOnCooldown(app_commands.Cooldown(1, 60.0), retry_after=12.9)
+
+        await cog.summary_error(mock_interaction, error)
+
+        mock_interaction.response.send_message.assert_awaited_once_with(
+            "This command is on cooldown. Try again in 12s.",
+            ephemeral=True,
+        )
+
+    async def test_summary_error_reraises_unknown_errors(self, cog, mock_interaction):
+        error = app_commands.AppCommandError("boom")
+
+        with pytest.raises(app_commands.AppCommandError, match="boom"):
+            await cog.summary_error(mock_interaction, error)
+
+
+async def test_setup_adds_channel_summary_cog(mock_bot):
+    from intelstream.discord.cogs.channel_summary import setup
+
+    mock_bot.add_cog = AsyncMock()
+
+    await setup(mock_bot)
+
+    mock_bot.add_cog.assert_awaited_once()
+    assert isinstance(mock_bot.add_cog.await_args.args[0], ChannelSummary)
 
 
 class _async_iter:

--- a/tests/test_discord/test_config_management.py
+++ b/tests/test_discord/test_config_management.py
@@ -306,9 +306,7 @@ class TestConfigManagementShow:
 
 
 class TestConfigManagementErrors:
-    async def test_config_channel_error_handles_missing_permissions(
-        self, config_management
-    ):
+    async def test_config_channel_error_handles_missing_permissions(self, config_management):
         interaction = MagicMock(spec=discord.Interaction)
         interaction.response = MagicMock()
         interaction.response.send_message = AsyncMock()

--- a/tests/test_discord/test_config_management.py
+++ b/tests/test_discord/test_config_management.py
@@ -2,8 +2,9 @@ from unittest.mock import AsyncMock, MagicMock
 
 import discord
 import pytest
+from discord import app_commands
 
-from intelstream.discord.cogs.config_management import ConfigManagement
+from intelstream.discord.cogs.config_management import ConfigManagement, setup
 
 
 @pytest.fixture
@@ -143,6 +144,39 @@ class TestConfigManagementChannel:
         call_args = interaction.followup.send.call_args
         assert "embed" in call_args[0][0].lower()
 
+    async def test_config_channel_succeeds_when_bot_member_not_cached(
+        self, config_management, mock_bot
+    ):
+        interaction = MagicMock(spec=discord.Interaction)
+        interaction.response = MagicMock()
+        interaction.response.defer = AsyncMock()
+        interaction.followup = MagicMock()
+        interaction.followup.send = AsyncMock()
+        interaction.user = MagicMock(id=123)
+
+        mock_guild = MagicMock(spec=discord.Guild)
+        mock_guild.id = 456
+        mock_guild.get_member = MagicMock(return_value=None)
+        interaction.guild = mock_guild
+
+        mock_channel = MagicMock(spec=discord.TextChannel)
+        mock_channel.id = 789
+        mock_channel.mention = "#test-channel"
+        mock_channel.permissions_for = MagicMock()
+
+        mock_config = MagicMock(id="config-id")
+        mock_bot.repository.get_or_create_discord_config = AsyncMock(return_value=mock_config)
+
+        await config_management.config_channel.callback(
+            config_management, interaction, channel=mock_channel
+        )
+
+        mock_channel.permissions_for.assert_not_called()
+        mock_bot.repository.get_or_create_discord_config.assert_awaited_once_with(
+            guild_id="456",
+            channel_id="789",
+        )
+
 
 class TestConfigManagementShow:
     async def test_config_show_with_config(self, config_management, mock_bot):
@@ -241,3 +275,66 @@ class TestConfigManagementShow:
         embed = call_kwargs["embed"]
         sources_field = next(f for f in embed.fields if f.name == "Sources")
         assert "2 active / 3 total" in sources_field.value
+
+    async def test_config_show_marks_unknown_channel_and_paused_status(
+        self, config_management, mock_bot
+    ):
+        interaction = MagicMock(spec=discord.Interaction)
+        interaction.response = MagicMock()
+        interaction.response.defer = AsyncMock()
+        interaction.followup = MagicMock()
+        interaction.followup.send = AsyncMock()
+
+        mock_guild = MagicMock(spec=discord.Guild)
+        mock_guild.id = 456
+        interaction.guild = mock_guild
+
+        mock_config = MagicMock()
+        mock_config.channel_id = "789"
+        mock_config.is_active = False
+        mock_bot.repository.get_discord_config = AsyncMock(return_value=mock_config)
+        mock_bot.repository.get_all_sources = AsyncMock(return_value=[])
+        mock_bot.get_channel = MagicMock(return_value=None)
+
+        await config_management.config_show.callback(config_management, interaction)
+
+        embed = interaction.followup.send.call_args.kwargs["embed"]
+        output_field = next(f for f in embed.fields if f.name == "Output Channel")
+        status_field = next(f for f in embed.fields if f.name == "Status")
+        assert output_field.value == "Unknown (789)"
+        assert status_field.value == "Paused"
+
+
+class TestConfigManagementErrors:
+    async def test_config_channel_error_handles_missing_permissions(
+        self, config_management
+    ):
+        interaction = MagicMock(spec=discord.Interaction)
+        interaction.response = MagicMock()
+        interaction.response.send_message = AsyncMock()
+
+        await config_management.config_channel_error(
+            interaction,
+            app_commands.MissingPermissions(["manage_guild"]),
+        )
+
+        interaction.response.send_message.assert_awaited_once()
+        assert "Manage Server" in interaction.response.send_message.await_args.args[0]
+
+    async def test_config_channel_error_reraises_other_errors(self, config_management):
+        interaction = MagicMock(spec=discord.Interaction)
+        error = app_commands.AppCommandError("boom")
+
+        with pytest.raises(app_commands.AppCommandError):
+            await config_management.config_channel_error(interaction, error)
+
+
+class TestSetup:
+    async def test_setup_adds_config_management_cog(self, mock_bot):
+        mock_bot.add_cog = AsyncMock()
+
+        await setup(mock_bot)
+
+        added_cog = mock_bot.add_cog.await_args.args[0]
+        assert isinstance(added_cog, ConfigManagement)
+        assert added_cog.bot is mock_bot

--- a/tests/test_discord/test_content_posting.py
+++ b/tests/test_discord/test_content_posting.py
@@ -1,3 +1,4 @@
+import asyncio
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import discord
@@ -157,6 +158,51 @@ class TestContentPostingCogUnload:
 
         deps["summarizer"].close.assert_called_once()
 
+    async def test_cog_unload_allows_missing_pipeline_and_summarizer(self, mock_bot):
+        cog = ContentPosting(mock_bot)
+
+        await cog.cog_unload()
+
+        assert cog._initialized is False
+
+    async def test_cog_unload_handles_pending_loop_task(self, mock_bot):
+        cog = ContentPosting(mock_bot)
+        pending_task = asyncio.create_task(asyncio.sleep(60))
+
+        async def fake_wait(tasks, **kwargs):
+            assert tasks == [pending_task]
+            assert kwargs["timeout"] == 5.0
+            pending_task.cancel()
+            return set(), {pending_task}
+
+        with (
+            patch.object(cog.content_loop, "get_task", return_value=pending_task),
+            patch("intelstream.discord.cogs.content_posting.asyncio.wait", side_effect=fake_wait),
+        ):
+            await cog.cog_unload()
+
+        assert pending_task.cancelled()
+
+    async def test_cog_unload_logs_pipeline_close_timeout(self, mock_bot):
+        cog = ContentPosting(mock_bot)
+        pipeline = MagicMock()
+        pipeline.close = AsyncMock(side_effect=TimeoutError)
+        cog._pipeline = pipeline
+
+        await cog.cog_unload()
+
+        pipeline.close.assert_awaited_once()
+
+    async def test_cog_unload_logs_pipeline_close_error(self, mock_bot):
+        cog = ContentPosting(mock_bot)
+        pipeline = MagicMock()
+        pipeline.close = AsyncMock(side_effect=RuntimeError("close failed"))
+        cog._pipeline = pipeline
+
+        await cog.cog_unload()
+
+        pipeline.close.assert_awaited_once()
+
 
 class TestContentLoop:
     async def test_content_loop_skips_when_not_initialized(self, _patch_cog_deps, mock_bot):
@@ -234,6 +280,13 @@ class TestContentLoop:
         await cog.content_loop()
 
         assert deps["poster"].post_unposted_items.call_count == 2
+
+    async def test_before_content_loop_waits_for_bot_ready(self, mock_bot):
+        cog = ContentPosting(mock_bot)
+
+        await cog.before_content_loop()
+
+        mock_bot.wait_until_ready.assert_awaited_once()
 
 
 class TestContentLoopErrorHandler:
@@ -367,3 +420,26 @@ class TestContentLoopBackoff:
         await cog.content_loop()
 
         mock_bot.notify_owner.assert_called_once()
+
+    async def test_apply_backoff_ignores_failures_beyond_circuit_breaker(
+        self, _patch_cog_deps, mock_bot
+    ):
+        cog = ContentPosting(mock_bot)
+        await cog.cog_load()
+        cog._consecutive_failures = ContentPosting.MAX_CONSECUTIVE_FAILURES + 1
+        cog.content_loop.change_interval(minutes=123)
+
+        cog._apply_backoff()
+
+        assert cog.content_loop.minutes == 123
+
+
+async def test_setup_adds_content_posting_cog(mock_bot):
+    from intelstream.discord.cogs.content_posting import setup
+
+    mock_bot.add_cog = AsyncMock()
+
+    await setup(mock_bot)
+
+    mock_bot.add_cog.assert_awaited_once()
+    assert isinstance(mock_bot.add_cog.await_args.args[0], ContentPosting)

--- a/tests/test_discord/test_github.py
+++ b/tests/test_discord/test_github.py
@@ -1,13 +1,16 @@
+from datetime import UTC, datetime
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import discord
 import pytest
+from discord import app_commands
 
 from intelstream.discord.cogs.github import (
     ConfirmGitHubRemoveView,
     GitHubCommands,
     parse_github_url,
 )
+from intelstream.services.github_service import GitHubAPIError
 
 
 @pytest.fixture
@@ -22,6 +25,32 @@ def mock_bot():
 @pytest.fixture
 def github_commands(mock_bot):
     return GitHubCommands(mock_bot)
+
+
+def make_interaction(
+    *,
+    guild_id: int | None = 456,
+    channel: MagicMock | None = None,
+) -> MagicMock:
+    interaction = MagicMock(spec=discord.Interaction)
+    interaction.response = MagicMock()
+    interaction.response.defer = AsyncMock()
+    interaction.response.send_message = AsyncMock()
+    interaction.followup = MagicMock()
+    interaction.followup.send = AsyncMock()
+    interaction.edit_original_response = AsyncMock()
+    interaction.user = MagicMock()
+    interaction.user.id = 123
+    interaction.guild_id = guild_id
+    interaction.channel = channel
+    return interaction
+
+
+def make_channel(channel_id: int = 789, name: str = "updates") -> MagicMock:
+    channel = MagicMock(spec=discord.TextChannel)
+    channel.id = channel_id
+    channel.name = name
+    return channel
 
 
 class TestParseGitHubUrl:
@@ -164,6 +193,209 @@ class TestGitHubAutocomplete:
         assert "[OFF]" in choices[1].name
 
 
+class TestGitHubServiceLifecycle:
+    def test_get_github_service_returns_none_without_token(self, github_commands, mock_bot):
+        mock_bot.settings.github_token = None
+
+        assert github_commands._get_github_service() is None
+
+    def test_get_github_service_caches_created_service(self, github_commands):
+        with patch("intelstream.discord.cogs.github.GitHubService") as service_cls:
+            first = github_commands._get_github_service()
+            second = github_commands._get_github_service()
+
+        assert first is second
+        service_cls.assert_called_once_with(token="test-token")
+
+    async def test_cog_unload_closes_cached_service(self, github_commands):
+        service = MagicMock()
+        service.close = AsyncMock()
+        github_commands._github_service = service
+
+        await github_commands.cog_unload()
+
+        service.close.assert_awaited_once()
+
+
+class TestGitHubAdd:
+    async def test_add_reports_missing_token(self, github_commands, mock_bot):
+        mock_bot.settings.github_token = None
+        interaction = make_interaction(channel=make_channel())
+
+        await github_commands.github_add.callback(
+            github_commands, interaction, repo_url="org/repo"
+        )
+
+        call_args = interaction.followup.send.call_args
+        assert "No GitHub token" in call_args.args[0]
+        assert call_args.kwargs["ephemeral"] is True
+
+    async def test_add_rejects_invalid_repo_url(self, github_commands):
+        github_commands._get_github_service = MagicMock(return_value=MagicMock())
+        interaction = make_interaction(channel=make_channel())
+
+        await github_commands.github_add.callback(
+            github_commands, interaction, repo_url="not-a-repo"
+        )
+
+        assert "Invalid GitHub URL" in interaction.followup.send.call_args.args[0]
+
+    async def test_add_requires_target_channel(self, github_commands):
+        github_commands._get_github_service = MagicMock(return_value=MagicMock())
+        interaction = make_interaction(channel=None)
+
+        await github_commands.github_add.callback(
+            github_commands, interaction, repo_url="org/repo"
+        )
+
+        assert "target channel" in interaction.followup.send.call_args.args[0]
+
+    async def test_add_requires_guild(self, github_commands):
+        github_commands._get_github_service = MagicMock(return_value=MagicMock())
+        interaction = make_interaction(guild_id=None, channel=make_channel())
+
+        await github_commands.github_add.callback(
+            github_commands, interaction, repo_url="org/repo"
+        )
+
+        assert "only be used in a server" in interaction.followup.send.call_args.args[0]
+
+    async def test_add_rejects_existing_repo(self, github_commands, mock_bot):
+        github_commands._get_github_service = MagicMock(return_value=MagicMock())
+        interaction = make_interaction(channel=make_channel())
+        existing = MagicMock()
+        existing.channel_id = "999"
+        mock_bot.repository.get_github_repo = AsyncMock(return_value=existing)
+
+        await github_commands.github_add.callback(
+            github_commands, interaction, repo_url="org/repo"
+        )
+
+        assert "already being monitored" in interaction.followup.send.call_args.args[0]
+
+    async def test_add_rejects_inaccessible_repo(self, github_commands, mock_bot):
+        service = MagicMock()
+        service.validate_repo = AsyncMock(return_value=False)
+        github_commands._get_github_service = MagicMock(return_value=service)
+        interaction = make_interaction(channel=make_channel())
+        mock_bot.repository.get_github_repo = AsyncMock(return_value=None)
+
+        await github_commands.github_add.callback(
+            github_commands, interaction, repo_url="org/repo"
+        )
+
+        assert "not found or is not accessible" in interaction.followup.send.call_args.args[0]
+
+    async def test_add_reports_validation_api_error(self, github_commands, mock_bot):
+        service = MagicMock()
+        service.validate_repo = AsyncMock(side_effect=GitHubAPIError(403, "rate limited"))
+        github_commands._get_github_service = MagicMock(return_value=service)
+        interaction = make_interaction(channel=make_channel())
+        mock_bot.repository.get_github_repo = AsyncMock(return_value=None)
+
+        await github_commands.github_add.callback(
+            github_commands, interaction, repo_url="org/repo"
+        )
+
+        assert "rate limited" in interaction.followup.send.call_args.args[0]
+
+    async def test_add_success_saves_repo_and_sends_embed(self, github_commands, mock_bot):
+        service = MagicMock()
+        service.validate_repo = AsyncMock(return_value=True)
+        github_commands._get_github_service = MagicMock(return_value=service)
+        channel = make_channel(channel_id=321)
+        interaction = make_interaction(channel=channel)
+        mock_bot.repository.get_github_repo = AsyncMock(return_value=None)
+        stored = MagicMock()
+        stored.id = 42
+        mock_bot.repository.add_github_repo = AsyncMock(return_value=stored)
+
+        await github_commands.github_add.callback(
+            github_commands,
+            interaction,
+            repo_url="Org/Repo",
+            track_commits=True,
+            track_prs=False,
+            track_issues=True,
+        )
+
+        mock_bot.repository.add_github_repo.assert_awaited_once_with(
+            guild_id="456",
+            channel_id="321",
+            owner="org",
+            repo="repo",
+            track_commits=True,
+            track_prs=False,
+            track_issues=True,
+        )
+        embed = interaction.followup.send.call_args.kwargs["embed"]
+        assert embed.title == "GitHub Repository Added"
+        assert "Commits, Issues" in embed.fields[2].value
+
+
+class TestGitHubList:
+    async def test_list_requires_target_channel(self, github_commands):
+        interaction = make_interaction(channel=None)
+
+        await github_commands.github_list.callback(github_commands, interaction)
+
+        assert "target channel" in interaction.followup.send.call_args.args[0]
+
+    async def test_list_reports_empty_channel(self, github_commands, mock_bot):
+        channel = make_channel(channel_id=321)
+        interaction = make_interaction(channel=channel)
+        mock_bot.repository.get_github_repos_for_channel = AsyncMock(return_value=[])
+
+        await github_commands.github_list.callback(github_commands, interaction)
+
+        assert "No GitHub repositories" in interaction.followup.send.call_args.args[0]
+        mock_bot.repository.get_github_repos_for_channel.assert_awaited_once_with("321")
+
+    async def test_list_formats_active_paused_and_failing_repos(self, github_commands, mock_bot):
+        channel = make_channel(channel_id=321, name="dev")
+        interaction = make_interaction(channel=channel)
+        active = MagicMock()
+        active.owner = "org"
+        active.repo = "active"
+        active.is_active = True
+        active.consecutive_failures = 0
+        active.track_commits = True
+        active.track_prs = True
+        active.track_issues = False
+        active.last_polled_at = datetime(2026, 5, 25, 12, tzinfo=UTC)
+        paused = MagicMock()
+        paused.owner = "org"
+        paused.repo = "paused"
+        paused.is_active = False
+        paused.consecutive_failures = 0
+        paused.track_commits = False
+        paused.track_prs = False
+        paused.track_issues = True
+        paused.last_polled_at = None
+        failing = MagicMock()
+        failing.owner = "org"
+        failing.repo = "failing"
+        failing.is_active = True
+        failing.consecutive_failures = 3
+        failing.track_commits = False
+        failing.track_prs = True
+        failing.track_issues = True
+        failing.last_polled_at = None
+        mock_bot.repository.get_github_repos_for_channel = AsyncMock(
+            return_value=[active, paused, failing]
+        )
+
+        await github_commands.github_list.callback(github_commands, interaction)
+
+        embed = interaction.followup.send.call_args.kwargs["embed"]
+        values = "\n".join(field.value for field in embed.fields)
+        assert embed.title == "GitHub Repositories in #dev"
+        assert embed.fields[0].name == "[ON] org/active"
+        assert embed.fields[1].name == "[OFF] org/paused"
+        assert "Failing (3 errors)" in values
+        assert "Never" in values
+
+
 class TestGitHubRemoveConfirmation:
     def _make_confirmed_view(self) -> MagicMock:
         view = MagicMock(spec=ConfirmGitHubRemoveView)
@@ -248,6 +480,60 @@ class TestGitHubRemoveConfirmation:
         call_args = interaction.followup.send.call_args
         assert "not being monitored" in call_args[0][0]
 
+    async def test_remove_rejects_invalid_repo_format(self, github_commands):
+        interaction = make_interaction(channel=make_channel())
+
+        await github_commands.github_remove.callback(
+            github_commands, interaction, repo="not-a-repo"
+        )
+
+        assert "Invalid repository format" in interaction.followup.send.call_args.args[0]
+
+    async def test_remove_requires_guild(self, github_commands):
+        interaction = make_interaction(guild_id=None, channel=make_channel())
+
+        await github_commands.github_remove.callback(github_commands, interaction, repo="org/repo")
+
+        assert "only be used in a server" in interaction.followup.send.call_args.args[0]
+
+    @patch("intelstream.discord.cogs.github.ConfirmGitHubRemoveView")
+    async def test_remove_treats_timeout_as_cancelled(
+        self, mock_view_cls, github_commands, mock_bot
+    ):
+        view = self._make_confirmed_view()
+        view.wait = AsyncMock(return_value=True)
+        mock_view_cls.return_value = view
+        interaction = make_interaction(channel=make_channel())
+        mock_repo = MagicMock()
+        mock_repo.channel_id = "789"
+        mock_repo.is_active = False
+        mock_repo.track_commits = False
+        mock_repo.track_prs = False
+        mock_repo.track_issues = False
+        mock_bot.repository.get_github_repo = AsyncMock(return_value=mock_repo)
+
+        await github_commands.github_remove.callback(github_commands, interaction, repo="org/repo")
+
+        mock_bot.repository.delete_github_repo.assert_not_called()
+        assert "cancelled" in interaction.edit_original_response.call_args.kwargs["content"]
+
+    @patch("intelstream.discord.cogs.github.ConfirmGitHubRemoveView")
+    async def test_remove_reports_already_removed(self, mock_view_cls, github_commands, mock_bot):
+        mock_view_cls.return_value = self._make_confirmed_view()
+        interaction = make_interaction(channel=make_channel())
+        mock_repo = MagicMock()
+        mock_repo.channel_id = "789"
+        mock_repo.is_active = True
+        mock_repo.track_commits = False
+        mock_repo.track_prs = False
+        mock_repo.track_issues = False
+        mock_bot.repository.get_github_repo = AsyncMock(return_value=mock_repo)
+        mock_bot.repository.delete_github_repo = AsyncMock(return_value=False)
+
+        await github_commands.github_remove.callback(github_commands, interaction, repo="org/repo")
+
+        assert "already removed" in interaction.edit_original_response.call_args.kwargs["content"]
+
     @patch("intelstream.discord.cogs.github.ConfirmGitHubRemoveView")
     async def test_remove_shows_confirmation_embed(self, mock_view_cls, github_commands, mock_bot):
         mock_view_cls.return_value = self._make_cancelled_view()
@@ -274,3 +560,86 @@ class TestGitHubRemoveConfirmation:
         embed = call_kwargs["embed"]
         assert embed.title == "Confirm Repository Removal"
         assert "org/repo" in embed.description
+
+
+class TestGitHubToggle:
+    async def test_toggle_rejects_invalid_repo_format(self, github_commands):
+        interaction = make_interaction(channel=make_channel())
+
+        await github_commands.github_toggle.callback(
+            github_commands, interaction, repo="not-a-repo"
+        )
+
+        assert "Invalid repository format" in interaction.followup.send.call_args.args[0]
+
+    async def test_toggle_requires_guild(self, github_commands):
+        interaction = make_interaction(guild_id=None, channel=make_channel())
+
+        await github_commands.github_toggle.callback(github_commands, interaction, repo="org/repo")
+
+        assert "only be used in a server" in interaction.followup.send.call_args.args[0]
+
+    async def test_toggle_reports_missing_repo(self, github_commands, mock_bot):
+        interaction = make_interaction(channel=make_channel())
+        mock_bot.repository.get_github_repo = AsyncMock(return_value=None)
+
+        await github_commands.github_toggle.callback(github_commands, interaction, repo="org/repo")
+
+        assert "not being monitored" in interaction.followup.send.call_args.args[0]
+
+    @pytest.mark.parametrize(
+        ("initial_state", "expected_state", "expected_word"),
+        [(True, False, "disabled"), (False, True, "enabled")],
+    )
+    async def test_toggle_flips_repo_state(
+        self,
+        github_commands,
+        mock_bot,
+        initial_state: bool,
+        expected_state: bool,
+        expected_word: str,
+    ):
+        interaction = make_interaction(channel=make_channel())
+        repo = MagicMock()
+        repo.id = 42
+        repo.is_active = initial_state
+        mock_bot.repository.get_github_repo = AsyncMock(return_value=repo)
+        mock_bot.repository.set_github_repo_active = AsyncMock()
+
+        await github_commands.github_toggle.callback(github_commands, interaction, repo="org/repo")
+
+        mock_bot.repository.set_github_repo_active.assert_awaited_once_with(42, expected_state)
+        assert expected_word in interaction.followup.send.call_args.args[0]
+
+
+class TestGitHubErrorHandlers:
+    @pytest.mark.parametrize(
+        ("handler_name", "expected"),
+        [
+            ("github_add_error", "add GitHub repositories"),
+            ("github_remove_error", "remove GitHub repositories"),
+            ("github_toggle_error", "toggle GitHub repositories"),
+        ],
+    )
+    async def test_missing_permission_errors_send_ephemeral_message(
+        self, github_commands, handler_name: str, expected: str
+    ):
+        interaction = make_interaction(channel=make_channel())
+        error = app_commands.MissingPermissions(["manage_guild"])
+
+        await getattr(github_commands, handler_name)(interaction, error)
+
+        interaction.response.send_message.assert_awaited_once()
+        assert expected in interaction.response.send_message.call_args.args[0]
+        assert interaction.response.send_message.call_args.kwargs["ephemeral"] is True
+
+    @pytest.mark.parametrize(
+        "handler_name",
+        ["github_add_error", "github_remove_error", "github_toggle_error"],
+    )
+    async def test_non_permission_errors_are_reraised(self, github_commands, handler_name: str):
+        interaction = make_interaction(channel=make_channel())
+        error = app_commands.CommandInvokeError(MagicMock(), RuntimeError("boom"))
+
+        with pytest.raises(app_commands.CommandInvokeError):
+            await getattr(github_commands, handler_name)(interaction, error)

--- a/tests/test_discord/test_github.py
+++ b/tests/test_discord/test_github.py
@@ -9,6 +9,7 @@ from intelstream.discord.cogs.github import (
     ConfirmGitHubRemoveView,
     GitHubCommands,
     parse_github_url,
+    setup,
 )
 from intelstream.services.github_service import GitHubAPIError
 
@@ -119,6 +120,28 @@ class TestParseGitHubUrl:
         assert result == ("owner", "repo")
 
 
+class TestConfirmGitHubRemoveView:
+    async def test_confirm_button_marks_view_confirmed(self) -> None:
+        view = ConfirmGitHubRemoveView()
+        interaction = make_interaction()
+
+        await view.children[0].callback(interaction)
+
+        assert view.confirmed is True
+        assert view.is_finished() is True
+        interaction.response.defer.assert_awaited_once()
+
+    async def test_cancel_button_marks_view_cancelled(self) -> None:
+        view = ConfirmGitHubRemoveView()
+        interaction = make_interaction()
+
+        await view.children[1].callback(interaction)
+
+        assert view.confirmed is False
+        assert view.is_finished() is True
+        interaction.response.defer.assert_awaited_once()
+
+
 class TestGitHubAutocomplete:
     def _make_repo(self, owner: str, repo: str, is_active: bool) -> MagicMock:
         r = MagicMock()
@@ -215,6 +238,11 @@ class TestGitHubServiceLifecycle:
         await github_commands.cog_unload()
 
         service.close.assert_awaited_once()
+
+    async def test_cog_unload_without_cached_service_noops(self, github_commands):
+        github_commands._github_service = None
+
+        await github_commands.cog_unload()
 
 
 class TestGitHubAdd:
@@ -319,6 +347,28 @@ class TestGitHubAdd:
         embed = interaction.followup.send.call_args.kwargs["embed"]
         assert embed.title == "GitHub Repository Added"
         assert "Commits, Issues" in embed.fields[2].value
+
+    async def test_add_success_can_track_only_prs(self, github_commands, mock_bot):
+        service = MagicMock()
+        service.validate_repo = AsyncMock(return_value=True)
+        github_commands._get_github_service = MagicMock(return_value=service)
+        interaction = make_interaction(channel=make_channel(channel_id=321))
+        mock_bot.repository.get_github_repo = AsyncMock(return_value=None)
+        stored = MagicMock()
+        stored.id = 42
+        mock_bot.repository.add_github_repo = AsyncMock(return_value=stored)
+
+        await github_commands.github_add.callback(
+            github_commands,
+            interaction,
+            repo_url="Org/Repo",
+            track_commits=False,
+            track_prs=True,
+            track_issues=False,
+        )
+
+        embed = interaction.followup.send.call_args.kwargs["embed"]
+        assert embed.fields[2].value == "PRs"
 
 
 class TestGitHubList:
@@ -599,6 +649,26 @@ class TestGitHubToggle:
         mock_bot.repository.set_github_repo_active.assert_awaited_once_with(42, expected_state)
         assert expected_word in interaction.followup.send.call_args.args[0]
 
+    async def test_remove_autocomplete_delegates_to_repo_autocomplete(self, github_commands):
+        interaction = make_interaction(channel=make_channel())
+        choice = app_commands.Choice(name="[ON] org/repo", value="org/repo")
+        github_commands._github_repo_autocomplete = AsyncMock(return_value=[choice])
+
+        choices = await github_commands.github_remove_autocomplete(interaction, "org")
+
+        assert choices == [choice]
+        github_commands._github_repo_autocomplete.assert_awaited_once_with(interaction, "org")
+
+    async def test_toggle_autocomplete_delegates_to_repo_autocomplete(self, github_commands):
+        interaction = make_interaction(channel=make_channel())
+        choice = app_commands.Choice(name="[ON] org/repo", value="org/repo")
+        github_commands._github_repo_autocomplete = AsyncMock(return_value=[choice])
+
+        choices = await github_commands.github_toggle_autocomplete(interaction, "org")
+
+        assert choices == [choice]
+        github_commands._github_repo_autocomplete.assert_awaited_once_with(interaction, "org")
+
 
 class TestGitHubErrorHandlers:
     @pytest.mark.parametrize(
@@ -631,3 +701,15 @@ class TestGitHubErrorHandlers:
 
         with pytest.raises(app_commands.CommandInvokeError):
             await getattr(github_commands, handler_name)(interaction, error)
+
+
+class TestSetup:
+    async def test_setup_registers_cog(self):
+        bot = MagicMock()
+        bot.add_cog = AsyncMock()
+
+        await setup(bot)
+
+        [cog] = bot.add_cog.await_args.args
+        assert isinstance(cog, GitHubCommands)
+        assert cog.bot is bot

--- a/tests/test_discord/test_github.py
+++ b/tests/test_discord/test_github.py
@@ -222,9 +222,7 @@ class TestGitHubAdd:
         mock_bot.settings.github_token = None
         interaction = make_interaction(channel=make_channel())
 
-        await github_commands.github_add.callback(
-            github_commands, interaction, repo_url="org/repo"
-        )
+        await github_commands.github_add.callback(github_commands, interaction, repo_url="org/repo")
 
         call_args = interaction.followup.send.call_args
         assert "No GitHub token" in call_args.args[0]
@@ -244,9 +242,7 @@ class TestGitHubAdd:
         github_commands._get_github_service = MagicMock(return_value=MagicMock())
         interaction = make_interaction(channel=None)
 
-        await github_commands.github_add.callback(
-            github_commands, interaction, repo_url="org/repo"
-        )
+        await github_commands.github_add.callback(github_commands, interaction, repo_url="org/repo")
 
         assert "target channel" in interaction.followup.send.call_args.args[0]
 
@@ -254,9 +250,7 @@ class TestGitHubAdd:
         github_commands._get_github_service = MagicMock(return_value=MagicMock())
         interaction = make_interaction(guild_id=None, channel=make_channel())
 
-        await github_commands.github_add.callback(
-            github_commands, interaction, repo_url="org/repo"
-        )
+        await github_commands.github_add.callback(github_commands, interaction, repo_url="org/repo")
 
         assert "only be used in a server" in interaction.followup.send.call_args.args[0]
 
@@ -267,9 +261,7 @@ class TestGitHubAdd:
         existing.channel_id = "999"
         mock_bot.repository.get_github_repo = AsyncMock(return_value=existing)
 
-        await github_commands.github_add.callback(
-            github_commands, interaction, repo_url="org/repo"
-        )
+        await github_commands.github_add.callback(github_commands, interaction, repo_url="org/repo")
 
         assert "already being monitored" in interaction.followup.send.call_args.args[0]
 
@@ -280,9 +272,7 @@ class TestGitHubAdd:
         interaction = make_interaction(channel=make_channel())
         mock_bot.repository.get_github_repo = AsyncMock(return_value=None)
 
-        await github_commands.github_add.callback(
-            github_commands, interaction, repo_url="org/repo"
-        )
+        await github_commands.github_add.callback(github_commands, interaction, repo_url="org/repo")
 
         assert "not found or is not accessible" in interaction.followup.send.call_args.args[0]
 
@@ -293,9 +283,7 @@ class TestGitHubAdd:
         interaction = make_interaction(channel=make_channel())
         mock_bot.repository.get_github_repo = AsyncMock(return_value=None)
 
-        await github_commands.github_add.callback(
-            github_commands, interaction, repo_url="org/repo"
-        )
+        await github_commands.github_add.callback(github_commands, interaction, repo_url="org/repo")
 
         assert "rate limited" in interaction.followup.send.call_args.args[0]
 

--- a/tests/test_discord/test_github_polling.py
+++ b/tests/test_discord/test_github_polling.py
@@ -1,8 +1,11 @@
-from unittest.mock import AsyncMock, MagicMock
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock, MagicMock, patch
 
+import discord
 import pytest
 
 from intelstream.discord.cogs.github_polling import GitHubPolling
+from intelstream.services.github_service import GitHubAPIError, GitHubEvent
 
 
 @pytest.fixture
@@ -27,6 +30,54 @@ def _make_cog(mock_bot: MagicMock) -> GitHubPolling:
     return cog
 
 
+def _make_repo(
+    *,
+    first_poll: bool = False,
+    track_commits: bool = True,
+    track_prs: bool = True,
+    track_issues: bool = True,
+) -> MagicMock:
+    repo = MagicMock()
+    repo.id = 42
+    repo.owner = "org"
+    repo.repo = "repo"
+    repo.channel_id = "987"
+    repo.track_commits = track_commits
+    repo.track_prs = track_prs
+    repo.track_issues = track_issues
+    repo.last_commit_sha = None if first_poll else "old-sha"
+    repo.last_pr_number = None if first_poll else 1
+    repo.last_issue_number = None if first_poll else 2
+    return repo
+
+
+def _make_event(
+    event_type: str,
+    *,
+    sha: str | None = None,
+    number: int | None = None,
+) -> GitHubEvent:
+    return GitHubEvent(
+        event_type=event_type,
+        repo_full_name="org/repo",
+        number=number,
+        sha=sha,
+        title="Title",
+        description=None,
+        author="octocat",
+        author_avatar_url="https://example.com/avatar.png",
+        url="https://github.com/org/repo",
+        created_at=datetime(2026, 5, 25, tzinfo=UTC),
+        state="open",
+    )
+
+
+def _make_text_channel() -> MagicMock:
+    channel = MagicMock(spec=discord.TextChannel)
+    channel.id = 987
+    return channel
+
+
 class TestGitHubPollingInit:
     def test_init_sets_consecutive_failures_to_zero(self, mock_bot):
         cog = GitHubPolling(mock_bot)
@@ -35,8 +86,64 @@ class TestGitHubPollingInit:
     def test_class_has_max_backoff_multiplier(self):
         assert GitHubPolling.MAX_BACKOFF_MULTIPLIER == 4
 
+    async def test_cog_load_noops_without_token(self, mock_bot):
+        mock_bot.settings.github_token = None
+        cog = GitHubPolling(mock_bot)
+
+        await cog.cog_load()
+
+        assert cog._initialized is False
+        assert cog._service is None
+        assert cog._poster is None
+
+    async def test_cog_load_initializes_service_poster_and_loop(self, mock_bot):
+        cog = GitHubPolling(mock_bot)
+
+        with (
+            patch("intelstream.discord.cogs.github_polling.httpx.AsyncClient") as client_cls,
+            patch("intelstream.discord.cogs.github_polling.GitHubService") as service_cls,
+            patch("intelstream.discord.cogs.github_polling.GitHubPoster") as poster_cls,
+            patch.object(cog.github_loop, "start") as start,
+        ):
+            await cog.cog_load()
+
+        client_cls.assert_called_once_with(timeout=30.0)
+        service_cls.assert_called_once_with(
+            token="test-github-token",
+            http_client=client_cls.return_value,
+        )
+        poster_cls.assert_called_once_with()
+        start.assert_called_once_with()
+        assert cog._initialized is True
+        assert cog._base_interval == 5
+
+    async def test_cog_unload_cancels_loop_and_closes_resources(self, mock_bot):
+        cog = GitHubPolling(mock_bot)
+        service = MagicMock()
+        service.close = AsyncMock()
+        http_client = MagicMock()
+        http_client.aclose = AsyncMock()
+        cog._service = service
+        cog._http_client = http_client
+        cog._initialized = True
+
+        with patch.object(cog.github_loop, "cancel") as cancel:
+            await cog.cog_unload()
+
+        cancel.assert_called_once_with()
+        service.close.assert_awaited_once()
+        http_client.aclose.assert_awaited_once()
+        assert cog._initialized is False
+
 
 class TestGitHubLoopBackoff:
+    async def test_loop_returns_when_not_initialized(self, mock_bot):
+        cog = GitHubPolling(mock_bot)
+
+        await cog.github_loop()
+
+        mock_bot.repository.get_all_github_repos.assert_not_awaited()
+
     async def test_backoff_increments_consecutive_failures(self, mock_bot):
         mock_bot.repository.get_all_github_repos = AsyncMock(side_effect=Exception("DB error"))
         cog = _make_cog(mock_bot)
@@ -141,6 +248,13 @@ class TestGitHubLoopBackoff:
 
 
 class TestGitHubLoopErrorHandler:
+    async def test_before_loop_waits_for_bot_ready(self, mock_bot):
+        cog = _make_cog(mock_bot)
+
+        await cog.before_github_loop()
+
+        mock_bot.wait_until_ready.assert_awaited_once()
+
     async def test_error_handler_notifies_owner_on_first_error(self, mock_bot):
         cog = _make_cog(mock_bot)
 
@@ -173,3 +287,153 @@ class TestGitHubLoopErrorHandler:
         await cog.github_loop_error(Exception("Loop error"))
 
         assert cog.github_loop.minutes == cog._base_interval * 2
+
+
+class TestProcessRepo:
+    async def test_returns_zero_when_service_or_poster_missing(self, mock_bot):
+        cog = _make_cog(mock_bot)
+        cog._service = None
+
+        posted = await cog._process_repo(_make_repo())
+
+        assert posted == 0
+
+    async def test_first_poll_updates_state_without_posting_events(self, mock_bot):
+        cog = _make_cog(mock_bot)
+        repo = _make_repo(first_poll=True)
+        commit = _make_event("commit", sha="new-sha")
+        pr = _make_event("pull_request", number=7)
+        issue = _make_event("issue", number=9)
+        cog._service.fetch_new_commits = AsyncMock(return_value=[commit])
+        cog._service.fetch_new_prs = AsyncMock(return_value=[pr])
+        cog._service.fetch_new_issues = AsyncMock(return_value=[issue])
+        cog._poster.post_events = AsyncMock()
+        mock_bot.repository.update_github_repo_state = AsyncMock()
+        mock_bot.repository.reset_github_failure = AsyncMock()
+
+        posted = await cog._process_repo(repo)
+
+        assert posted == 0
+        cog._poster.post_events.assert_not_awaited()
+        mock_bot.repository.update_github_repo_state.assert_awaited_once_with(
+            42,
+            last_commit_sha="new-sha",
+            last_pr_number=7,
+            last_issue_number=9,
+        )
+        mock_bot.repository.reset_github_failure.assert_awaited_once_with(42)
+
+    async def test_subsequent_poll_posts_events_to_target_channel(self, mock_bot):
+        cog = _make_cog(mock_bot)
+        repo = _make_repo()
+        commit = _make_event("commit", sha="new-sha")
+        pr_low = _make_event("pull_request", number=3)
+        pr_high = _make_event("pull_request", number=8)
+        issue = _make_event("issue", number=6)
+        cog._service.fetch_new_commits = AsyncMock(return_value=[commit])
+        cog._service.fetch_new_prs = AsyncMock(return_value=[pr_low, pr_high])
+        cog._service.fetch_new_issues = AsyncMock(return_value=[issue])
+        cog._poster.post_events = AsyncMock()
+        channel = _make_text_channel()
+        mock_bot.get_channel = MagicMock(return_value=channel)
+        mock_bot.repository.update_github_repo_state = AsyncMock()
+        mock_bot.repository.reset_github_failure = AsyncMock()
+
+        posted = await cog._process_repo(repo)
+
+        assert posted == 4
+        cog._poster.post_events.assert_awaited_once()
+        assert cog._poster.post_events.await_args.args[0] is channel
+        mock_bot.repository.update_github_repo_state.assert_awaited_once_with(
+            42,
+            last_commit_sha="new-sha",
+            last_pr_number=8,
+            last_issue_number=6,
+        )
+
+    async def test_process_repo_tolerates_partial_github_api_errors(self, mock_bot):
+        cog = _make_cog(mock_bot)
+        repo = _make_repo()
+        pr = _make_event("pull_request", number=5)
+        cog._service.fetch_new_commits = AsyncMock(
+            side_effect=GitHubAPIError(500, "commit error")
+        )
+        cog._service.fetch_new_prs = AsyncMock(return_value=[pr])
+        cog._service.fetch_new_issues = AsyncMock(
+            side_effect=GitHubAPIError(500, "issue error")
+        )
+        cog._poster.post_events = AsyncMock()
+        mock_bot.get_channel = MagicMock(return_value=_make_text_channel())
+        mock_bot.repository.update_github_repo_state = AsyncMock()
+        mock_bot.repository.reset_github_failure = AsyncMock()
+
+        posted = await cog._process_repo(repo)
+
+        assert posted == 1
+        mock_bot.repository.update_github_repo_state.assert_awaited_once_with(
+            42,
+            last_commit_sha=None,
+            last_pr_number=5,
+            last_issue_number=None,
+        )
+        mock_bot.repository.reset_github_failure.assert_awaited_once_with(42)
+
+    async def test_process_repo_skips_post_when_channel_missing(self, mock_bot):
+        cog = _make_cog(mock_bot)
+        repo = _make_repo()
+        commit = _make_event("commit", sha="new-sha")
+        cog._service.fetch_new_commits = AsyncMock(return_value=[commit])
+        cog._service.fetch_new_prs = AsyncMock(return_value=[])
+        cog._service.fetch_new_issues = AsyncMock(return_value=[])
+        cog._poster.post_events = AsyncMock()
+        mock_bot.get_channel = MagicMock(return_value=None)
+        mock_bot.repository.update_github_repo_state = AsyncMock()
+        mock_bot.repository.reset_github_failure = AsyncMock()
+
+        posted = await cog._process_repo(repo)
+
+        assert posted == 1
+        cog._poster.post_events.assert_not_awaited()
+        mock_bot.repository.reset_github_failure.assert_awaited_once_with(42)
+
+    async def test_process_repo_respects_tracking_flags(self, mock_bot):
+        cog = _make_cog(mock_bot)
+        repo = _make_repo(track_commits=False, track_prs=True, track_issues=False)
+        cog._service.fetch_new_commits = AsyncMock(return_value=[])
+        cog._service.fetch_new_prs = AsyncMock(return_value=[])
+        cog._service.fetch_new_issues = AsyncMock(return_value=[])
+        mock_bot.repository.update_github_repo_state = AsyncMock()
+        mock_bot.repository.reset_github_failure = AsyncMock()
+
+        posted = await cog._process_repo(repo)
+
+        assert posted == 0
+        cog._service.fetch_new_commits.assert_not_called()
+        cog._service.fetch_new_prs.assert_awaited_once_with("org", "repo", 1)
+        cog._service.fetch_new_issues.assert_not_called()
+
+
+class TestHandleFailure:
+    async def test_handle_failure_only_increments_below_disable_threshold(self, mock_bot):
+        cog = _make_cog(mock_bot)
+        repo = _make_repo()
+        mock_bot.repository.increment_github_failure = AsyncMock(return_value=4)
+        mock_bot.repository.set_github_repo_active = AsyncMock()
+
+        await cog._handle_failure(repo, RuntimeError("boom"))
+
+        mock_bot.repository.increment_github_failure.assert_awaited_once_with(42)
+        mock_bot.repository.set_github_repo_active.assert_not_awaited()
+        mock_bot.notify_owner.assert_not_awaited()
+
+    async def test_handle_failure_disables_repo_at_threshold(self, mock_bot):
+        cog = _make_cog(mock_bot)
+        repo = _make_repo()
+        mock_bot.repository.increment_github_failure = AsyncMock(return_value=5)
+        mock_bot.repository.set_github_repo_active = AsyncMock()
+
+        await cog._handle_failure(repo, RuntimeError("boom"))
+
+        mock_bot.repository.set_github_repo_active.assert_awaited_once_with(42, False)
+        mock_bot.notify_owner.assert_awaited_once()
+        assert "disabled after 5 consecutive failures" in mock_bot.notify_owner.await_args.args[0]

--- a/tests/test_discord/test_github_polling.py
+++ b/tests/test_discord/test_github_polling.py
@@ -355,13 +355,9 @@ class TestProcessRepo:
         cog = _make_cog(mock_bot)
         repo = _make_repo()
         pr = _make_event("pull_request", number=5)
-        cog._service.fetch_new_commits = AsyncMock(
-            side_effect=GitHubAPIError(500, "commit error")
-        )
+        cog._service.fetch_new_commits = AsyncMock(side_effect=GitHubAPIError(500, "commit error"))
         cog._service.fetch_new_prs = AsyncMock(return_value=[pr])
-        cog._service.fetch_new_issues = AsyncMock(
-            side_effect=GitHubAPIError(500, "issue error")
-        )
+        cog._service.fetch_new_issues = AsyncMock(side_effect=GitHubAPIError(500, "issue error"))
         cog._poster.post_events = AsyncMock()
         mock_bot.get_channel = MagicMock(return_value=_make_text_channel())
         mock_bot.repository.update_github_repo_state = AsyncMock()

--- a/tests/test_discord/test_github_polling.py
+++ b/tests/test_discord/test_github_polling.py
@@ -135,6 +135,16 @@ class TestGitHubPollingInit:
         http_client.aclose.assert_awaited_once()
         assert cog._initialized is False
 
+    async def test_cog_unload_without_resources_only_marks_uninitialized(self, mock_bot):
+        cog = GitHubPolling(mock_bot)
+        cog._initialized = True
+
+        with patch.object(cog.github_loop, "cancel") as cancel:
+            await cog.cog_unload()
+
+        cancel.assert_called_once_with()
+        assert cog._initialized is False
+
 
 class TestGitHubLoopBackoff:
     async def test_loop_returns_when_not_initialized(self, mock_bot):
@@ -490,6 +500,45 @@ class TestProcessRepo:
         cog._service.fetch_new_commits.assert_not_called()
         cog._service.fetch_new_prs.assert_awaited_once_with("org", "repo", 1)
         cog._service.fetch_new_issues.assert_not_called()
+
+    async def test_process_repo_skips_pr_fetch_when_tracking_disabled(self, mock_bot):
+        cog = _make_cog(mock_bot)
+        repo = _make_repo(track_commits=False, track_prs=False, track_issues=False)
+        cog._service.fetch_new_commits = AsyncMock(return_value=[])
+        cog._service.fetch_new_prs = AsyncMock(return_value=[])
+        cog._service.fetch_new_issues = AsyncMock(return_value=[])
+        mock_bot.repository.update_github_repo_state = AsyncMock()
+        mock_bot.repository.reset_github_failure = AsyncMock()
+
+        posted = await cog._process_repo(repo)
+
+        assert posted == 0
+        cog._service.fetch_new_commits.assert_not_called()
+        cog._service.fetch_new_prs.assert_not_called()
+        cog._service.fetch_new_issues.assert_not_called()
+
+    async def test_process_repo_keeps_highest_pr_number_when_events_descend(self, mock_bot):
+        cog = _make_cog(mock_bot)
+        repo = _make_repo(track_commits=False, track_prs=True, track_issues=False)
+        pr_high = _make_event("pull_request", number=8)
+        pr_low = _make_event("pull_request", number=3)
+        cog._service.fetch_new_commits = AsyncMock(return_value=[])
+        cog._service.fetch_new_prs = AsyncMock(return_value=[pr_high, pr_low])
+        cog._service.fetch_new_issues = AsyncMock(return_value=[])
+        cog._poster.post_events = AsyncMock()
+        mock_bot.get_channel = MagicMock(return_value=_make_text_channel())
+        mock_bot.repository.update_github_repo_state = AsyncMock()
+        mock_bot.repository.reset_github_failure = AsyncMock()
+
+        posted = await cog._process_repo(repo)
+
+        assert posted == 2
+        mock_bot.repository.update_github_repo_state.assert_awaited_once_with(
+            42,
+            last_commit_sha=None,
+            last_pr_number=8,
+            last_issue_number=None,
+        )
 
 
 class TestHandleFailure:

--- a/tests/test_discord/test_github_polling.py
+++ b/tests/test_discord/test_github_polling.py
@@ -246,6 +246,24 @@ class TestGitHubLoopBackoff:
 
         mock_bot.notify_owner.assert_called_once()
 
+    async def test_loop_processes_successes_and_failures(self, mock_bot):
+        repo_ok = _make_repo()
+        repo_failed = _make_repo()
+        repo_failed.id = 43
+        repo_failed.repo = "broken"
+        mock_bot.repository.get_all_github_repos = AsyncMock(return_value=[repo_ok, repo_failed])
+        cog = _make_cog(mock_bot)
+        cog._process_repo = AsyncMock(side_effect=[2, RuntimeError("boom")])
+        cog._handle_failure = AsyncMock()
+
+        await cog.github_loop()
+
+        assert cog._process_repo.await_count == 2
+        cog._handle_failure.assert_awaited_once()
+        assert cog._handle_failure.await_args.args[0] is repo_failed
+        assert isinstance(cog._handle_failure.await_args.args[1], RuntimeError)
+        assert cog._consecutive_failures == 0
+
 
 class TestGitHubLoopErrorHandler:
     async def test_before_loop_waits_for_bot_ready(self, mock_bot):
@@ -374,6 +392,71 @@ class TestProcessRepo:
         )
         mock_bot.repository.reset_github_failure.assert_awaited_once_with(42)
 
+    async def test_process_repo_tolerates_pr_github_api_error(self, mock_bot):
+        cog = _make_cog(mock_bot)
+        repo = _make_repo()
+        commit = _make_event("commit", sha="new-sha")
+        issue = _make_event("issue", number=11)
+        cog._service.fetch_new_commits = AsyncMock(return_value=[commit])
+        cog._service.fetch_new_prs = AsyncMock(side_effect=GitHubAPIError(500, "pr error"))
+        cog._service.fetch_new_issues = AsyncMock(return_value=[issue])
+        cog._poster.post_events = AsyncMock()
+        mock_bot.get_channel = MagicMock(return_value=_make_text_channel())
+        mock_bot.repository.update_github_repo_state = AsyncMock()
+        mock_bot.repository.reset_github_failure = AsyncMock()
+
+        posted = await cog._process_repo(repo)
+
+        assert posted == 2
+        mock_bot.repository.update_github_repo_state.assert_awaited_once_with(
+            42,
+            last_commit_sha="new-sha",
+            last_pr_number=None,
+            last_issue_number=11,
+        )
+
+    async def test_process_repo_posts_to_thread_channel(self, mock_bot):
+        cog = _make_cog(mock_bot)
+        repo = _make_repo()
+        commit = _make_event("commit", sha="new-sha")
+        cog._service.fetch_new_commits = AsyncMock(return_value=[commit])
+        cog._service.fetch_new_prs = AsyncMock(return_value=[])
+        cog._service.fetch_new_issues = AsyncMock(return_value=[])
+        cog._poster.post_events = AsyncMock()
+        thread = MagicMock(spec=discord.Thread)
+        mock_bot.get_channel = MagicMock(return_value=thread)
+        mock_bot.repository.update_github_repo_state = AsyncMock()
+        mock_bot.repository.reset_github_failure = AsyncMock()
+
+        posted = await cog._process_repo(repo)
+
+        assert posted == 1
+        cog._poster.post_events.assert_awaited_once_with(thread, [commit])
+
+    async def test_process_repo_updates_none_for_events_without_identifiers(self, mock_bot):
+        cog = _make_cog(mock_bot)
+        repo = _make_repo()
+        commit_without_sha = _make_event("commit")
+        pr_without_number = _make_event("pull_request")
+        issue_without_number = _make_event("issue")
+        cog._service.fetch_new_commits = AsyncMock(return_value=[commit_without_sha])
+        cog._service.fetch_new_prs = AsyncMock(return_value=[pr_without_number])
+        cog._service.fetch_new_issues = AsyncMock(return_value=[issue_without_number])
+        cog._poster.post_events = AsyncMock()
+        mock_bot.get_channel = MagicMock(return_value=_make_text_channel())
+        mock_bot.repository.update_github_repo_state = AsyncMock()
+        mock_bot.repository.reset_github_failure = AsyncMock()
+
+        posted = await cog._process_repo(repo)
+
+        assert posted == 3
+        mock_bot.repository.update_github_repo_state.assert_awaited_once_with(
+            42,
+            last_commit_sha=None,
+            last_pr_number=None,
+            last_issue_number=None,
+        )
+
     async def test_process_repo_skips_post_when_channel_missing(self, mock_bot):
         cog = _make_cog(mock_bot)
         repo = _make_repo()
@@ -433,3 +516,14 @@ class TestHandleFailure:
         mock_bot.repository.set_github_repo_active.assert_awaited_once_with(42, False)
         mock_bot.notify_owner.assert_awaited_once()
         assert "disabled after 5 consecutive failures" in mock_bot.notify_owner.await_args.args[0]
+
+
+async def test_setup_adds_github_polling_cog(mock_bot):
+    from intelstream.discord.cogs.github_polling import setup
+
+    mock_bot.add_cog = AsyncMock()
+
+    await setup(mock_bot)
+
+    mock_bot.add_cog.assert_awaited_once()
+    assert isinstance(mock_bot.add_cog.await_args.args[0], GitHubPolling)

--- a/tests/test_discord/test_lore.py
+++ b/tests/test_discord/test_lore.py
@@ -171,6 +171,16 @@ class TestSplitMessage:
         assert len(parts[0]) == 2000
         assert len(parts[1]) == 1000
 
+    def test_string_like_false_value_returns_no_parts(self):
+        class FalseLongText(str):
+            def __len__(self) -> int:
+                return 3000
+
+            def __bool__(self) -> bool:
+                return False
+
+        assert _split_message(FalseLongText("content"), max_len=2000) == []
+
 
 class TestLoreQuery:
     async def test_command_temporarily_disabled(self, lore_cog, mock_interaction):
@@ -216,6 +226,18 @@ class TestLoreCogUnload:
         lore_cog._ingestion_service.stop_backfill.assert_called_once_with()
         lore_cog._flush_all_buffers.assert_awaited_once()
         lore_cog._llm_client.close.assert_awaited_once()
+
+    async def test_cog_unload_without_optional_resources_only_flushes(self, lore_cog):
+        lore_cog._index_rebuild_task = None
+        lore_cog._ingestion_service = None
+        lore_cog._llm_client = None
+        lore_cog._flush_all_buffers = AsyncMock()
+
+        with patch.object(lore_cog._flush_buffers, "cancel") as cancel:
+            await lore_cog.cog_unload()
+
+        cancel.assert_called_once_with()
+        lore_cog._flush_all_buffers.assert_awaited_once()
 
 
 class TestIndexHealth:
@@ -275,6 +297,15 @@ class TestIndexHealth:
 
         with pytest.raises(asyncio.CancelledError):
             await lore_cog._ensure_message_chunk_index()
+
+    async def test_ensure_message_chunk_index_allows_zero_recovery_attempts(
+        self, lore_cog, mock_bot, monkeypatch
+    ):
+        monkeypatch.setattr("intelstream.discord.cogs.lore.INDEX_RECOVERY_MAX_ATTEMPTS", 0)
+
+        await lore_cog._ensure_message_chunk_index()
+
+        mock_bot.repository.get_message_chunk_guild_ids.assert_not_called()
 
     async def test_message_index_healthy(self, lore_cog, mock_bot, mock_vector_store):
         mock_bot.repository.get_message_chunk_metas_batch.return_value = [
@@ -549,6 +580,31 @@ class TestFlushBuffers:
         lore_cog._chunker.chunk_messages.assert_called_once_with([raw], "111", "222", "general")
         lore_cog._ingestion_service.store_chunks.assert_awaited_once_with([chunk])
         assert "111:222" not in lore_cog._message_buffers
+
+    async def test_flush_buffer_uses_empty_channel_name_for_non_text_channel(
+        self, lore_cog, mock_bot
+    ):
+        raw = make_raw_message(1)
+        lore_cog._message_buffers["111:222"] = [raw]
+        guild = MagicMock(spec=discord.Guild)
+        guild.get_channel.return_value = MagicMock(spec=discord.VoiceChannel)
+        mock_bot.get_guild.return_value = guild
+        chunk = MagicMock()
+        lore_cog._chunker.chunk_messages.return_value = [chunk]
+        lore_cog._ingestion_service.store_chunks = AsyncMock(return_value=1)
+
+        await lore_cog._flush_buffer("111:222")
+
+        lore_cog._chunker.chunk_messages.assert_called_once_with([raw], "111", "222", "")
+
+    async def test_flush_buffer_does_not_log_when_no_chunks_stored(self, lore_cog):
+        lore_cog._message_buffers["111:222"] = [make_raw_message(1)]
+        lore_cog._chunker.chunk_messages.return_value = [MagicMock()]
+        lore_cog._ingestion_service.store_chunks = AsyncMock(return_value=0)
+
+        await lore_cog._flush_buffer("111:222")
+
+        lore_cog._ingestion_service.store_chunks.assert_awaited_once()
 
     async def test_flush_buffer_skips_store_without_chunks_or_ingestion_service(self, lore_cog):
         lore_cog._message_buffers["111:222"] = [make_raw_message(1)]

--- a/tests/test_discord/test_lore.py
+++ b/tests/test_discord/test_lore.py
@@ -201,9 +201,7 @@ class TestLoreCogLoadWithoutApiKey:
 
 
 class TestLoreCogUnload:
-    async def test_cog_unload_cancels_rebuild_stops_backfill_flushes_and_closes_llm(
-        self, lore_cog
-    ):
+    async def test_cog_unload_cancels_rebuild_stops_backfill_flushes_and_closes_llm(self, lore_cog):
         lore_cog._index_rebuild_task = asyncio.create_task(asyncio.sleep(10))
         lore_cog._ingestion_service.is_running = True
         lore_cog._ingestion_service.stop_backfill = MagicMock()
@@ -230,9 +228,7 @@ class TestIndexHealth:
 
         mock_bot.repository.get_message_chunk_guild_ids.assert_not_called()
 
-    async def test_ensure_message_chunk_index_clears_error_when_no_chunks(
-        self, lore_cog, mock_bot
-    ):
+    async def test_ensure_message_chunk_index_clears_error_when_no_chunks(self, lore_cog, mock_bot):
         lore_cog._index_rebuild_error = "stale"
         mock_bot.repository.get_message_chunk_guild_ids.return_value = []
 
@@ -240,9 +236,7 @@ class TestIndexHealth:
 
         assert lore_cog._index_rebuild_error is None
 
-    async def test_ensure_message_chunk_index_skips_empty_guild(
-        self, lore_cog, mock_bot
-    ):
+    async def test_ensure_message_chunk_index_skips_empty_guild(self, lore_cog, mock_bot):
         mock_bot.repository.get_message_chunk_guild_ids.return_value = ["guild-1"]
         mock_bot.repository.count_message_chunk_metas.return_value = 0
 
@@ -250,9 +244,7 @@ class TestIndexHealth:
 
         lore_cog._ingestion_service.rebuild_vector_index.assert_not_called()
 
-    async def test_ensure_message_chunk_index_skips_healthy_index(
-        self, lore_cog, mock_bot
-    ):
+    async def test_ensure_message_chunk_index_skips_healthy_index(self, lore_cog, mock_bot):
         mock_bot.repository.get_message_chunk_guild_ids.return_value = ["guild-1"]
         mock_bot.repository.count_message_chunk_metas.return_value = 3
         lore_cog._message_index_is_healthy = AsyncMock(return_value=True)
@@ -276,9 +268,7 @@ class TestIndexHealth:
         assert sleep.await_count == 2
         assert lore_cog._index_rebuild_error == "RuntimeError: db locked"
 
-    async def test_ensure_message_chunk_index_reraises_cancellation(
-        self, lore_cog, mock_bot
-    ):
+    async def test_ensure_message_chunk_index_reraises_cancellation(self, lore_cog, mock_bot):
         mock_bot.repository.get_message_chunk_guild_ids = AsyncMock(
             side_effect=asyncio.CancelledError
         )
@@ -556,9 +546,7 @@ class TestFlushBuffers:
 
         await lore_cog._flush_buffer("111:222")
 
-        lore_cog._chunker.chunk_messages.assert_called_once_with(
-            [raw], "111", "222", "general"
-        )
+        lore_cog._chunker.chunk_messages.assert_called_once_with([raw], "111", "222", "general")
         lore_cog._ingestion_service.store_chunks.assert_awaited_once_with([chunk])
         assert "111:222" not in lore_cog._message_buffers
 

--- a/tests/test_discord/test_lore.py
+++ b/tests/test_discord/test_lore.py
@@ -1,12 +1,13 @@
 import asyncio
 from datetime import UTC, datetime
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import discord
 import pytest
 
 from intelstream.database.vector_store import ChunkSearchResult
 from intelstream.discord.cogs.lore import Lore, _parse_timeframe, _split_message
+from intelstream.services.message_ingestion import RawMessage
 
 
 @pytest.fixture
@@ -71,6 +72,41 @@ def mock_interaction():
     interaction.guild.text_channels = []
     interaction.guild.me = MagicMock()
     return interaction
+
+
+def make_raw_message(message_id: int = 1, *, minutes: int = 0) -> RawMessage:
+    return RawMessage(
+        id=message_id,
+        content=f"Message {message_id}",
+        author_name="alice",
+        author_bot=False,
+        created_at=datetime(2024, 6, 1, 12, minutes, tzinfo=UTC),
+        is_system=False,
+    )
+
+
+def make_discord_message(
+    *,
+    message_id: int = 12345,
+    guild_id: int = 111,
+    channel_id: int = 222,
+    content: str = "Hello world",
+    message_type: discord.MessageType = discord.MessageType.default,
+    created_at: datetime | None = None,
+) -> MagicMock:
+    msg = MagicMock(spec=discord.Message)
+    msg.guild = MagicMock()
+    msg.guild.id = guild_id
+    msg.channel = MagicMock()
+    msg.channel.id = channel_id
+    msg.author = MagicMock()
+    msg.author.bot = False
+    msg.author.display_name = "testuser"
+    msg.type = message_type
+    msg.content = content
+    msg.id = message_id
+    msg.created_at = created_at or datetime(2024, 6, 1, 12, 0, tzinfo=UTC)
+    return msg
 
 
 class TestParseTimeframe:
@@ -164,7 +200,92 @@ class TestLoreCogLoadWithoutApiKey:
             await cog._index_rebuild_task
 
 
+class TestLoreCogUnload:
+    async def test_cog_unload_cancels_rebuild_stops_backfill_flushes_and_closes_llm(
+        self, lore_cog
+    ):
+        lore_cog._index_rebuild_task = asyncio.create_task(asyncio.sleep(10))
+        lore_cog._ingestion_service.is_running = True
+        lore_cog._ingestion_service.stop_backfill = MagicMock()
+        lore_cog._flush_all_buffers = AsyncMock()
+        lore_cog._llm_client.close = AsyncMock()
+
+        with patch.object(lore_cog._flush_buffers, "cancel") as cancel:
+            await lore_cog.cog_unload()
+
+        cancel.assert_called_once_with()
+        assert lore_cog._index_rebuild_task.cancelled()
+        lore_cog._ingestion_service.stop_backfill.assert_called_once_with()
+        lore_cog._flush_all_buffers.assert_awaited_once()
+        lore_cog._llm_client.close.assert_awaited_once()
+
+
 class TestIndexHealth:
+    async def test_ensure_message_chunk_index_noops_without_ingestion_service(
+        self, lore_cog, mock_bot
+    ):
+        lore_cog._ingestion_service = None
+
+        await lore_cog._ensure_message_chunk_index()
+
+        mock_bot.repository.get_message_chunk_guild_ids.assert_not_called()
+
+    async def test_ensure_message_chunk_index_clears_error_when_no_chunks(
+        self, lore_cog, mock_bot
+    ):
+        lore_cog._index_rebuild_error = "stale"
+        mock_bot.repository.get_message_chunk_guild_ids.return_value = []
+
+        await lore_cog._ensure_message_chunk_index()
+
+        assert lore_cog._index_rebuild_error is None
+
+    async def test_ensure_message_chunk_index_skips_empty_guild(
+        self, lore_cog, mock_bot
+    ):
+        mock_bot.repository.get_message_chunk_guild_ids.return_value = ["guild-1"]
+        mock_bot.repository.count_message_chunk_metas.return_value = 0
+
+        await lore_cog._ensure_message_chunk_index()
+
+        lore_cog._ingestion_service.rebuild_vector_index.assert_not_called()
+
+    async def test_ensure_message_chunk_index_skips_healthy_index(
+        self, lore_cog, mock_bot
+    ):
+        mock_bot.repository.get_message_chunk_guild_ids.return_value = ["guild-1"]
+        mock_bot.repository.count_message_chunk_metas.return_value = 3
+        lore_cog._message_index_is_healthy = AsyncMock(return_value=True)
+
+        await lore_cog._ensure_message_chunk_index()
+
+        lore_cog._ingestion_service.rebuild_vector_index.assert_not_called()
+        assert lore_cog._index_rebuild_error is None
+
+    async def test_ensure_message_chunk_index_keeps_error_after_max_attempts(
+        self, lore_cog, mock_bot
+    ):
+        mock_bot.repository.get_message_chunk_guild_ids = AsyncMock(
+            side_effect=RuntimeError("db locked")
+        )
+
+        with patch("intelstream.discord.cogs.lore.asyncio.sleep", AsyncMock()) as sleep:
+            await lore_cog._ensure_message_chunk_index()
+
+        assert mock_bot.repository.get_message_chunk_guild_ids.await_count == 3
+        assert sleep.await_count == 2
+        assert lore_cog._index_rebuild_error == "RuntimeError: db locked"
+
+    async def test_ensure_message_chunk_index_reraises_cancellation(
+        self, lore_cog, mock_bot
+    ):
+        mock_bot.repository.get_message_chunk_guild_ids = AsyncMock(
+            side_effect=asyncio.CancelledError
+        )
+
+        with pytest.raises(asyncio.CancelledError):
+            await lore_cog._ensure_message_chunk_index()
+
     async def test_message_index_healthy(self, lore_cog, mock_bot, mock_vector_store):
         mock_bot.repository.get_message_chunk_metas_batch.return_value = [
             MagicMock(id="chunk-1", text="sample chunk text")
@@ -185,6 +306,32 @@ class TestIndexHealth:
 
         assert result is False
         mock_vector_store.search_message_chunks.assert_not_called()
+
+    async def test_message_index_healthy_when_no_sample_chunk(
+        self, lore_cog, mock_bot, mock_vector_store
+    ):
+        mock_vector_store.message_chunk_doc_count.return_value = 2
+        mock_bot.repository.get_message_chunk_metas_batch.return_value = []
+
+        result = await lore_cog._message_index_is_healthy("guild-1", expected_count=2)
+
+        assert result is True
+        mock_vector_store.search_message_chunks.assert_not_called()
+
+    async def test_message_index_unhealthy_when_probe_misses_sample(
+        self, lore_cog, mock_bot, mock_vector_store
+    ):
+        mock_bot.repository.get_message_chunk_metas_batch.return_value = [
+            MagicMock(id="chunk-1", text="[2024-01-01 00:00] alice: sample")
+        ]
+        mock_vector_store.message_chunk_doc_count.return_value = 1
+        mock_vector_store.search_message_chunks.return_value = [
+            ChunkSearchResult(chunk_id="other-chunk", score=0.5)
+        ]
+
+        result = await lore_cog._message_index_is_healthy("guild-1", expected_count=1)
+
+        assert result is False
 
     async def test_ensure_message_chunk_index_rebuilds_unhealthy_index(
         self, lore_cog, mock_bot, mock_vector_store
@@ -245,6 +392,14 @@ class TestIndexHealth:
 
 
 class TestAutoStartIngestion:
+    async def test_start_ingestion_noops_without_ingestion_service(self, lore_cog, mock_bot):
+        lore_cog._ingestion_service = None
+        guild = MagicMock(spec=discord.Guild)
+
+        await lore_cog.start_ingestion_for_guild(guild)
+
+        mock_bot.repository.get_ingestion_progress_for_guild.assert_not_called()
+
     async def test_starts_for_guild_with_no_progress(self, lore_cog, mock_bot):
         guild = MagicMock(spec=discord.Guild)
         guild.id = 111
@@ -328,20 +483,140 @@ class TestOnMessage:
         await lore_cog.on_message(msg)
         assert len(lore_cog._message_buffers) == 0
 
+    async def test_ignores_system_message_type(self, lore_cog):
+        msg = make_discord_message(message_type=discord.MessageType.pins_add)
+
+        await lore_cog.on_message(msg)
+
+        assert len(lore_cog._message_buffers) == 0
+
     async def test_buffers_valid_message(self, lore_cog):
-        msg = MagicMock(spec=discord.Message)
-        msg.guild = MagicMock()
-        msg.guild.id = 111
-        msg.channel = MagicMock()
-        msg.channel.id = 222
-        msg.author = MagicMock()
-        msg.author.bot = False
-        msg.author.display_name = "testuser"
-        msg.type = discord.MessageType.default
-        msg.content = "Hello world"
-        msg.id = 12345
-        msg.created_at = datetime(2024, 6, 1, 12, 0, tzinfo=UTC)
+        msg = make_discord_message()
 
         await lore_cog.on_message(msg)
         assert "111:222" in lore_cog._message_buffers
         assert len(lore_cog._message_buffers["111:222"]) == 1
+
+    async def test_flushes_existing_buffer_when_time_gap_exceeds_threshold(self, lore_cog):
+        lore_cog._message_buffers["111:222"] = [make_raw_message(minutes=0)]
+        lore_cog._flush_buffer = AsyncMock()
+        msg = make_discord_message(created_at=datetime(2024, 6, 1, 12, 30, tzinfo=UTC))
+
+        await lore_cog.on_message(msg)
+
+        lore_cog._flush_buffer.assert_awaited_once_with("111:222")
+        assert len(lore_cog._message_buffers["111:222"]) == 2
+
+    async def test_flushes_when_buffer_reaches_max_messages(self, lore_cog):
+        lore_cog.bot.settings.lore_chunk_max_messages = 2
+        lore_cog._flush_buffer = AsyncMock()
+
+        await lore_cog.on_message(make_discord_message(message_id=1))
+        await lore_cog.on_message(
+            make_discord_message(
+                message_id=2,
+                created_at=datetime(2024, 6, 1, 12, 1, tzinfo=UTC),
+            )
+        )
+
+        lore_cog._flush_buffer.assert_awaited_once_with("111:222")
+
+
+class TestFlushBuffers:
+    async def test_flush_buffers_flushes_non_empty_buffers(self, lore_cog):
+        lore_cog._message_buffers = {
+            "111:222": [make_raw_message(1)],
+            "111:333": [],
+        }
+        lore_cog._flush_buffer = AsyncMock()
+
+        await lore_cog._flush_buffers()
+
+        lore_cog._flush_buffer.assert_awaited_once_with("111:222")
+
+    async def test_flush_buffer_returns_for_empty_or_invalid_key(self, lore_cog):
+        lore_cog._message_buffers = {"bad-key": [make_raw_message(1)]}
+
+        await lore_cog._flush_buffer("missing")
+        await lore_cog._flush_buffer("bad-key")
+
+        lore_cog._chunker.chunk_messages.assert_not_called()
+
+    async def test_flush_buffer_uses_channel_name_and_stores_chunks(self, lore_cog, mock_bot):
+        raw = make_raw_message(1)
+        lore_cog._message_buffers["111:222"] = [raw]
+        guild = MagicMock(spec=discord.Guild)
+        channel = MagicMock(spec=discord.TextChannel)
+        channel.name = "general"
+        guild.get_channel.return_value = channel
+        mock_bot.get_guild.return_value = guild
+        chunk = MagicMock()
+        lore_cog._chunker.chunk_messages.return_value = [chunk]
+        lore_cog._ingestion_service.store_chunks = AsyncMock(return_value=1)
+
+        await lore_cog._flush_buffer("111:222")
+
+        lore_cog._chunker.chunk_messages.assert_called_once_with(
+            [raw], "111", "222", "general"
+        )
+        lore_cog._ingestion_service.store_chunks.assert_awaited_once_with([chunk])
+        assert "111:222" not in lore_cog._message_buffers
+
+    async def test_flush_buffer_skips_store_without_chunks_or_ingestion_service(self, lore_cog):
+        lore_cog._message_buffers["111:222"] = [make_raw_message(1)]
+        lore_cog._chunker.chunk_messages.return_value = []
+
+        await lore_cog._flush_buffer("111:222")
+
+        lore_cog._ingestion_service.store_chunks.assert_not_called()
+
+        lore_cog._message_buffers["111:222"] = [make_raw_message(2)]
+        lore_cog._chunker.chunk_messages.return_value = [MagicMock()]
+        lore_cog._ingestion_service = None
+
+        await lore_cog._flush_buffer("111:222")
+
+    async def test_flush_all_buffers_flushes_every_key(self, lore_cog):
+        lore_cog._message_buffers = {
+            "111:222": [make_raw_message(1)],
+            "111:333": [make_raw_message(2)],
+        }
+        lore_cog._flush_buffer = AsyncMock()
+
+        await lore_cog._flush_all_buffers()
+
+        assert [call.args[0] for call in lore_cog._flush_buffer.await_args_list] == [
+            "111:222",
+            "111:333",
+        ]
+
+
+class TestStartIndexRebuild:
+    def test_start_index_rebuild_noops_when_existing_task_running(self, lore_cog):
+        task = MagicMock(spec=asyncio.Task)
+        task.done.return_value = False
+        lore_cog._index_rebuild_task = task
+
+        with patch("intelstream.discord.cogs.lore.asyncio.create_task") as create_task:
+            lore_cog._start_index_rebuild()
+
+        create_task.assert_not_called()
+
+    def test_start_index_rebuild_creates_named_task(self, lore_cog):
+        task = MagicMock(spec=asyncio.Task)
+
+        def fake_create_task(coro, *, name: str):
+            coro.close()
+            fake_create_task.name = name
+            return task
+
+        fake_create_task.name = ""
+
+        with patch(
+            "intelstream.discord.cogs.lore.asyncio.create_task",
+            side_effect=fake_create_task,
+        ):
+            lore_cog._start_index_rebuild()
+
+        assert lore_cog._index_rebuild_task is task
+        assert fake_create_task.name == "lore-index-rebuild"

--- a/tests/test_discord/test_message_forwarding.py
+++ b/tests/test_discord/test_message_forwarding.py
@@ -115,6 +115,26 @@ class TestForwardAdd:
         call_args = interaction.followup.send.call_args
         assert "already exists" in call_args[0][0]
 
+    async def test_forward_add_ignores_existing_rule_for_different_destination(self, cog, mock_bot):
+        interaction = make_interaction()
+        interaction.guild.me = MagicMock()
+        source = make_channel(111, "#source")
+        destination = make_channel(222, "#dest")
+        permissions = MagicMock()
+        permissions.send_messages = True
+        destination.permissions_for = MagicMock(return_value=permissions)
+        existing_rule = MagicMock()
+        existing_rule.destination_channel_id = "333"
+        mock_bot.repository.get_forwarding_rules_for_source = AsyncMock(
+            return_value=[existing_rule]
+        )
+        mock_bot.repository.add_forwarding_rule = AsyncMock()
+
+        await cog.forward_add.callback(cog, interaction, source=source, destination=destination)
+
+        mock_bot.repository.add_forwarding_rule.assert_awaited_once()
+        assert "Forwarding configured" in interaction.followup.send.await_args.args[0]
+
     async def test_forward_add_bot_no_permission(self, cog, mock_bot):
         interaction = MagicMock(spec=discord.Interaction)
         interaction.response = MagicMock()

--- a/tests/test_discord/test_message_forwarding.py
+++ b/tests/test_discord/test_message_forwarding.py
@@ -264,9 +264,7 @@ class TestForwardList:
         mock_bot.repository.get_forwarding_rules_for_guild.assert_not_called()
         assert "server" in interaction.followup.send.call_args.args[0]
 
-    async def test_forward_list_resolves_destination_thread_from_guilds(
-        self, cog, mock_bot
-    ):
+    async def test_forward_list_resolves_destination_thread_from_guilds(self, cog, mock_bot):
         interaction = make_interaction()
         mock_rule = MagicMock()
         mock_rule.source_channel_id = "111"
@@ -280,7 +278,9 @@ class TestForwardList:
         guild.get_thread = MagicMock(return_value=thread)
         mock_bot.guilds = [guild]
         mock_bot.repository.get_forwarding_rules_for_guild = AsyncMock(return_value=[mock_rule])
-        mock_bot.get_channel = MagicMock(side_effect=lambda channel_id: source if channel_id == 111 else None)
+        mock_bot.get_channel = MagicMock(
+            side_effect=lambda channel_id: source if channel_id == 111 else None
+        )
 
         await cog.forward_list.callback(cog, interaction)
 
@@ -288,9 +288,7 @@ class TestForwardList:
         assert "#source -> #thread" in message
         assert "paused" in message
 
-    async def test_forward_list_uses_unknown_names_when_channels_missing(
-        self, cog, mock_bot
-    ):
+    async def test_forward_list_uses_unknown_names_when_channels_missing(self, cog, mock_bot):
         interaction = make_interaction()
         mock_rule = MagicMock()
         mock_rule.source_channel_id = "111"
@@ -672,9 +670,7 @@ class TestCacheRefresh:
 
         assert "111" not in cog._rules_cache
 
-    async def test_refresh_cache_groups_multiple_active_rules_for_same_source(
-        self, cog, mock_bot
-    ):
+    async def test_refresh_cache_groups_multiple_active_rules_for_same_source(self, cog, mock_bot):
         rule_1 = MagicMock()
         rule_1.source_channel_id = "111"
         rule_1.is_active = True

--- a/tests/test_discord/test_message_forwarding.py
+++ b/tests/test_discord/test_message_forwarding.py
@@ -2,8 +2,9 @@ from unittest.mock import AsyncMock, MagicMock
 
 import discord
 import pytest
+from discord import app_commands
 
-from intelstream.discord.cogs.message_forwarding import MessageForwarding
+from intelstream.discord.cogs.message_forwarding import MessageForwarding, setup
 
 
 @pytest.fixture
@@ -20,6 +21,27 @@ def mock_bot():
 @pytest.fixture
 def cog(mock_bot):
     return MessageForwarding(mock_bot)
+
+
+def make_interaction(*, in_guild: bool = True) -> MagicMock:
+    interaction = MagicMock(spec=discord.Interaction)
+    interaction.response = MagicMock()
+    interaction.response.defer = AsyncMock()
+    interaction.response.send_message = AsyncMock()
+    interaction.followup = MagicMock()
+    interaction.followup.send = AsyncMock()
+    interaction.user = MagicMock()
+    interaction.user.id = 123
+    interaction.guild_id = 456
+    interaction.guild = MagicMock(spec=discord.Guild) if in_guild else None
+    return interaction
+
+
+def make_channel(channel_id: int, mention: str = "#channel") -> MagicMock:
+    channel = MagicMock(spec=discord.TextChannel)
+    channel.id = channel_id
+    channel.mention = mention
+    return channel
 
 
 class TestForwardAdd:
@@ -234,6 +256,59 @@ class TestForwardList:
         call_args = interaction.followup.send.call_args
         assert "No forwarding rules" in call_args[0][0]
 
+    async def test_forward_list_not_in_guild(self, cog, mock_bot):
+        interaction = make_interaction(in_guild=False)
+
+        await cog.forward_list.callback(cog, interaction)
+
+        mock_bot.repository.get_forwarding_rules_for_guild.assert_not_called()
+        assert "server" in interaction.followup.send.call_args.args[0]
+
+    async def test_forward_list_resolves_destination_thread_from_guilds(
+        self, cog, mock_bot
+    ):
+        interaction = make_interaction()
+        mock_rule = MagicMock()
+        mock_rule.source_channel_id = "111"
+        mock_rule.destination_channel_id = "222"
+        mock_rule.is_active = False
+        mock_rule.messages_forwarded = 7
+        source = make_channel(111, "#source")
+        thread = MagicMock(spec=discord.Thread)
+        thread.mention = "#thread"
+        guild = MagicMock()
+        guild.get_thread = MagicMock(return_value=thread)
+        mock_bot.guilds = [guild]
+        mock_bot.repository.get_forwarding_rules_for_guild = AsyncMock(return_value=[mock_rule])
+        mock_bot.get_channel = MagicMock(side_effect=lambda channel_id: source if channel_id == 111 else None)
+
+        await cog.forward_list.callback(cog, interaction)
+
+        message = interaction.followup.send.call_args.args[0]
+        assert "#source -> #thread" in message
+        assert "paused" in message
+
+    async def test_forward_list_uses_unknown_names_when_channels_missing(
+        self, cog, mock_bot
+    ):
+        interaction = make_interaction()
+        mock_rule = MagicMock()
+        mock_rule.source_channel_id = "111"
+        mock_rule.destination_channel_id = "222"
+        mock_rule.is_active = True
+        mock_rule.messages_forwarded = 0
+        guild = MagicMock()
+        guild.get_thread = MagicMock(return_value=None)
+        mock_bot.guilds = [guild]
+        mock_bot.repository.get_forwarding_rules_for_guild = AsyncMock(return_value=[mock_rule])
+        mock_bot.get_channel = MagicMock(return_value=None)
+
+        await cog.forward_list.callback(cog, interaction)
+
+        message = interaction.followup.send.call_args.args[0]
+        assert "Unknown (111)" in message
+        assert "Unknown (222)" in message
+
 
 class TestForwardRemove:
     async def test_forward_remove_success(self, cog, mock_bot):
@@ -296,6 +371,16 @@ class TestForwardRemove:
 
         call_args = interaction.followup.send.call_args
         assert "No forwarding rule found" in call_args[0][0]
+
+    async def test_forward_remove_not_in_guild(self, cog, mock_bot):
+        interaction = make_interaction(in_guild=False)
+        source = make_channel(111, "#source")
+        dest = make_channel(222, "#dest")
+
+        await cog.forward_remove.callback(cog, interaction, source=source, destination=dest)
+
+        mock_bot.repository.delete_forwarding_rule.assert_not_called()
+        assert "server" in interaction.followup.send.call_args.args[0]
 
 
 class TestForwardPauseResume:
@@ -397,6 +482,36 @@ class TestForwardPauseResume:
         call_args = interaction.followup.send.call_args
         assert "No forwarding rule found" in call_args[0][0]
 
+    async def test_forward_pause_not_in_guild(self, cog, mock_bot):
+        interaction = make_interaction(in_guild=False)
+        source = make_channel(111, "#source")
+        dest = make_channel(222, "#dest")
+
+        await cog.forward_pause.callback(cog, interaction, source=source, destination=dest)
+
+        mock_bot.repository.set_forwarding_rule_active.assert_not_called()
+        assert "server" in interaction.followup.send.call_args.args[0]
+
+    async def test_forward_resume_not_in_guild(self, cog, mock_bot):
+        interaction = make_interaction(in_guild=False)
+        source = make_channel(111, "#source")
+        dest = make_channel(222, "#dest")
+
+        await cog.forward_resume.callback(cog, interaction, source=source, destination=dest)
+
+        mock_bot.repository.set_forwarding_rule_active.assert_not_called()
+        assert "server" in interaction.followup.send.call_args.args[0]
+
+    async def test_forward_resume_not_found(self, cog, mock_bot):
+        interaction = make_interaction()
+        source = make_channel(111, "#source")
+        dest = make_channel(222, "#dest")
+        mock_bot.repository.set_forwarding_rule_active = AsyncMock(return_value=False)
+
+        await cog.forward_resume.callback(cog, interaction, source=source, destination=dest)
+
+        assert "No forwarding rule found" in interaction.followup.send.call_args.args[0]
+
 
 class TestOnMessage:
     async def test_on_message_forwards_to_matching_rule(self, cog, mock_bot):
@@ -492,8 +607,40 @@ class TestOnMessage:
 
         mock_bot.repository.increment_forwarding_count.assert_not_called()
 
+    async def test_on_message_forwards_to_all_matching_rules(self, cog, mock_bot):
+        rule_1 = MagicMock()
+        rule_1.id = "rule-1"
+        rule_1.destination_channel_id = "222"
+        rule_1.destination_type = "channel"
+        rule_2 = MagicMock()
+        rule_2.id = "rule-2"
+        rule_2.destination_channel_id = "333"
+        rule_2.destination_type = "thread"
+        cog._rules_cache = {"111": [rule_1, rule_2]}
+        cog.forwarder.forward_message = AsyncMock(side_effect=[MagicMock(), MagicMock()])
+        mock_bot.repository.increment_forwarding_count = AsyncMock()
+
+        message = MagicMock(spec=discord.Message)
+        message.author = MagicMock()
+        message.guild = MagicMock()
+        message.channel = MagicMock()
+        message.channel.id = 111
+
+        await cog.on_message(message)
+
+        assert cog.forwarder.forward_message.await_count == 2
+        mock_bot.repository.increment_forwarding_count.assert_any_await("rule-1")
+        mock_bot.repository.increment_forwarding_count.assert_any_await("rule-2")
+
 
 class TestCacheRefresh:
+    async def test_on_ready_refreshes_cache(self, cog):
+        cog._refresh_cache = AsyncMock()
+
+        await cog.on_ready()
+
+        cog._refresh_cache.assert_awaited_once()
+
     async def test_refresh_cache_loads_active_rules(self, cog, mock_bot):
         mock_rule = MagicMock()
         mock_rule.source_channel_id = "111"
@@ -524,3 +671,103 @@ class TestCacheRefresh:
         await cog._refresh_cache()
 
         assert "111" not in cog._rules_cache
+
+    async def test_refresh_cache_groups_multiple_active_rules_for_same_source(
+        self, cog, mock_bot
+    ):
+        rule_1 = MagicMock()
+        rule_1.source_channel_id = "111"
+        rule_1.is_active = True
+        rule_2 = MagicMock()
+        rule_2.source_channel_id = "111"
+        rule_2.is_active = True
+        mock_guild = MagicMock()
+        mock_guild.id = 456
+        mock_bot.guilds = [mock_guild]
+        mock_bot.repository.get_forwarding_rules_for_guild = AsyncMock(
+            return_value=[rule_1, rule_2]
+        )
+
+        await cog._refresh_cache()
+
+        assert cog._rules_cache["111"] == [rule_1, rule_2]
+
+
+class TestForwardingErrors:
+    async def test_forward_add_missing_permissions_message(self, cog):
+        interaction = make_interaction()
+
+        await cog.forward_add_error(
+            interaction,
+            app_commands.MissingPermissions(["manage_guild"]),
+        )
+
+        assert "add forwarding rules" in interaction.response.send_message.call_args.args[0]
+
+    async def test_forward_add_non_permission_error_is_reraised(self, cog):
+        interaction = make_interaction()
+        error = app_commands.AppCommandError("boom")
+
+        with pytest.raises(app_commands.AppCommandError):
+            await cog.forward_add_error(interaction, error)
+
+    async def test_forward_remove_missing_permissions_message(self, cog):
+        interaction = make_interaction()
+
+        await cog.forward_remove_error(
+            interaction,
+            app_commands.MissingPermissions(["manage_guild"]),
+        )
+
+        assert "remove forwarding rules" in interaction.response.send_message.call_args.args[0]
+
+    async def test_forward_remove_non_permission_error_is_reraised(self, cog):
+        interaction = make_interaction()
+        error = app_commands.AppCommandError("boom")
+
+        with pytest.raises(app_commands.AppCommandError):
+            await cog.forward_remove_error(interaction, error)
+
+    async def test_forward_pause_missing_permissions_message(self, cog):
+        interaction = make_interaction()
+
+        await cog.forward_pause_error(
+            interaction,
+            app_commands.MissingPermissions(["manage_guild"]),
+        )
+
+        assert "pause forwarding rules" in interaction.response.send_message.call_args.args[0]
+
+    async def test_forward_pause_non_permission_error_is_reraised(self, cog):
+        interaction = make_interaction()
+        error = app_commands.AppCommandError("boom")
+
+        with pytest.raises(app_commands.AppCommandError):
+            await cog.forward_pause_error(interaction, error)
+
+    async def test_forward_resume_missing_permissions_message(self, cog):
+        interaction = make_interaction()
+
+        await cog.forward_resume_error(
+            interaction,
+            app_commands.MissingPermissions(["manage_guild"]),
+        )
+
+        assert "resume forwarding rules" in interaction.response.send_message.call_args.args[0]
+
+    async def test_forward_resume_non_permission_error_is_reraised(self, cog):
+        interaction = make_interaction()
+        error = app_commands.AppCommandError("boom")
+
+        with pytest.raises(app_commands.AppCommandError):
+            await cog.forward_resume_error(interaction, error)
+
+
+class TestSetup:
+    async def test_setup_adds_message_forwarding_cog(self, mock_bot):
+        mock_bot.add_cog = AsyncMock()
+
+        await setup(mock_bot)
+
+        mock_bot.add_cog.assert_awaited_once()
+        assert isinstance(mock_bot.add_cog.call_args.args[0], MessageForwarding)

--- a/tests/test_discord/test_search.py
+++ b/tests/test_discord/test_search.py
@@ -433,6 +433,15 @@ class TestIndex:
         with pytest.raises(asyncio.CancelledError):
             await search_cog._ensure_article_index()
 
+    async def test_ensure_article_index_allows_zero_recovery_attempts(
+        self, search_cog, mock_bot, monkeypatch
+    ):
+        monkeypatch.setattr(search_module, "INDEX_RECOVERY_MAX_ATTEMPTS", 0)
+
+        await search_cog._ensure_article_index()
+
+        mock_bot.repository.count_summarized_content_items.assert_not_called()
+
     async def test_article_index_unhealthy_when_article_counts_mismatch(self, search_cog):
         status = ArticleIndexStatus(
             expected_articles=2,

--- a/tests/test_discord/test_search.py
+++ b/tests/test_discord/test_search.py
@@ -399,9 +399,7 @@ class TestIndex:
 
         assert await search_cog._article_index_is_healthy(status) is True
 
-    async def test_article_index_unhealthy_when_sample_has_no_chunks(
-        self, search_cog, mock_bot
-    ):
+    async def test_article_index_unhealthy_when_sample_has_no_chunks(self, search_cog, mock_bot):
         status = ArticleIndexStatus(
             expected_articles=1,
             indexed_articles=1,
@@ -417,7 +415,9 @@ class TestIndex:
 
         assert await search_cog._article_index_is_healthy(status) is False
 
-    async def test_article_index_probe_matches_sample(self, search_cog, mock_bot, mock_vector_store):
+    async def test_article_index_probe_matches_sample(
+        self, search_cog, mock_bot, mock_vector_store
+    ):
         status = ArticleIndexStatus(
             expected_articles=1,
             indexed_articles=1,
@@ -523,9 +523,7 @@ class TestIndex:
 
 
 class TestSearchErrors:
-    async def test_search_cooldown_error_sends_retry_message(
-        self, search_cog, mock_interaction
-    ):
+    async def test_search_cooldown_error_sends_retry_message(self, search_cog, mock_interaction):
         error = app_commands.CommandOnCooldown(
             app_commands.Cooldown(rate=5, per=60.0), retry_after=12.8
         )

--- a/tests/test_discord/test_search.py
+++ b/tests/test_discord/test_search.py
@@ -222,6 +222,44 @@ class TestSearch:
         assert "Open article" not in embed.fields[0].value
         assert "Summary:" not in embed.fields[0].value
 
+    async def test_search_embed_omits_blank_best_match(
+        self, search_cog, mock_interaction, mock_bot
+    ):
+        mock_result = ArticleChunkSearchResult(
+            chunk_id="item-1__0000",
+            content_item_id="item-1",
+            chunk_index=0,
+            text="   ",
+            search_text="Title",
+            score=0.7,
+        )
+        search_cog._vector_store.search_article_chunks.return_value = [mock_result]
+        search_cog._reranker.rerank = AsyncMock(
+            return_value=[
+                RankedArticleChunk(
+                    chunk_id="item-1__0000",
+                    content_item_id="item-1",
+                    chunk_index=0,
+                    text="   ",
+                    vector_score=0.7,
+                    relevance_score=0.7,
+                )
+            ]
+        )
+
+        item = MagicMock()
+        item.id = "item-1"
+        item.title = "Article with summary"
+        item.summary = "Useful summary"
+        item.original_url = "https://example.com/article"
+        mock_bot.repository.get_content_items_by_ids.return_value = [item]
+
+        await search_cog.search.callback(search_cog, mock_interaction, "query")
+
+        embed = mock_interaction.followup.send.call_args.kwargs["embed"]
+        assert "Best match:" not in embed.fields[0].value
+        assert "Summary: Useful summary" in embed.fields[0].value
+
 
 class TestSearchLifecycle:
     async def test_cog_load_starts_background_rebuild(self, search_cog):
@@ -238,6 +276,13 @@ class TestSearchLifecycle:
 
         assert search_cog._index_rebuild_task.cancelled()
 
+    async def test_cog_unload_without_background_rebuild(self, search_cog):
+        search_cog._index_rebuild_task = None
+
+        await search_cog.cog_unload()
+
+        assert search_cog._index_rebuild_task is None
+
     async def test_start_index_rebuild_is_noop_when_task_running(self, search_cog):
         task = asyncio.create_task(asyncio.sleep(10))
         search_cog._index_rebuild_task = task
@@ -249,6 +294,17 @@ class TestSearchLifecycle:
             task.cancel()
             with pytest.raises(asyncio.CancelledError):
                 await task
+
+    async def test_start_index_rebuild_creates_named_task(self, search_cog):
+        search_cog._ensure_article_index = AsyncMock()
+
+        search_cog._start_index_rebuild()
+        task = search_cog._index_rebuild_task
+        assert task is not None
+        assert task.get_name() == "article-index-rebuild"
+
+        await task
+        search_cog._ensure_article_index.assert_awaited_once_with()
 
 
 class TestIndex:
@@ -311,6 +367,15 @@ class TestIndex:
         await search_cog._ensure_article_index()
 
         search_cog._rebuild_article_index.assert_awaited_once()
+
+    async def test_ensure_article_index_skips_when_no_summarized_content(self, search_cog):
+        search_cog._get_article_index_status = AsyncMock()
+        search_cog._index_rebuild_error = "RuntimeError: stale"
+
+        await search_cog._ensure_article_index()
+
+        assert search_cog._index_rebuild_error is None
+        search_cog._get_article_index_status.assert_not_awaited()
 
     async def test_ensure_article_index_retries_after_failure(
         self, search_cog, mock_bot, monkeypatch
@@ -520,6 +585,36 @@ class TestIndex:
             [0.1, 0.2, 0.3],
             topk=3,
         )
+
+    async def test_search_articles_returns_empty_when_scores_below_threshold(
+        self, search_cog, mock_bot, mock_vector_store
+    ):
+        mock_vector_store.search_article_chunks.return_value = [
+            ArticleChunkSearchResult(
+                chunk_id="item-1__0000",
+                content_item_id="item-1",
+                chunk_index=0,
+                text="Chunk",
+                search_text="Title\n\nChunk",
+                score=0.9,
+            )
+        ]
+        search_cog._reranker.rerank = AsyncMock(
+            return_value=[
+                RankedArticleChunk(
+                    chunk_id="item-1__0000",
+                    content_item_id="item-1",
+                    chunk_index=0,
+                    text="Chunk",
+                    vector_score=0.9,
+                    relevance_score=0.1,
+                )
+            ]
+        )
+        mock_bot.repository.get_content_items_by_ids = AsyncMock()
+
+        assert await search_cog._search_articles("query") == []
+        mock_bot.repository.get_content_items_by_ids.assert_not_awaited()
 
 
 class TestSearchErrors:

--- a/tests/test_discord/test_search.py
+++ b/tests/test_discord/test_search.py
@@ -3,10 +3,21 @@ from unittest.mock import AsyncMock, MagicMock
 
 import discord
 import pytest
+from discord import app_commands
 
 from intelstream.database.vector_store import ArticleChunkSearchResult
 from intelstream.discord.cogs import search as search_module
-from intelstream.discord.cogs.search import Search, _truncate
+from intelstream.discord.cogs.search import (
+    ArticleIndexStatus,
+    Search,
+    _bool_setting,
+    _clean_preview,
+    _float_setting,
+    _int_setting,
+    _str_setting,
+    _supporting_excerpt_label,
+    _truncate,
+)
 from intelstream.services.article_search import RankedArticleChunk
 
 
@@ -173,6 +184,72 @@ class TestSearch:
         msg = mock_interaction.response.send_message.call_args[0][0].lower()
         assert "recovers" in msg or "recover" in msg
 
+    async def test_search_embed_omits_empty_url_snippet_and_duplicate_summary(
+        self, search_cog, mock_interaction, mock_bot
+    ):
+        mock_result = ArticleChunkSearchResult(
+            chunk_id="item-1__0000",
+            content_item_id="item-1",
+            chunk_index=0,
+            text="Same preview",
+            search_text="Title\n\nSame preview",
+            score=0.7,
+        )
+        search_cog._vector_store.search_article_chunks.return_value = [mock_result]
+        search_cog._reranker.rerank = AsyncMock(
+            return_value=[
+                RankedArticleChunk(
+                    chunk_id="item-1__0000",
+                    content_item_id="item-1",
+                    chunk_index=0,
+                    text="Same preview",
+                    vector_score=0.7,
+                    relevance_score=0.7,
+                )
+            ]
+        )
+
+        item = MagicMock()
+        item.id = "item-1"
+        item.title = "Article without URL"
+        item.summary = "Same preview"
+        item.original_url = ""
+        mock_bot.repository.get_content_items_by_ids.return_value = [item]
+
+        await search_cog.search.callback(search_cog, mock_interaction, "query")
+
+        embed = mock_interaction.followup.send.call_args.kwargs["embed"]
+        assert "Open article" not in embed.fields[0].value
+        assert "Summary:" not in embed.fields[0].value
+
+
+class TestSearchLifecycle:
+    async def test_cog_load_starts_background_rebuild(self, search_cog):
+        search_cog._start_index_rebuild = MagicMock()
+
+        await search_cog.cog_load()
+
+        search_cog._start_index_rebuild.assert_called_once_with()
+
+    async def test_cog_unload_cancels_background_rebuild(self, search_cog):
+        search_cog._index_rebuild_task = asyncio.create_task(asyncio.sleep(10))
+
+        await search_cog.cog_unload()
+
+        assert search_cog._index_rebuild_task.cancelled()
+
+    async def test_start_index_rebuild_is_noop_when_task_running(self, search_cog):
+        task = asyncio.create_task(asyncio.sleep(10))
+        search_cog._index_rebuild_task = task
+
+        try:
+            search_cog._start_index_rebuild()
+            assert search_cog._index_rebuild_task is task
+        finally:
+            task.cancel()
+            with pytest.raises(asyncio.CancelledError):
+                await task
+
 
 class TestIndex:
     async def test_index_empty(self, search_cog, mock_interaction, mock_bot):
@@ -180,6 +257,19 @@ class TestIndex:
         await search_cog.index.callback(search_cog, mock_interaction)
         mock_interaction.followup.send.assert_called_once()
         assert "0" in mock_interaction.followup.send.call_args.args[0]
+
+    async def test_index_reports_rebuild_already_running(self, search_cog, mock_interaction):
+        search_cog._index_rebuild_task = asyncio.create_task(asyncio.sleep(10))
+
+        try:
+            await search_cog.index.callback(search_cog, mock_interaction)
+        finally:
+            search_cog._index_rebuild_task.cancel()
+            with pytest.raises(asyncio.CancelledError):
+                await search_cog._index_rebuild_task
+
+        msg = mock_interaction.followup.send.call_args.args[0]
+        assert "already" in msg
 
     async def test_index_processes_items(
         self, search_cog, mock_interaction, mock_bot, mock_embedding_service, mock_vector_store
@@ -258,6 +348,215 @@ class TestIndex:
             vector_chunks=8,
         )
 
+    async def test_ensure_article_index_gives_up_after_max_failures(
+        self, search_cog, mock_bot, monkeypatch
+    ):
+        search_cog._get_article_index_status = AsyncMock(side_effect=RuntimeError("locked"))
+        mock_bot.repository.count_summarized_content_items.return_value = 3
+        sleep_mock = AsyncMock()
+        monkeypatch.setattr("intelstream.discord.cogs.search.asyncio.sleep", sleep_mock)
+
+        await search_cog._ensure_article_index()
+
+        assert search_cog._get_article_index_status.await_count == 3
+        assert search_cog._index_rebuild_error == "RuntimeError: locked"
+
+    async def test_ensure_article_index_propagates_cancelled_error(self, search_cog, mock_bot):
+        search_cog._get_article_index_status = AsyncMock(side_effect=asyncio.CancelledError)
+        mock_bot.repository.count_summarized_content_items.return_value = 3
+
+        with pytest.raises(asyncio.CancelledError):
+            await search_cog._ensure_article_index()
+
+    async def test_article_index_unhealthy_when_article_counts_mismatch(self, search_cog):
+        status = ArticleIndexStatus(
+            expected_articles=2,
+            indexed_articles=1,
+            stored_chunks=3,
+            vector_chunks=3,
+        )
+
+        assert await search_cog._article_index_is_healthy(status) is False
+
+    async def test_article_index_unhealthy_when_chunk_counts_mismatch(self, search_cog):
+        status = ArticleIndexStatus(
+            expected_articles=2,
+            indexed_articles=2,
+            stored_chunks=3,
+            vector_chunks=2,
+        )
+
+        assert await search_cog._article_index_is_healthy(status) is False
+
+    async def test_article_index_healthy_when_no_sample_available(self, search_cog, mock_bot):
+        status = ArticleIndexStatus(
+            expected_articles=2,
+            indexed_articles=2,
+            stored_chunks=3,
+            vector_chunks=3,
+        )
+        mock_bot.repository.get_summarized_content_items.return_value = []
+
+        assert await search_cog._article_index_is_healthy(status) is True
+
+    async def test_article_index_unhealthy_when_sample_has_no_chunks(
+        self, search_cog, mock_bot
+    ):
+        status = ArticleIndexStatus(
+            expected_articles=1,
+            indexed_articles=1,
+            stored_chunks=0,
+            vector_chunks=0,
+        )
+        sample = MagicMock()
+        sample.id = "item-empty"
+        sample.title = ""
+        sample.raw_content = ""
+        sample.summary = ""
+        mock_bot.repository.get_summarized_content_items.return_value = [sample]
+
+        assert await search_cog._article_index_is_healthy(status) is False
+
+    async def test_article_index_probe_matches_sample(self, search_cog, mock_bot, mock_vector_store):
+        status = ArticleIndexStatus(
+            expected_articles=1,
+            indexed_articles=1,
+            stored_chunks=1,
+            vector_chunks=1,
+        )
+        sample = MagicMock()
+        sample.id = "item-1"
+        sample.title = "Probe"
+        sample.raw_content = "Probe body"
+        sample.summary = None
+        mock_bot.repository.get_summarized_content_items.return_value = [sample]
+        mock_vector_store.search_article_chunks.return_value = [
+            ArticleChunkSearchResult(
+                chunk_id="item-1__0000",
+                content_item_id="item-1",
+                chunk_index=0,
+                text="Probe body",
+                search_text="Probe\n\nProbe body",
+                score=0.9,
+            )
+        ]
+
+        assert await search_cog._article_index_is_healthy(status) is True
+
+    async def test_article_index_probe_misses_sample(self, search_cog, mock_bot, mock_vector_store):
+        status = ArticleIndexStatus(
+            expected_articles=1,
+            indexed_articles=1,
+            stored_chunks=1,
+            vector_chunks=1,
+        )
+        sample = MagicMock()
+        sample.id = "item-1"
+        sample.title = "Probe"
+        sample.raw_content = "Probe body"
+        sample.summary = None
+        mock_bot.repository.get_summarized_content_items.return_value = [sample]
+        mock_vector_store.search_article_chunks.return_value = [
+            ArticleChunkSearchResult(
+                chunk_id="other__0000",
+                content_item_id="other",
+                chunk_index=0,
+                text="Other body",
+                search_text="Other\n\nOther body",
+                score=0.9,
+            )
+        ]
+
+        assert await search_cog._article_index_is_healthy(status) is False
+
+    async def test_rebuild_article_index_skips_items_without_chunks(
+        self, search_cog, mock_bot, mock_embedding_service, mock_vector_store
+    ):
+        item = MagicMock()
+        item.id = "empty-item"
+        item.title = ""
+        item.raw_content = ""
+        item.summary = ""
+        mock_bot.repository.count_summarized_content_items.return_value = 1
+        mock_bot.repository.get_summarized_content_items.side_effect = [[item], []]
+
+        assert await search_cog._rebuild_article_index(batch_size=1) == (0, 0)
+        mock_embedding_service.embed_batch.assert_not_called()
+        mock_bot.repository.add_article_chunk_metas_batch.assert_not_called()
+        mock_vector_store.upsert_article_chunks_batch.assert_not_called()
+
+    async def test_search_articles_uses_result_limit_as_candidate_floor(
+        self, search_cog, mock_bot, mock_vector_store
+    ):
+        mock_bot.settings.article_search_candidate_limit = 1
+        mock_bot.settings.search_result_limit = 3
+        mock_bot.settings.article_search_min_relevance_score = 0.1
+        mock_vector_store.search_article_chunks.return_value = [
+            ArticleChunkSearchResult(
+                chunk_id="item-1__0000",
+                content_item_id="item-1",
+                chunk_index=0,
+                text="Chunk",
+                search_text="Title\n\nChunk",
+                score=0.9,
+            )
+        ]
+        search_cog._reranker.rerank = AsyncMock(
+            return_value=[
+                RankedArticleChunk(
+                    chunk_id="item-1__0000",
+                    content_item_id="item-1",
+                    chunk_index=0,
+                    text="Chunk",
+                    vector_score=0.9,
+                    relevance_score=0.9,
+                )
+            ]
+        )
+        mock_bot.repository.get_content_items_by_ids.return_value = []
+
+        assert await search_cog._search_articles("query") == []
+        mock_vector_store.search_article_chunks.assert_called_once_with(
+            [0.1, 0.2, 0.3],
+            topk=3,
+        )
+
+
+class TestSearchErrors:
+    async def test_search_cooldown_error_sends_retry_message(
+        self, search_cog, mock_interaction
+    ):
+        error = app_commands.CommandOnCooldown(
+            app_commands.Cooldown(rate=5, per=60.0), retry_after=12.8
+        )
+
+        await search_cog.search_error(mock_interaction, error)
+
+        msg = mock_interaction.response.send_message.call_args.args[0]
+        assert "12s" in msg
+
+    async def test_search_non_cooldown_error_is_reraised(self, search_cog, mock_interaction):
+        error = app_commands.MissingPermissions(["administrator"])
+
+        with pytest.raises(app_commands.MissingPermissions):
+            await search_cog.search_error(mock_interaction, error)
+
+    async def test_index_missing_permissions_error_sends_message(
+        self, search_cog, mock_interaction
+    ):
+        error = app_commands.MissingPermissions(["administrator"])
+
+        await search_cog.index_error(mock_interaction, error)
+
+        msg = mock_interaction.response.send_message.call_args.args[0]
+        assert "Administrator permissions required" in msg
+
+    async def test_index_non_permission_error_is_reraised(self, search_cog, mock_interaction):
+        error = app_commands.AppCommandError("boom")
+
+        with pytest.raises(app_commands.AppCommandError):
+            await search_cog.index_error(mock_interaction, error)
+
 
 class TestTruncate:
     def test_short_text(self):
@@ -271,3 +570,36 @@ class TestTruncate:
 
     def test_empty_text(self):
         assert _truncate("", 10) == ""
+
+
+class TestHelpers:
+    def test_clean_preview_collapses_whitespace(self):
+        assert _clean_preview("  hello\n\nworld\tagain ") == "hello world again"
+
+    def test_supporting_excerpt_label_pluralizes(self):
+        assert _supporting_excerpt_label(1) == "1 matching excerpt"
+        assert _supporting_excerpt_label(2) == "2 matching excerpts"
+
+    def test_setting_helpers_use_defaults_for_wrong_types(self):
+        settings = MagicMock()
+        settings.size = True
+        settings.score = False
+        settings.enabled = "yes"
+        settings.model = 123
+
+        assert _int_setting(settings, "size", 10) == 10
+        assert _float_setting(settings, "score", 0.5) == 0.5
+        assert _bool_setting(settings, "enabled", False) is False
+        assert _str_setting(settings, "model", "default") == "default"
+
+    def test_setting_helpers_accept_expected_types(self):
+        settings = MagicMock()
+        settings.size = 8
+        settings.score = 1
+        settings.enabled = False
+        settings.model = "reranker"
+
+        assert _int_setting(settings, "size", 10) == 8
+        assert _float_setting(settings, "score", 0.5) == 1.0
+        assert _bool_setting(settings, "enabled", True) is False
+        assert _str_setting(settings, "model", "default") == "reranker"

--- a/tests/test_discord/test_source_management.py
+++ b/tests/test_discord/test_source_management.py
@@ -651,9 +651,7 @@ class TestSourceManagementAdd:
         mock_bot.repository.add_source.assert_not_called()
         assert "URL not allowed" in interaction.followup.send.call_args.args[0]
 
-    async def test_add_handles_repository_duplicate_race(
-        self, source_management, mock_bot
-    ):
+    async def test_add_handles_repository_duplicate_race(self, source_management, mock_bot):
         interaction = make_interaction()
         source_type_choice = MagicMock()
         source_type_choice.value = "rss"
@@ -672,9 +670,7 @@ class TestSourceManagementAdd:
 
         assert "already exists" in interaction.followup.send.call_args.args[0]
 
-    async def test_add_page_stores_analyzed_extraction_profile(
-        self, source_management, mock_bot
-    ):
+    async def test_add_page_stores_analyzed_extraction_profile(self, source_management, mock_bot):
         mock_bot.settings.anthropic_api_key = "anthropic-key"
         interaction = make_interaction()
         source_type_choice = MagicMock()
@@ -690,7 +686,9 @@ class TestSourceManagementAdd:
         mock_bot.repository.get_source_by_name = AsyncMock(return_value=None)
         mock_bot.repository.add_source = AsyncMock(return_value=mock_source)
 
-        with patch("intelstream.discord.cogs.source_management.PageAnalyzer", return_value=analyzer):
+        with patch(
+            "intelstream.discord.cogs.source_management.PageAnalyzer", return_value=analyzer
+        ):
             await source_management.source_add.callback(
                 source_management,
                 interaction,
@@ -710,7 +708,9 @@ class TestSourceManagementAdd:
         analyzer = MagicMock()
         analyzer.analyze = AsyncMock(side_effect=PageAnalysisError("no posts"))
 
-        with patch("intelstream.discord.cogs.source_management.PageAnalyzer", return_value=analyzer):
+        with patch(
+            "intelstream.discord.cogs.source_management.PageAnalyzer", return_value=analyzer
+        ):
             await source_management.source_add.callback(
                 source_management,
                 interaction,
@@ -872,9 +872,7 @@ class TestSourceManagementList:
         paused_source.consecutive_failures = 0
         paused_source.last_polled_at = None
 
-        mock_bot.repository.get_all_sources = AsyncMock(
-            return_value=[failed_source, paused_source]
-        )
+        mock_bot.repository.get_all_sources = AsyncMock(return_value=[failed_source, paused_source])
 
         await source_management.source_list.callback(source_management, interaction)
 
@@ -1341,9 +1339,7 @@ class TestSourceManagementToggle:
         call_args = interaction.followup.send.call_args
         assert "No source found" in call_args[0][0]
 
-    async def test_toggle_handles_source_not_found_during_update(
-        self, source_management, mock_bot
-    ):
+    async def test_toggle_handles_source_not_found_during_update(self, source_management, mock_bot):
         interaction = make_interaction()
         mock_source = MagicMock()
         mock_source.identifier = "test-identifier"

--- a/tests/test_discord/test_source_management.py
+++ b/tests/test_discord/test_source_management.py
@@ -1,8 +1,16 @@
+import json
+from datetime import UTC, datetime
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import discord
 import pytest
+from discord import app_commands
 
+from intelstream.database.exceptions import (
+    DatabaseConnectionError,
+    DuplicateSourceError,
+    SourceNotFoundError,
+)
 from intelstream.database.models import PauseReason, SourceType
 from intelstream.discord.cogs.source_management import (
     ConfirmSourceRemoveView,
@@ -10,6 +18,7 @@ from intelstream.discord.cogs.source_management import (
     SourceManagement,
     parse_source_identifier,
 )
+from intelstream.services.page_analyzer import PageAnalysisError
 
 
 @pytest.fixture
@@ -26,6 +35,21 @@ def mock_bot():
 @pytest.fixture
 def source_management(mock_bot):
     return SourceManagement(mock_bot)
+
+
+def make_interaction() -> MagicMock:
+    interaction = MagicMock(spec=discord.Interaction)
+    interaction.response = MagicMock()
+    interaction.response.defer = AsyncMock()
+    interaction.response.send_message = AsyncMock()
+    interaction.followup = MagicMock()
+    interaction.followup.send = AsyncMock()
+    interaction.edit_original_response = AsyncMock()
+    interaction.user = MagicMock()
+    interaction.user.id = 123
+    interaction.guild_id = 456
+    interaction.channel_id = 789
+    return interaction
 
 
 class TestParseSourceIdentifier:
@@ -122,6 +146,11 @@ class TestParseSourceIdentifier:
         assert identifier == "cs.AI"
         assert feed_url == "https://arxiv.org/rss/cs.AI"
 
+    def test_parse_arxiv_url_without_scheme(self):
+        identifier, feed_url = parse_source_identifier(SourceType.ARXIV, "arxiv.org/rss/cs.AI")
+        assert identifier == "cs.AI"
+        assert feed_url == "https://arxiv.org/rss/cs.AI"
+
     def test_parse_arxiv_rss_url(self):
         identifier, feed_url = parse_source_identifier(
             SourceType.ARXIV,
@@ -134,13 +163,39 @@ class TestParseSourceIdentifier:
         with pytest.raises(InvalidSourceURLError, match=r"Expected arxiv\.org domain"):
             parse_source_identifier(SourceType.ARXIV, "https://example.com/list/cs.AI/")
 
+    def test_parse_arxiv_list_url_without_category(self):
+        with pytest.raises(InvalidSourceURLError, match=r"Expected an arxiv\.org list or RSS URL"):
+            parse_source_identifier(SourceType.ARXIV, "https://arxiv.org/list/")
+
+    def test_parse_arxiv_unexpected_path(self):
+        with pytest.raises(InvalidSourceURLError, match=r"Expected an arxiv\.org list or RSS URL"):
+            parse_source_identifier(SourceType.ARXIV, "https://arxiv.org/abs/1234.5678")
+
+    def test_parse_arxiv_invalid_category(self):
+        with pytest.raises(InvalidSourceURLError, match="Invalid Arxiv category"):
+            parse_source_identifier(SourceType.ARXIV, "cs AI!")
+
     def test_parse_page_no_host(self):
         with pytest.raises(InvalidSourceURLError, match="No host found"):
             parse_source_identifier(SourceType.PAGE, "not-a-url")
 
+    def test_parse_page_trims_trailing_slash(self):
+        identifier, feed_url = parse_source_identifier(
+            SourceType.PAGE, "https://example.com/articles/"
+        )
+        assert identifier == "example.com/articles"
+        assert feed_url == "https://example.com/articles/"
+
     def test_parse_blog_no_host(self):
         with pytest.raises(InvalidSourceURLError, match="No host found"):
             parse_source_identifier(SourceType.BLOG, "not-a-url")
+
+    def test_parse_blog_trims_trailing_slash(self):
+        identifier, feed_url = parse_source_identifier(
+            SourceType.BLOG, "https://blog.example.com/posts/"
+        )
+        assert identifier == "blog.example.com/posts"
+        assert feed_url is None
 
     def test_parse_twitter_url(self):
         identifier, feed_url = parse_source_identifier(
@@ -509,6 +564,243 @@ class TestSourceManagementAdd:
         assert call_kwargs["identifier"] == "cs.AI"
         assert call_kwargs["feed_url"] == "https://arxiv.org/rss/cs.AI"
 
+    async def test_add_invalid_source_type(self, source_management, mock_bot):
+        interaction = make_interaction()
+        source_type_choice = MagicMock()
+        source_type_choice.value = "bad-type"
+
+        await source_management.source_add.callback(
+            source_management,
+            interaction,
+            source_type=source_type_choice,
+            name="Bad",
+            url="https://example.com/feed",
+        )
+
+        mock_bot.repository.add_source.assert_not_called()
+        assert "Invalid source type" in interaction.followup.send.call_args.args[0]
+
+    async def test_add_page_without_anthropic_key(self, source_management, mock_bot):
+        mock_bot.settings.anthropic_api_key = None
+        interaction = make_interaction()
+        source_type_choice = MagicMock()
+        source_type_choice.value = "page"
+
+        await source_management.source_add.callback(
+            source_management,
+            interaction,
+            source_type=source_type_choice,
+            name="Page",
+            url="https://example.com/news",
+        )
+
+        mock_bot.repository.add_source.assert_not_called()
+        assert "not available" in interaction.followup.send.call_args.args[0]
+
+    async def test_add_blog_without_anthropic_key(self, source_management, mock_bot):
+        mock_bot.settings.anthropic_api_key = None
+        interaction = make_interaction()
+        source_type_choice = MagicMock()
+        source_type_choice.value = "blog"
+
+        await source_management.source_add.callback(
+            source_management,
+            interaction,
+            source_type=source_type_choice,
+            name="Blog",
+            url="https://blog.example.com",
+        )
+
+        mock_bot.repository.add_source.assert_not_called()
+        assert "not available" in interaction.followup.send.call_args.args[0]
+
+    async def test_add_invalid_url_reports_parse_error(self, source_management, mock_bot):
+        interaction = make_interaction()
+        source_type_choice = MagicMock()
+        source_type_choice.value = "rss"
+
+        await source_management.source_add.callback(
+            source_management,
+            interaction,
+            source_type=source_type_choice,
+            name="Feed",
+            url="not-a-url",
+        )
+
+        mock_bot.repository.add_source.assert_not_called()
+        assert "Invalid RSS URL" in interaction.followup.send.call_args.args[0]
+
+    async def test_add_rejects_unsafe_url(self, source_management, mock_bot):
+        interaction = make_interaction()
+        source_type_choice = MagicMock()
+        source_type_choice.value = "rss"
+        source_type_choice.name = "RSS"
+
+        with patch(
+            "intelstream.discord.cogs.source_management.is_safe_url",
+            return_value=(False, "private address"),
+        ):
+            await source_management.source_add.callback(
+                source_management,
+                interaction,
+                source_type=source_type_choice,
+                name="Feed",
+                url="https://example.com/feed.xml",
+            )
+
+        mock_bot.repository.add_source.assert_not_called()
+        assert "URL not allowed" in interaction.followup.send.call_args.args[0]
+
+    async def test_add_handles_repository_duplicate_race(
+        self, source_management, mock_bot
+    ):
+        interaction = make_interaction()
+        source_type_choice = MagicMock()
+        source_type_choice.value = "rss"
+        source_type_choice.name = "RSS"
+        mock_bot.repository.get_source_by_identifier = AsyncMock(return_value=None)
+        mock_bot.repository.get_source_by_name = AsyncMock(return_value=None)
+        mock_bot.repository.add_source = AsyncMock(side_effect=DuplicateSourceError("dupe"))
+
+        await source_management.source_add.callback(
+            source_management,
+            interaction,
+            source_type=source_type_choice,
+            name="Feed",
+            url="https://example.com/feed.xml",
+        )
+
+        assert "already exists" in interaction.followup.send.call_args.args[0]
+
+    async def test_add_page_stores_analyzed_extraction_profile(
+        self, source_management, mock_bot
+    ):
+        mock_bot.settings.anthropic_api_key = "anthropic-key"
+        interaction = make_interaction()
+        source_type_choice = MagicMock()
+        source_type_choice.value = "page"
+        source_type_choice.name = "Page"
+        profile = MagicMock()
+        profile.to_dict.return_value = {"post_selector": "article"}
+        analyzer = MagicMock()
+        analyzer.analyze = AsyncMock(return_value=profile)
+        mock_source = MagicMock()
+        mock_source.id = "source-id"
+        mock_bot.repository.get_source_by_identifier = AsyncMock(return_value=None)
+        mock_bot.repository.get_source_by_name = AsyncMock(return_value=None)
+        mock_bot.repository.add_source = AsyncMock(return_value=mock_source)
+
+        with patch("intelstream.discord.cogs.source_management.PageAnalyzer", return_value=analyzer):
+            await source_management.source_add.callback(
+                source_management,
+                interaction,
+                source_type=source_type_choice,
+                name="Page",
+                url="https://example.com/news",
+            )
+
+        call_kwargs = mock_bot.repository.add_source.call_args.kwargs
+        assert json.loads(call_kwargs["extraction_profile"]) == {"post_selector": "article"}
+
+    async def test_add_page_reports_analysis_error(self, source_management, mock_bot):
+        mock_bot.settings.anthropic_api_key = "anthropic-key"
+        interaction = make_interaction()
+        source_type_choice = MagicMock()
+        source_type_choice.value = "page"
+        analyzer = MagicMock()
+        analyzer.analyze = AsyncMock(side_effect=PageAnalysisError("no posts"))
+
+        with patch("intelstream.discord.cogs.source_management.PageAnalyzer", return_value=analyzer):
+            await source_management.source_add.callback(
+                source_management,
+                interaction,
+                source_type=source_type_choice,
+                name="Page",
+                url="https://example.com/news",
+            )
+
+        mock_bot.repository.add_source.assert_not_called()
+        assert "Failed to analyze page structure" in interaction.followup.send.call_args.args[0]
+
+    async def test_add_blog_uses_discovered_metadata(self, source_management, mock_bot):
+        mock_bot.settings.anthropic_api_key = "anthropic-key"
+        interaction = make_interaction()
+        source_type_choice = MagicMock()
+        source_type_choice.value = "blog"
+        source_type_choice.name = "Blog"
+        result = MagicMock()
+        result.success = True
+        result.strategy = "rss"
+        result.feed_url = "https://blog.example.com/feed"
+        result.url_pattern = "/posts/*"
+        result.post_count = 12
+        adapter = MagicMock()
+        adapter.analyze_site = AsyncMock(return_value=result)
+        mock_source = MagicMock()
+        mock_source.id = "source-id"
+        mock_bot.repository.get_source_by_identifier = AsyncMock(return_value=None)
+        mock_bot.repository.get_source_by_name = AsyncMock(return_value=None)
+        mock_bot.repository.add_source = AsyncMock(return_value=mock_source)
+
+        with (
+            patch.object(source_management, "_get_anthropic_client", return_value=MagicMock()),
+            patch(
+                "intelstream.discord.cogs.source_management.is_safe_url",
+                return_value=(True, None),
+            ),
+            patch(
+                "intelstream.discord.cogs.source_management.SmartBlogAdapter",
+                return_value=adapter,
+            ),
+        ):
+            await source_management.source_add.callback(
+                source_management,
+                interaction,
+                source_type=source_type_choice,
+                name="Blog",
+                url="https://blog.example.com",
+            )
+
+        call_kwargs = mock_bot.repository.add_source.call_args.kwargs
+        assert call_kwargs["feed_url"] == "https://blog.example.com/feed"
+        assert call_kwargs["discovery_strategy"] == "rss"
+        assert call_kwargs["url_pattern"] == "/posts/*"
+        embed = interaction.followup.send.call_args.kwargs["embed"]
+        assert any(field.name == "Discovery Strategy" for field in embed.fields)
+
+    async def test_add_blog_reports_analysis_failure(self, source_management, mock_bot):
+        mock_bot.settings.anthropic_api_key = "anthropic-key"
+        interaction = make_interaction()
+        source_type_choice = MagicMock()
+        source_type_choice.value = "blog"
+        result = MagicMock()
+        result.success = False
+        result.error = "no strategy"
+        adapter = MagicMock()
+        adapter.analyze_site = AsyncMock(return_value=result)
+
+        with (
+            patch.object(source_management, "_get_anthropic_client", return_value=MagicMock()),
+            patch(
+                "intelstream.discord.cogs.source_management.is_safe_url",
+                return_value=(True, None),
+            ),
+            patch(
+                "intelstream.discord.cogs.source_management.SmartBlogAdapter",
+                return_value=adapter,
+            ),
+        ):
+            await source_management.source_add.callback(
+                source_management,
+                interaction,
+                source_type=source_type_choice,
+                name="Blog",
+                url="https://blog.example.com",
+            )
+
+        mock_bot.repository.add_source.assert_not_called()
+        assert "Failed to analyze blog" in interaction.followup.send.call_args.args[0]
+
 
 class TestSourceManagementList:
     async def test_list_sources_empty(self, source_management, mock_bot):
@@ -559,6 +851,38 @@ class TestSourceManagementList:
         embed = call_kwargs["embed"]
         assert len(embed.fields) == 2
 
+    async def test_list_sources_formats_failure_pause_and_last_poll(
+        self, source_management, mock_bot
+    ):
+        interaction = make_interaction()
+
+        failed_source = MagicMock()
+        failed_source.name = "Failed"
+        failed_source.type = SourceType.RSS
+        failed_source.is_active = False
+        failed_source.pause_reason = PauseReason.CONSECUTIVE_FAILURES.value
+        failed_source.consecutive_failures = 4
+        failed_source.last_polled_at = datetime(2026, 1, 2, 3, 4, tzinfo=UTC)
+
+        paused_source = MagicMock()
+        paused_source.name = "Paused"
+        paused_source.type = SourceType.BLOG
+        paused_source.is_active = False
+        paused_source.pause_reason = PauseReason.NONE.value
+        paused_source.consecutive_failures = 0
+        paused_source.last_polled_at = None
+
+        mock_bot.repository.get_all_sources = AsyncMock(
+            return_value=[failed_source, paused_source]
+        )
+
+        await source_management.source_list.callback(source_management, interaction)
+
+        embed = interaction.followup.send.call_args.kwargs["embed"]
+        assert "Disabled: 4 consecutive failures" in embed.fields[0].value
+        assert "2026-01-02 03:04 UTC" in embed.fields[0].value
+        assert "**Status:** Paused" in embed.fields[1].value
+
 
 class TestSourceManagementRemove:
     def _make_confirmed_view(self) -> MagicMock:
@@ -571,6 +895,12 @@ class TestSourceManagementRemove:
         view = MagicMock(spec=ConfirmSourceRemoveView)
         view.confirmed = False
         view.wait = AsyncMock(return_value=False)
+        return view
+
+    def _make_timed_out_view(self) -> MagicMock:
+        view = MagicMock(spec=ConfirmSourceRemoveView)
+        view.confirmed = None
+        view.wait = AsyncMock(return_value=True)
         return view
 
     @patch("intelstream.discord.cogs.source_management.ConfirmSourceRemoveView")
@@ -665,6 +995,72 @@ class TestSourceManagementRemove:
         mock_bot.repository.set_source_active.assert_not_called()
         msg = interaction.edit_original_response.call_args.kwargs["content"]
         assert "cancelled" in msg
+
+    @patch("intelstream.discord.cogs.source_management.ConfirmSourceRemoveView")
+    async def test_remove_source_timeout_cancels(self, mock_view_cls, source_management, mock_bot):
+        mock_view_cls.return_value = self._make_timed_out_view()
+        interaction = make_interaction()
+        mock_source = MagicMock()
+        mock_source.identifier = "test-identifier"
+        mock_source.id = "source-id-1"
+        mock_source.type = SourceType.SUBSTACK
+        mock_source.is_active = True
+        mock_bot.repository.get_source_by_name = AsyncMock(return_value=mock_source)
+        mock_bot.repository.get_content_count_for_source = AsyncMock(return_value=0)
+
+        await source_management.source_remove.callback(
+            source_management, interaction, name="Test Source"
+        )
+
+        mock_bot.repository.set_source_active.assert_not_called()
+        msg = interaction.edit_original_response.call_args.kwargs["content"]
+        assert "cancelled" in msg
+
+    @patch("intelstream.discord.cogs.source_management.ConfirmSourceRemoveView")
+    async def test_remove_source_handles_source_not_found_during_archive(
+        self, mock_view_cls, source_management, mock_bot
+    ):
+        mock_view_cls.return_value = self._make_confirmed_view()
+        interaction = make_interaction()
+        mock_source = MagicMock()
+        mock_source.identifier = "test-identifier"
+        mock_source.id = "source-id-1"
+        mock_source.type = SourceType.SUBSTACK
+        mock_source.is_active = True
+        mock_bot.repository.get_source_by_name = AsyncMock(return_value=mock_source)
+        mock_bot.repository.get_content_count_for_source = AsyncMock(return_value=0)
+        mock_bot.repository.set_source_active = AsyncMock(side_effect=SourceNotFoundError("gone"))
+
+        await source_management.source_remove.callback(
+            source_management, interaction, name="Test Source"
+        )
+
+        msg = interaction.edit_original_response.call_args.kwargs["content"]
+        assert "already archived or removed" in msg
+
+    @patch("intelstream.discord.cogs.source_management.ConfirmSourceRemoveView")
+    async def test_remove_source_handles_database_error(
+        self, mock_view_cls, source_management, mock_bot
+    ):
+        mock_view_cls.return_value = self._make_confirmed_view()
+        interaction = make_interaction()
+        mock_source = MagicMock()
+        mock_source.identifier = "test-identifier"
+        mock_source.id = "source-id-1"
+        mock_source.type = SourceType.SUBSTACK
+        mock_source.is_active = True
+        mock_bot.repository.get_source_by_name = AsyncMock(return_value=mock_source)
+        mock_bot.repository.get_content_count_for_source = AsyncMock(return_value=0)
+        mock_bot.repository.set_source_active = AsyncMock(
+            side_effect=DatabaseConnectionError("db down")
+        )
+
+        await source_management.source_remove.callback(
+            source_management, interaction, name="Test Source"
+        )
+
+        msg = interaction.edit_original_response.call_args.kwargs["content"]
+        assert "database error" in msg
 
     async def test_remove_source_not_found(self, source_management, mock_bot):
         interaction = MagicMock(spec=discord.Interaction)
@@ -844,6 +1240,32 @@ class TestSourceManagementInfo:
         assert "URL Pattern" in field_names
         assert "Feed URL" not in field_names
 
+    async def test_info_generic_paused_source_with_last_poll(self, source_management, mock_bot):
+        interaction = make_interaction()
+        mock_source = MagicMock()
+        mock_source.name = "Paused Source"
+        mock_source.type = SourceType.RSS
+        mock_source.identifier = "example.com/feed"
+        mock_source.is_active = False
+        mock_source.pause_reason = PauseReason.NONE.value
+        mock_source.feed_url = None
+        mock_source.discovery_strategy = None
+        mock_source.url_pattern = None
+        mock_source.consecutive_failures = 0
+        mock_source.skip_summary = False
+        mock_source.last_polled_at = datetime(2026, 1, 2, 3, 4, tzinfo=UTC)
+        mock_bot.repository.get_source_by_name = AsyncMock(return_value=mock_source)
+
+        await source_management.source_info.callback(
+            source_management, interaction, name="Paused Source"
+        )
+
+        embed = interaction.followup.send.call_args.kwargs["embed"]
+        status_field = next(f for f in embed.fields if f.name == "Status")
+        last_poll_field = next(f for f in embed.fields if f.name == "Last Poll")
+        assert status_field.value == "Paused"
+        assert last_poll_field.value == "2026-01-02 03:04 UTC"
+
 
 class TestSourceManagementToggle:
     async def test_toggle_source_enable(self, source_management, mock_bot):
@@ -918,6 +1340,38 @@ class TestSourceManagementToggle:
         mock_bot.repository.set_source_active.assert_not_called()
         call_args = interaction.followup.send.call_args
         assert "No source found" in call_args[0][0]
+
+    async def test_toggle_handles_source_not_found_during_update(
+        self, source_management, mock_bot
+    ):
+        interaction = make_interaction()
+        mock_source = MagicMock()
+        mock_source.identifier = "test-identifier"
+        mock_source.is_active = False
+        mock_bot.repository.get_source_by_name = AsyncMock(return_value=mock_source)
+        mock_bot.repository.set_source_active = AsyncMock(side_effect=SourceNotFoundError("gone"))
+
+        await source_management.source_toggle.callback(
+            source_management, interaction, name="Test Source"
+        )
+
+        assert "no longer exists" in interaction.followup.send.call_args.args[0]
+
+    async def test_toggle_handles_database_error(self, source_management, mock_bot):
+        interaction = make_interaction()
+        mock_source = MagicMock()
+        mock_source.identifier = "test-identifier"
+        mock_source.is_active = True
+        mock_bot.repository.get_source_by_name = AsyncMock(return_value=mock_source)
+        mock_bot.repository.set_source_active = AsyncMock(
+            side_effect=DatabaseConnectionError("db down")
+        )
+
+        await source_management.source_toggle.callback(
+            source_management, interaction, name="Test Source"
+        )
+
+        assert "database error" in interaction.followup.send.call_args.args[0]
 
 
 class TestSourceAutocomplete:
@@ -995,3 +1449,77 @@ class TestSourceAutocomplete:
         choices = await source_management._source_name_autocomplete(interaction, "")
 
         assert "(rss)" in choices[0].name
+
+
+class TestSourceManagementLifecycle:
+    def test_get_anthropic_client_is_cached(self, source_management, mock_bot):
+        mock_bot.settings.anthropic_api_key = "anthropic-key"
+        with patch("intelstream.discord.cogs.source_management.anthropic.AsyncAnthropic") as cls:
+            first = source_management._get_anthropic_client()
+            second = source_management._get_anthropic_client()
+
+        assert first is second
+        cls.assert_called_once_with(api_key="anthropic-key")
+
+    async def test_setup_adds_cog(self, mock_bot):
+        from intelstream.discord.cogs.source_management import setup
+
+        mock_bot.add_cog = AsyncMock()
+
+        await setup(mock_bot)
+
+        mock_bot.add_cog.assert_awaited_once()
+        assert isinstance(mock_bot.add_cog.call_args.args[0], SourceManagement)
+
+
+class TestSourceManagementErrors:
+    async def test_source_add_missing_permissions_message(self, source_management):
+        interaction = make_interaction()
+
+        await source_management.source_add_error(
+            interaction,
+            app_commands.MissingPermissions(["manage_guild"]),
+        )
+
+        assert "Manage Server" in interaction.response.send_message.call_args.args[0]
+
+    async def test_source_add_non_permission_error_is_reraised(self, source_management):
+        interaction = make_interaction()
+        error = app_commands.AppCommandError("boom")
+
+        with pytest.raises(app_commands.AppCommandError):
+            await source_management.source_add_error(interaction, error)
+
+    async def test_source_remove_missing_permissions_message(self, source_management):
+        interaction = make_interaction()
+
+        await source_management.source_remove_error(
+            interaction,
+            app_commands.MissingPermissions(["manage_guild"]),
+        )
+
+        assert "remove sources" in interaction.response.send_message.call_args.args[0]
+
+    async def test_source_remove_non_permission_error_is_reraised(self, source_management):
+        interaction = make_interaction()
+        error = app_commands.AppCommandError("boom")
+
+        with pytest.raises(app_commands.AppCommandError):
+            await source_management.source_remove_error(interaction, error)
+
+    async def test_source_toggle_missing_permissions_message(self, source_management):
+        interaction = make_interaction()
+
+        await source_management.source_toggle_error(
+            interaction,
+            app_commands.MissingPermissions(["manage_guild"]),
+        )
+
+        assert "toggle sources" in interaction.response.send_message.call_args.args[0]
+
+    async def test_source_toggle_non_permission_error_is_reraised(self, source_management):
+        interaction = make_interaction()
+        error = app_commands.AppCommandError("boom")
+
+        with pytest.raises(app_commands.AppCommandError):
+            await source_management.source_toggle_error(interaction, error)

--- a/tests/test_discord/test_source_management.py
+++ b/tests/test_discord/test_source_management.py
@@ -1,5 +1,6 @@
 import json
 from datetime import UTC, datetime
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import discord
@@ -68,6 +69,10 @@ class TestParseSourceIdentifier:
         )
         assert identifier == "newsletter.example.com"
         assert feed_url == "https://newsletter.example.com/feed"
+
+    def test_parse_substack_no_host(self):
+        with pytest.raises(InvalidSourceURLError, match="No host found"):
+            parse_source_identifier(SourceType.SUBSTACK, "not-a-url")
 
     def test_parse_youtube_handle(self):
         identifier, feed_url = parse_source_identifier(
@@ -167,6 +172,22 @@ class TestParseSourceIdentifier:
         with pytest.raises(InvalidSourceURLError, match=r"Expected an arxiv\.org list or RSS URL"):
             parse_source_identifier(SourceType.ARXIV, "https://arxiv.org/list/")
 
+    def test_parse_arxiv_list_url_with_unextractable_category(self):
+        class PersistentListPath(str):
+            def rstrip(self, _chars: str | None = None) -> str:
+                return self
+
+        parsed = SimpleNamespace(
+            scheme="https",
+            netloc="arxiv.org",
+            path=PersistentListPath("/list/"),
+        )
+        with (
+            patch("intelstream.discord.cogs.source_management.urlparse", return_value=parsed),
+            pytest.raises(InvalidSourceURLError, match="Could not extract category"),
+        ):
+            parse_source_identifier(SourceType.ARXIV, "https://arxiv.org/list/")
+
     def test_parse_arxiv_unexpected_path(self):
         with pytest.raises(InvalidSourceURLError, match=r"Expected an arxiv\.org list or RSS URL"):
             parse_source_identifier(SourceType.ARXIV, "https://arxiv.org/abs/1234.5678")
@@ -239,6 +260,32 @@ class TestParseSourceIdentifier:
     def test_parse_twitter_wrong_domain(self):
         with pytest.raises(InvalidSourceURLError, match=r"Expected twitter\.com or x\.com"):
             parse_source_identifier(SourceType.TWITTER, "https://example.com/user")
+
+    def test_parse_unknown_source_type_returns_url(self):
+        identifier, feed_url = parse_source_identifier(object(), "raw-source")
+
+        assert identifier == "raw-source"
+        assert feed_url is None
+
+
+class TestConfirmSourceRemoveView:
+    async def test_confirm_button_marks_confirmed_and_defers(self):
+        view = ConfirmSourceRemoveView()
+        interaction = make_interaction()
+
+        await view.children[0].callback(interaction)
+
+        assert view.confirmed is True
+        interaction.response.defer.assert_awaited_once()
+
+    async def test_cancel_button_marks_rejected_and_defers(self):
+        view = ConfirmSourceRemoveView()
+        interaction = make_interaction()
+
+        await view.children[1].callback(interaction)
+
+        assert view.confirmed is False
+        interaction.response.defer.assert_awaited_once()
 
 
 class TestSourceManagementAdd:
@@ -614,6 +661,23 @@ class TestSourceManagementAdd:
         mock_bot.repository.add_source.assert_not_called()
         assert "not available" in interaction.followup.send.call_args.args[0]
 
+    async def test_add_source_without_interaction_channel(self, source_management, mock_bot):
+        interaction = make_interaction()
+        interaction.channel_id = None
+        source_type_choice = MagicMock()
+        source_type_choice.value = "rss"
+
+        await source_management.source_add.callback(
+            source_management,
+            interaction,
+            source_type=source_type_choice,
+            name="Feed",
+            url="https://example.com/feed.xml",
+        )
+
+        mock_bot.repository.add_source.assert_not_called()
+        assert "Could not determine target channel" in interaction.followup.send.call_args.args[0]
+
     async def test_add_invalid_url_reports_parse_error(self, source_management, mock_bot):
         interaction = make_interaction()
         source_type_choice = MagicMock()
@@ -721,6 +785,38 @@ class TestSourceManagementAdd:
 
         mock_bot.repository.add_source.assert_not_called()
         assert "Failed to analyze page structure" in interaction.followup.send.call_args.args[0]
+
+    async def test_add_page_rechecks_anthropic_key_before_analysis(
+        self, source_management, mock_bot
+    ):
+        class SettingsWithClearedAnthropicKey:
+            default_poll_interval_minutes = 5
+            twitter_bearer_token = "test-twitter-token"
+            youtube_api_key = "test-api-key"
+
+            def __init__(self) -> None:
+                self.calls = 0
+
+            @property
+            def anthropic_api_key(self) -> str | None:
+                self.calls += 1
+                return "anthropic-key" if self.calls == 1 else None
+
+        mock_bot.settings = SettingsWithClearedAnthropicKey()
+        interaction = make_interaction()
+        source_type_choice = MagicMock()
+        source_type_choice.value = "page"
+
+        await source_management.source_add.callback(
+            source_management,
+            interaction,
+            source_type=source_type_choice,
+            name="Page",
+            url="https://example.com/news",
+        )
+
+        mock_bot.repository.add_source.assert_not_called()
+        assert "require ANTHROPIC_API_KEY" in interaction.followup.send.call_args.args[0]
 
     async def test_add_blog_uses_discovered_metadata(self, source_management, mock_bot):
         mock_bot.settings.anthropic_api_key = "anthropic-key"
@@ -1445,6 +1541,29 @@ class TestSourceAutocomplete:
         choices = await source_management._source_name_autocomplete(interaction, "")
 
         assert "(rss)" in choices[0].name
+
+    async def test_command_autocomplete_wrappers_delegate(self, source_management, mock_bot):
+        interaction = MagicMock(spec=discord.Interaction)
+        interaction.channel_id = 789
+        sources = [self._make_source("My Feed", SourceType.RSS, True)]
+        mock_bot.repository.get_all_sources = AsyncMock(return_value=sources)
+
+        remove_choices = await source_management.source_remove_autocomplete(
+            interaction,
+            "feed",
+        )
+        info_choices = await source_management.source_info_autocomplete(
+            interaction,
+            "feed",
+        )
+        toggle_choices = await source_management.source_toggle_autocomplete(
+            interaction,
+            "feed",
+        )
+
+        assert [choice.value for choice in remove_choices] == ["My Feed"]
+        assert [choice.value for choice in info_choices] == ["My Feed"]
+        assert [choice.value for choice in toggle_choices] == ["My Feed"]
 
 
 class TestSourceManagementLifecycle:

--- a/tests/test_discord/test_suck_boobs.py
+++ b/tests/test_discord/test_suck_boobs.py
@@ -157,6 +157,28 @@ class TestScoreCommand:
         assert "Known User: 4" in embed.fields[0].value
         assert "Unknown (20): 7" in embed.fields[1].value
 
+    async def test_score_renders_unknown_user_and_known_pinged_member(self):
+        bot = MagicMock()
+        bot.repository.get_suck_boobs_leaderboard = AsyncMock(
+            return_value=(
+                [SimpleNamespace(user_id="10", times_used=4)],
+                [SimpleNamespace(user_id="20", times_pinged=7)],
+            )
+        )
+        cog = SuckBoobs(bot)
+        interaction = make_interaction()
+        member = MagicMock(spec=discord.Member)
+        member.display_name = "Known Pinged"
+        interaction.guild.fetch_member = AsyncMock(
+            side_effect=[discord.DiscordException("missing"), member]
+        )
+
+        await cog.suck_boobs_score.callback(cog, interaction)
+
+        embed = interaction.followup.send.await_args.kwargs["embed"]
+        assert "Unknown (10): 4" in embed.fields[0].value
+        assert "Known Pinged: 7" in embed.fields[1].value
+
 
 class TestSetup:
     async def test_setup_registers_cog(self):

--- a/tests/test_discord/test_suck_boobs.py
+++ b/tests/test_discord/test_suck_boobs.py
@@ -1,0 +1,170 @@
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import discord
+
+from intelstream.discord.cogs.suck_boobs import SuckBoobs, setup
+
+
+def make_member(member_id: int, *, bot: bool = False, display_name: str | None = None):
+    member = MagicMock(spec=discord.Member)
+    member.id = member_id
+    member.bot = bot
+    member.display_name = display_name or f"User {member_id}"
+    return member
+
+
+def make_interaction():
+    interaction = MagicMock(spec=discord.Interaction)
+    interaction.guild = MagicMock(spec=discord.Guild)
+    interaction.guild_id = 123
+    interaction.user = make_member(1, display_name="Caller")
+    interaction.response = MagicMock()
+    interaction.response.send_message = AsyncMock()
+    interaction.response.defer = AsyncMock()
+    interaction.followup = MagicMock()
+    interaction.followup.send = AsyncMock()
+    return interaction
+
+
+class TestRandomMemberSelection:
+    def test_get_random_member_excludes_bots_and_requester(self):
+        cog = SuckBoobs(MagicMock())
+        target = make_member(3)
+        members = [make_member(1), make_member(2, bot=True), target]
+
+        with patch("intelstream.discord.cogs.suck_boobs.random.choice", return_value=target):
+            assert cog._get_random_member(members, exclude_id=1) == target
+
+    def test_get_random_member_returns_none_without_eligible_members(self):
+        cog = SuckBoobs(MagicMock())
+
+        assert cog._get_random_member([make_member(1), make_member(2, bot=True)], 1) is None
+
+
+class TestCommand:
+    async def test_rejects_dm_or_non_channel_interaction(self):
+        cog = SuckBoobs(MagicMock())
+        interaction = make_interaction()
+        interaction.guild = None
+        interaction.channel = MagicMock()
+
+        await cog.suck_boobs.callback(cog, interaction)
+
+        interaction.response.send_message.assert_awaited_once_with(
+            "This command can only be used in a server channel.",
+            ephemeral=True,
+        )
+
+    async def test_rejects_when_no_eligible_target(self):
+        bot = MagicMock()
+        bot.repository.record_suck_boobs_usage = AsyncMock()
+        cog = SuckBoobs(bot)
+        interaction = make_interaction()
+        interaction.channel = MagicMock(spec=discord.TextChannel)
+        interaction.channel.members = [interaction.user, make_member(2, bot=True)]
+
+        await cog.suck_boobs.callback(cog, interaction)
+
+        interaction.response.send_message.assert_awaited_once_with(
+            "No eligible users found in this channel.",
+            ephemeral=True,
+        )
+        bot.repository.record_suck_boobs_usage.assert_not_awaited()
+
+    async def test_records_usage_and_sends_normal_response(self):
+        bot = MagicMock()
+        bot.repository.record_suck_boobs_usage = AsyncMock()
+        cog = SuckBoobs(bot)
+        interaction = make_interaction()
+        target = make_member(2, display_name="Target")
+        interaction.channel = MagicMock(spec=discord.TextChannel)
+        interaction.channel.members = [interaction.user, target]
+
+        with patch("intelstream.discord.cogs.suck_boobs.random.randint", return_value=2):
+            await cog.suck_boobs.callback(cog, interaction)
+
+        bot.repository.record_suck_boobs_usage.assert_awaited_once_with(
+            guild_id="123",
+            user_id="1",
+            pinged_user_id="2",
+        )
+        message = interaction.response.send_message.await_args.args[0]
+        assert "Caller" in message
+        assert "<@2>" in message
+
+    async def test_rare_response_still_records_usage(self):
+        bot = MagicMock()
+        bot.repository.record_suck_boobs_usage = AsyncMock()
+        cog = SuckBoobs(bot)
+        interaction = make_interaction()
+        target = make_member(2)
+        interaction.channel = MagicMock(spec=discord.Thread)
+        interaction.channel.members = [interaction.user, target]
+
+        with patch("intelstream.discord.cogs.suck_boobs.random.randint", return_value=1):
+            await cog.suck_boobs.callback(cog, interaction)
+
+        bot.repository.record_suck_boobs_usage.assert_awaited_once()
+        assert "<@2>" in interaction.response.send_message.await_args.args[0]
+
+
+class TestScoreCommand:
+    async def test_score_rejects_dm_interaction(self):
+        cog = SuckBoobs(MagicMock())
+        interaction = make_interaction()
+        interaction.guild = None
+
+        await cog.suck_boobs_score.callback(cog, interaction)
+
+        interaction.response.send_message.assert_awaited_once_with(
+            "This command can only be used in a server.",
+            ephemeral=True,
+        )
+
+    async def test_score_renders_empty_leaderboard(self):
+        bot = MagicMock()
+        bot.repository.get_suck_boobs_leaderboard = AsyncMock(return_value=([], []))
+        cog = SuckBoobs(bot)
+        interaction = make_interaction()
+
+        await cog.suck_boobs_score.callback(cog, interaction)
+
+        interaction.response.defer.assert_awaited_once()
+        embed = interaction.followup.send.await_args.kwargs["embed"]
+        assert embed.title
+        assert [field.value.startswith("No data yet") for field in embed.fields] == [True, True]
+
+    async def test_score_renders_known_and_unknown_members(self):
+        bot = MagicMock()
+        bot.repository.get_suck_boobs_leaderboard = AsyncMock(
+            return_value=(
+                [SimpleNamespace(user_id="10", times_used=4)],
+                [SimpleNamespace(user_id="20", times_pinged=7)],
+            )
+        )
+        cog = SuckBoobs(bot)
+        interaction = make_interaction()
+        member = MagicMock(spec=discord.Member)
+        member.display_name = "Known User"
+        interaction.guild.fetch_member = AsyncMock(
+            side_effect=[member, discord.DiscordException("missing")]
+        )
+
+        await cog.suck_boobs_score.callback(cog, interaction)
+
+        embed = interaction.followup.send.await_args.kwargs["embed"]
+        assert "Known User: 4" in embed.fields[0].value
+        assert "Unknown (20): 7" in embed.fields[1].value
+
+
+class TestSetup:
+    async def test_setup_registers_cog(self):
+        bot = MagicMock()
+        bot.add_cog = AsyncMock()
+
+        await setup(bot)
+
+        [cog] = bot.add_cog.await_args.args
+        assert isinstance(cog, SuckBoobs)
+        assert cog.bot == bot

--- a/tests/test_discord/test_summarize.py
+++ b/tests/test_discord/test_summarize.py
@@ -235,9 +235,7 @@ class TestFetchYoutubeContent:
         mock_bot.settings.youtube_api_key = None
 
         with pytest.raises(WebFetchError, match="API key"):
-            await summarize_cog._fetch_youtube_content(
-                "https://youtube.com/watch?v=dQw4w9WgXcQ"
-            )
+            await summarize_cog._fetch_youtube_content("https://youtube.com/watch?v=dQw4w9WgXcQ")
 
     async def test_fetch_youtube_reports_missing_video(self, summarize_cog):
         with (
@@ -248,9 +246,7 @@ class TestFetchYoutubeContent:
             ),
             pytest.raises(WebFetchError, match="Video not found"),
         ):
-            await summarize_cog._fetch_youtube_content(
-                "https://youtube.com/watch?v=dQw4w9WgXcQ"
-            )
+            await summarize_cog._fetch_youtube_content("https://youtube.com/watch?v=dQw4w9WgXcQ")
 
     async def test_fetch_youtube_uses_description_when_transcript_missing(self, summarize_cog):
         response = {
@@ -469,9 +465,7 @@ class TestFetchSubstackContent:
         assert content.content == "Article body"
         assert content.author == "Author"
 
-    async def test_fetch_substack_matches_url_containment_and_empty_content(
-        self, summarize_cog
-    ):
+    async def test_fetch_substack_matches_url_containment_and_empty_content(self, summarize_cog):
         miss = MagicMock()
         miss.original_url = "https://example.substack.com/p/other"
         hit = MagicMock()
@@ -500,9 +494,7 @@ class TestFetchSubstackContent:
             patch("intelstream.discord.cogs.summarize.SubstackAdapter", return_value=adapter),
             pytest.raises(WebFetchError, match="Could not find the article"),
         ):
-            await summarize_cog._fetch_substack_content(
-                "https://example.substack.com/p/missing"
-            )
+            await summarize_cog._fetch_substack_content("https://example.substack.com/p/missing")
 
 
 class TestFetchWebContent:
@@ -755,7 +747,9 @@ class TestSummarizeCommand:
             model="claude-sonnet-4-6",
         )
         summarization_service.assert_called_once()
-        assert mock_interaction.followup.send.call_args.kwargs["embed"].description == "Lazy summary"
+        assert (
+            mock_interaction.followup.send.call_args.kwargs["embed"].description == "Lazy summary"
+        )
 
 
 class TestCogLifecycle:

--- a/tests/test_discord/test_summarize.py
+++ b/tests/test_discord/test_summarize.py
@@ -1,10 +1,16 @@
 from datetime import UTC, datetime
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import discord
 import pytest
+from youtube_transcript_api._errors import (
+    NoTranscriptFound,
+    TranscriptsDisabled,
+    VideoUnavailable,
+)
 
-from intelstream.discord.cogs.summarize import Summarize
+from intelstream.discord.cogs.summarize import Summarize, setup
 from intelstream.services.web_fetcher import WebContent, WebFetchError
 
 
@@ -64,6 +70,10 @@ class TestDetectUrlType:
         assert summarize_cog.detect_url_type("https://nytimes.com/2024/article") == "web"
         assert summarize_cog.detect_url_type("https://blog.example.org/post") == "web"
 
+    def test_is_substack_url(self, summarize_cog):
+        assert summarize_cog._is_substack_url("https://example.substack.com/p/post") is True
+        assert summarize_cog._is_substack_url("https://example.com/p/post") is False
+
 
 class TestExtractYoutubeVideoId:
     def test_extract_from_watch_url(self, summarize_cog):
@@ -76,6 +86,10 @@ class TestExtractYoutubeVideoId:
 
     def test_extract_from_embed_url(self, summarize_cog):
         url = "https://www.youtube.com/embed/dQw4w9WgXcQ"
+        assert summarize_cog._extract_youtube_video_id(url) == "dQw4w9WgXcQ"
+
+    def test_extract_from_v_url(self, summarize_cog):
+        url = "https://www.youtube.com/v/dQw4w9WgXcQ"
         assert summarize_cog._extract_youtube_video_id(url) == "dQw4w9WgXcQ"
 
     def test_extract_returns_none_for_invalid(self, summarize_cog):
@@ -200,6 +214,310 @@ class TestCreateSummaryEmbed:
 
         assert embed.image.url == "https://example.com/image.jpg"
 
+    def test_unknown_source_type_uses_default_color_and_footer(self, summarize_cog):
+        embed = summarize_cog.create_summary_embed(
+            url="https://example.com/article",
+            title="Article",
+            summary="Summary",
+            source_type="mystery",
+        )
+
+        assert embed.color == discord.Color.greyple()
+        assert embed.footer.text == "Web"
+
+
+class TestFetchYoutubeContent:
+    async def test_fetch_youtube_requires_video_id(self, summarize_cog):
+        with pytest.raises(WebFetchError, match="video ID"):
+            await summarize_cog._fetch_youtube_content("https://youtube.com/watch")
+
+    async def test_fetch_youtube_requires_api_key(self, summarize_cog, mock_bot):
+        mock_bot.settings.youtube_api_key = None
+
+        with pytest.raises(WebFetchError, match="API key"):
+            await summarize_cog._fetch_youtube_content(
+                "https://youtube.com/watch?v=dQw4w9WgXcQ"
+            )
+
+    async def test_fetch_youtube_reports_missing_video(self, summarize_cog):
+        with (
+            patch("intelstream.discord.cogs.summarize.build"),
+            patch(
+                "intelstream.discord.cogs.summarize.asyncio.to_thread",
+                AsyncMock(return_value={"items": []}),
+            ),
+            pytest.raises(WebFetchError, match="Video not found"),
+        ):
+            await summarize_cog._fetch_youtube_content(
+                "https://youtube.com/watch?v=dQw4w9WgXcQ"
+            )
+
+    async def test_fetch_youtube_uses_description_when_transcript_missing(self, summarize_cog):
+        response = {
+            "items": [
+                {
+                    "snippet": {
+                        "title": "Video Title",
+                        "channelTitle": "Channel",
+                        "publishedAt": "2026-05-25T12:30:00Z",
+                        "description": "Description fallback",
+                        "thumbnails": {
+                            "medium": {"url": "https://example.com/medium.jpg"},
+                            "high": {"url": "https://example.com/high.jpg"},
+                        },
+                    }
+                }
+            ]
+        }
+
+        with (
+            patch("intelstream.discord.cogs.summarize.build") as build,
+            patch(
+                "intelstream.discord.cogs.summarize.asyncio.to_thread",
+                AsyncMock(return_value=response),
+            ),
+            patch.object(summarize_cog, "_fetch_youtube_transcript", AsyncMock(return_value=None)),
+        ):
+            content = await summarize_cog._fetch_youtube_content(
+                "https://youtube.com/watch?v=dQw4w9WgXcQ"
+            )
+
+        build.assert_called_once_with("youtube", "v3", developerKey="test-youtube-key")
+        assert content.title == "Video Title"
+        assert content.author == "Channel"
+        assert content.content == "Description fallback"
+        assert content.thumbnail_url == "https://example.com/high.jpg"
+        assert content.published_at == datetime(2026, 5, 25, 12, 30, tzinfo=UTC)
+
+    async def test_fetch_youtube_uses_transcript_when_available(self, summarize_cog):
+        response = {
+            "items": [
+                {
+                    "snippet": {
+                        "title": "Video Title",
+                        "description": "Description fallback",
+                        "thumbnails": {},
+                    }
+                }
+            ]
+        }
+
+        with (
+            patch("intelstream.discord.cogs.summarize.build"),
+            patch(
+                "intelstream.discord.cogs.summarize.asyncio.to_thread",
+                AsyncMock(return_value=response),
+            ),
+            patch.object(
+                summarize_cog,
+                "_fetch_youtube_transcript",
+                AsyncMock(return_value="Transcript text"),
+            ),
+        ):
+            content = await summarize_cog._fetch_youtube_content(
+                "https://youtube.com/watch?v=dQw4w9WgXcQ"
+            )
+
+        assert content.content == "Transcript text"
+
+
+class TestFetchYoutubeTranscript:
+    async def test_fetch_transcript_uses_manual_transcript(self, summarize_cog):
+        transcript = MagicMock()
+        transcript.fetch.return_value = [
+            SimpleNamespace(text="Manual"),
+            SimpleNamespace(text="transcript"),
+        ]
+        transcript_list = MagicMock()
+        transcript_list.find_manually_created_transcript.return_value = transcript
+        api = MagicMock()
+        api.list.return_value = transcript_list
+
+        with patch("intelstream.discord.cogs.summarize.YouTubeTranscriptApi", return_value=api):
+            result = await summarize_cog._fetch_youtube_transcript("video-id")
+
+        assert result == "Manual transcript"
+        transcript_list.find_manually_created_transcript.assert_called_once_with(["en"])
+
+    async def test_fetch_transcript_falls_back_to_generated_transcript(self, summarize_cog):
+        generated = MagicMock()
+        generated.fetch.return_value = [SimpleNamespace(text="Generated transcript")]
+        transcript_list = MagicMock()
+        transcript_list.find_manually_created_transcript.side_effect = NoTranscriptFound(
+            "video-id", ["en"], []
+        )
+        transcript_list.find_generated_transcript.return_value = generated
+        api = MagicMock()
+        api.list.return_value = transcript_list
+
+        with patch("intelstream.discord.cogs.summarize.YouTubeTranscriptApi", return_value=api):
+            result = await summarize_cog._fetch_youtube_transcript("video-id")
+
+        assert result == "Generated transcript"
+
+    async def test_fetch_transcript_translates_first_available_transcript(self, summarize_cog):
+        translated = MagicMock()
+        translated.fetch.return_value = [SimpleNamespace(text="Translated transcript")]
+        foreign = MagicMock()
+        foreign.language_code = "es"
+        foreign.translate.return_value = translated
+
+        class TranscriptList:
+            def find_manually_created_transcript(self, _languages):
+                raise NoTranscriptFound("video-id", ["en"], [])
+
+            def find_generated_transcript(self, _languages):
+                raise NoTranscriptFound("video-id", ["en"], [])
+
+            def __iter__(self):
+                return iter([foreign])
+
+        api = MagicMock()
+        api.list.return_value = TranscriptList()
+
+        with patch("intelstream.discord.cogs.summarize.YouTubeTranscriptApi", return_value=api):
+            result = await summarize_cog._fetch_youtube_transcript("video-id")
+
+        assert result == "Translated transcript"
+        foreign.translate.assert_called_once_with("en")
+
+    async def test_fetch_transcript_returns_first_available_english_transcript(self, summarize_cog):
+        english = MagicMock()
+        english.language_code = "en"
+        english.fetch.return_value = [SimpleNamespace(text="English transcript")]
+
+        class TranscriptList:
+            def find_manually_created_transcript(self, _languages):
+                raise NoTranscriptFound("video-id", ["en"], [])
+
+            def find_generated_transcript(self, _languages):
+                raise NoTranscriptFound("video-id", ["en"], [])
+
+            def __iter__(self):
+                return iter([english])
+
+        api = MagicMock()
+        api.list.return_value = TranscriptList()
+
+        with patch("intelstream.discord.cogs.summarize.YouTubeTranscriptApi", return_value=api):
+            result = await summarize_cog._fetch_youtube_transcript("video-id")
+
+        assert result == "English transcript"
+        english.translate.assert_not_called()
+
+    async def test_fetch_transcript_returns_none_when_no_transcripts_exist(self, summarize_cog):
+        class TranscriptList:
+            def find_manually_created_transcript(self, _languages):
+                raise NoTranscriptFound("video-id", ["en"], [])
+
+            def find_generated_transcript(self, _languages):
+                raise NoTranscriptFound("video-id", ["en"], [])
+
+            def __iter__(self):
+                return iter([])
+
+        api = MagicMock()
+        api.list.return_value = TranscriptList()
+
+        with patch("intelstream.discord.cogs.summarize.YouTubeTranscriptApi", return_value=api):
+            assert await summarize_cog._fetch_youtube_transcript("video-id") is None
+
+    @pytest.mark.parametrize(
+        "error",
+        [TranscriptsDisabled("video-id"), VideoUnavailable("video-id")],
+    )
+    async def test_fetch_transcript_returns_none_for_expected_transcript_errors(
+        self, summarize_cog, error
+    ):
+        api = MagicMock()
+        api.list.side_effect = error
+
+        with patch("intelstream.discord.cogs.summarize.YouTubeTranscriptApi", return_value=api):
+            assert await summarize_cog._fetch_youtube_transcript("video-id") is None
+
+    async def test_fetch_transcript_returns_none_for_unexpected_error(self, summarize_cog):
+        api = MagicMock()
+        api.list.side_effect = RuntimeError("boom")
+
+        with patch("intelstream.discord.cogs.summarize.YouTubeTranscriptApi", return_value=api):
+            assert await summarize_cog._fetch_youtube_transcript("video-id") is None
+
+
+class TestFetchSubstackContent:
+    async def test_fetch_substack_rejects_non_article_url(self, summarize_cog):
+        with pytest.raises(WebFetchError, match="Invalid Substack article URL"):
+            await summarize_cog._fetch_substack_content("https://example.substack.com/about")
+
+    async def test_fetch_substack_returns_matching_feed_item(self, summarize_cog):
+        item = MagicMock()
+        item.original_url = "https://example.substack.com/p/article"
+        item.title = "Article"
+        item.raw_content = "Article body"
+        item.author = "Author"
+        item.thumbnail_url = "https://example.com/image.jpg"
+        item.published_at = datetime(2026, 5, 25, tzinfo=UTC)
+        adapter = MagicMock()
+        adapter.fetch_latest = AsyncMock(return_value=[item])
+
+        with patch("intelstream.discord.cogs.summarize.SubstackAdapter", return_value=adapter):
+            content = await summarize_cog._fetch_substack_content(
+                "https://example.substack.com/p/article"
+            )
+
+        adapter.fetch_latest.assert_awaited_once_with("example.substack.com")
+        assert content.title == "Article"
+        assert content.content == "Article body"
+        assert content.author == "Author"
+
+    async def test_fetch_substack_matches_url_containment_and_empty_content(
+        self, summarize_cog
+    ):
+        miss = MagicMock()
+        miss.original_url = "https://example.substack.com/p/other"
+        hit = MagicMock()
+        hit.original_url = "https://example.substack.com/p/article?utm_source=feed"
+        hit.title = "Article"
+        hit.raw_content = None
+        hit.author = "Author"
+        hit.thumbnail_url = None
+        hit.published_at = datetime(2026, 5, 25, tzinfo=UTC)
+        adapter = MagicMock()
+        adapter.fetch_latest = AsyncMock(return_value=[miss, hit])
+
+        with patch("intelstream.discord.cogs.summarize.SubstackAdapter", return_value=adapter):
+            content = await summarize_cog._fetch_substack_content(
+                "https://example.substack.com/p/article"
+            )
+
+        assert content.url == hit.original_url
+        assert content.content == ""
+
+    async def test_fetch_substack_reports_missing_article(self, summarize_cog):
+        adapter = MagicMock()
+        adapter.fetch_latest = AsyncMock(return_value=[])
+
+        with (
+            patch("intelstream.discord.cogs.summarize.SubstackAdapter", return_value=adapter),
+            pytest.raises(WebFetchError, match="Could not find the article"),
+        ):
+            await summarize_cog._fetch_substack_content(
+                "https://example.substack.com/p/missing"
+            )
+
+
+class TestFetchWebContent:
+    async def test_fetch_web_content_uses_web_fetcher(self, summarize_cog):
+        fetcher = MagicMock()
+        fetcher.fetch = AsyncMock(
+            return_value=WebContent(url="https://example.com", title="T", content="Body")
+        )
+
+        with patch("intelstream.discord.cogs.summarize.WebFetcher", return_value=fetcher):
+            content = await summarize_cog._fetch_web_content("https://example.com")
+
+        fetcher.fetch.assert_awaited_once_with("https://example.com")
+        assert content.title == "T"
+
 
 class TestSummarizeCommand:
     async def test_rejects_invalid_url(self, summarize_cog, mock_interaction):
@@ -218,6 +536,19 @@ class TestSummarizeCommand:
         mock_interaction.followup.send.assert_called_once()
         call_args = mock_interaction.followup.send.call_args
         assert "HTTP" in call_args[0][0]
+        assert call_args[1]["ephemeral"] is True
+
+    async def test_rejects_unsafe_url(self, summarize_cog, mock_interaction):
+        with patch(
+            "intelstream.discord.cogs.summarize.is_safe_url",
+            return_value=(False, "private network target"),
+        ):
+            await summarize_cog.summarize.callback(
+                summarize_cog, mock_interaction, "https://example.com/article"
+            )
+
+        call_args = mock_interaction.followup.send.call_args
+        assert "private network target" in call_args[0][0]
         assert call_args[1]["ephemeral"] is True
 
     async def test_rejects_twitter_url(self, summarize_cog, mock_interaction):
@@ -245,6 +576,20 @@ class TestSummarizeCommand:
         assert "Test error" in call_args[0][0]
         assert call_args[1]["ephemeral"] is True
 
+    async def test_handles_unexpected_fetch_exception(self, summarize_cog, mock_interaction):
+        with patch.object(
+            summarize_cog,
+            "_fetch_web_content",
+            AsyncMock(side_effect=RuntimeError("boom")),
+        ):
+            await summarize_cog.summarize.callback(
+                summarize_cog, mock_interaction, "https://example.com/article"
+            )
+
+        call_args = mock_interaction.followup.send.call_args
+        assert "Could not fetch content" in call_args[0][0]
+        assert call_args[1]["ephemeral"] is True
+
     async def test_handles_insufficient_content(self, summarize_cog, mock_interaction):
         mock_content = WebContent(
             url="https://example.com/article",
@@ -263,6 +608,22 @@ class TestSummarizeCommand:
         call_args = mock_interaction.followup.send.call_args
         assert "enough content" in call_args[0][0]
         assert call_args[1]["ephemeral"] is True
+
+    async def test_handles_blank_content(self, summarize_cog, mock_interaction):
+        mock_content = WebContent(
+            url="https://example.com/article",
+            title="Blank Article",
+            content="   ",
+        )
+
+        with patch.object(
+            summarize_cog, "_fetch_web_content", AsyncMock(return_value=mock_content)
+        ):
+            await summarize_cog.summarize.callback(
+                summarize_cog, mock_interaction, "https://example.com/article"
+            )
+
+        assert "enough content" in mock_interaction.followup.send.call_args[0][0]
 
     async def test_successful_web_summarization(self, summarize_cog, mock_interaction):
         mock_content = WebContent(
@@ -364,6 +725,38 @@ class TestSummarizeCommand:
         assert "Failed to generate summary" in call_args[0][0]
         assert call_args[1]["ephemeral"] is True
 
+    async def test_lazily_initializes_summarizer_when_missing(
+        self, summarize_cog, mock_interaction
+    ):
+        summarize_cog._summarizer = None
+        mock_content = WebContent(
+            url="https://example.com/article",
+            title="Test Article",
+            content="This is enough content for summarization. " * 10,
+        )
+        summarizer = MagicMock()
+        summarizer.summarize = AsyncMock(return_value="Lazy summary")
+
+        with (
+            patch.object(summarize_cog, "_fetch_web_content", AsyncMock(return_value=mock_content)),
+            patch("intelstream.discord.cogs.summarize.create_llm_client") as create_client,
+            patch(
+                "intelstream.discord.cogs.summarize.SummarizationService",
+                return_value=summarizer,
+            ) as summarization_service,
+        ):
+            await summarize_cog.summarize.callback(
+                summarize_cog, mock_interaction, "https://example.com/article"
+            )
+
+        create_client.assert_called_once_with(
+            provider="anthropic",
+            api_key="test-api-key",
+            model="claude-sonnet-4-6",
+        )
+        summarization_service.assert_called_once()
+        assert mock_interaction.followup.send.call_args.kwargs["embed"].description == "Lazy summary"
+
 
 class TestCogLifecycle:
     async def test_cog_load_initializes_http_client(self, mock_bot):
@@ -384,10 +777,31 @@ class TestCogLifecycle:
         mock_client = MagicMock()
         mock_client.aclose = AsyncMock()
         cog._http_client = mock_client
+        mock_summarizer = MagicMock()
+        mock_summarizer.close = AsyncMock()
+        cog._summarizer = mock_summarizer
 
         await cog.cog_unload()
 
         mock_client.aclose.assert_called_once()
+        mock_summarizer.close.assert_awaited_once()
+
+    async def test_cog_unload_noops_without_resources(self, mock_bot):
+        cog = Summarize(mock_bot)
+
+        await cog.cog_unload()
+
+        assert cog._http_client is None
+        assert cog._summarizer is None
+
+    async def test_setup_adds_summarize_cog(self, mock_bot):
+        mock_bot.add_cog = AsyncMock()
+
+        await setup(mock_bot)
+
+        added_cog = mock_bot.add_cog.await_args.args[0]
+        assert isinstance(added_cog, Summarize)
+        assert added_cog.bot is mock_bot
 
 
 class TestSummarizeCooldown:

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,0 +1,80 @@
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from intelstream import main as main_module
+
+
+class TestConfigureLogging:
+    def test_debug_level_enables_debug_for_third_party_loggers(self) -> None:
+        main_module.configure_logging("DEBUG")
+
+        assert main_module.logging.getLogger("discord").level == main_module.logging.DEBUG
+        assert main_module.logging.getLogger("discord.http").level == main_module.logging.DEBUG
+        assert main_module.logging.getLogger("httpx").level == main_module.logging.DEBUG
+
+    def test_non_debug_level_warns_for_third_party_loggers(self) -> None:
+        main_module.configure_logging("INFO")
+
+        assert main_module.logging.getLogger("discord").level == main_module.logging.WARNING
+        assert main_module.logging.getLogger("discord.http").level == main_module.logging.WARNING
+        assert main_module.logging.getLogger("httpx").level == main_module.logging.WARNING
+
+    def test_invalid_log_level_raises_attribute_error(self) -> None:
+        with pytest.raises(AttributeError):
+            main_module.configure_logging("not-a-level")
+
+
+class TestMainEntrypoint:
+    def test_main_runs_bot_with_settings(self) -> None:
+        settings = SimpleNamespace(log_level="INFO")
+
+        with (
+            patch("intelstream.main.get_settings", return_value=settings),
+            patch("intelstream.main.configure_logging") as configure_logging,
+            patch(
+                "intelstream.main.run_bot",
+                new=MagicMock(return_value="run-bot-result"),
+            ) as run_bot,
+            patch("intelstream.main.asyncio.run") as asyncio_run,
+        ):
+            main_module.main()
+
+        configure_logging.assert_called_once_with("INFO")
+        run_bot.assert_called_once_with(settings)
+        asyncio_run.assert_called_once_with("run-bot-result")
+
+    def test_main_handles_keyboard_interrupt_without_exiting(self) -> None:
+        settings = SimpleNamespace(log_level="INFO")
+
+        with (
+            patch("intelstream.main.get_settings", return_value=settings),
+            patch("intelstream.main.configure_logging"),
+            patch(
+                "intelstream.main.run_bot",
+                new=MagicMock(return_value="run-bot-result"),
+            ),
+            patch("intelstream.main.asyncio.run", side_effect=KeyboardInterrupt),
+            patch("intelstream.main.sys.exit") as sys_exit,
+        ):
+            main_module.main()
+
+        sys_exit.assert_not_called()
+
+    def test_main_exits_on_unhandled_exception(self) -> None:
+        settings = SimpleNamespace(log_level="INFO")
+
+        with (
+            patch("intelstream.main.get_settings", return_value=settings),
+            patch("intelstream.main.configure_logging"),
+            patch(
+                "intelstream.main.run_bot",
+                new=MagicMock(return_value="run-bot-result"),
+            ),
+            patch("intelstream.main.asyncio.run", side_effect=RuntimeError("boom")),
+            patch("intelstream.main.sys.exit") as sys_exit,
+        ):
+            main_module.main()
+
+        sys_exit.assert_called_once_with(1)

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,3 +1,4 @@
+import runpy
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
@@ -78,3 +79,16 @@ class TestMainEntrypoint:
             main_module.main()
 
         sys_exit.assert_called_once_with(1)
+
+    def test_module_execution_invokes_main(self) -> None:
+        settings = SimpleNamespace(log_level="INFO")
+        main_path = main_module.__file__
+
+        with (
+            patch("intelstream.config.get_settings", return_value=settings),
+            patch("intelstream.bot.run_bot", new=MagicMock(return_value="run-bot-result")),
+            patch("asyncio.run") as asyncio_run,
+        ):
+            runpy.run_path(main_path, run_name="__main__")
+
+        asyncio_run.assert_called_once_with("run-bot-result")

--- a/tests/test_services/test_article_search.py
+++ b/tests/test_services/test_article_search.py
@@ -96,6 +96,13 @@ class TestArticleChunker:
 
         assert chunker._chunk_text("abcdef") == ["abcde"]
 
+    def test_chunk_text_returns_empty_when_long_unit_produces_no_segments(self, monkeypatch):
+        chunker = ArticleChunker(chunk_size_chars=5, overlap_chars=0)
+
+        monkeypatch.setattr(chunker, "_split_long_unit", lambda _unit: [])
+
+        assert chunker._chunk_text("abcdef") == []
+
     def test_build_overlap_returns_empty_for_no_units_or_disabled_overlap(self):
         assert ArticleChunker(overlap_chars=10)._build_overlap([]) == []
         assert ArticleChunker(overlap_chars=0)._build_overlap(["first"]) == []
@@ -109,6 +116,19 @@ class TestArticleChunker:
         chunker = ArticleChunker(chunk_size_chars=10, overlap_chars=0)
 
         assert chunker._split_long_unit("   ") == []
+
+    def test_split_long_unit_handles_truthy_empty_word_container(self):
+        chunker = ArticleChunker(chunk_size_chars=10, overlap_chars=0)
+
+        class TruthyEmptyWords(list[str]):
+            def __bool__(self) -> bool:
+                return True
+
+        class OddUnit(str):
+            def split(self, *_args: object, **_kwargs: object) -> list[str]:
+                return TruthyEmptyWords()
+
+        assert chunker._split_long_unit(OddUnit("ignored")) == []
 
 
 class TestArticleReranker:

--- a/tests/test_services/test_article_search.py
+++ b/tests/test_services/test_article_search.py
@@ -208,6 +208,35 @@ class TestArticleReranker:
         assert first.model_name == "rerank-model"
         assert created_models == [first]
 
+    async def test_get_model_returns_model_set_while_waiting_for_lock(self):
+        reranker = ArticleReranker(enabled=True, model_name="unused")
+        model = object()
+
+        class LockThatSetsModel:
+            async def __aenter__(self):
+                reranker._model = model
+
+            async def __aexit__(self, *_args: object) -> None:
+                return None
+
+        reranker._lock = LockThatSetsModel()  # type: ignore[assignment]
+
+        assert await reranker._get_model() is model
+
+    async def test_get_model_returns_none_when_load_failed_while_waiting_for_lock(self):
+        reranker = ArticleReranker(enabled=True, model_name="unused")
+
+        class LockThatMarksLoadFailed:
+            async def __aenter__(self):
+                reranker._load_failed = True
+
+            async def __aexit__(self, *_args: object) -> None:
+                return None
+
+        reranker._lock = LockThatMarksLoadFailed()  # type: ignore[assignment]
+
+        assert await reranker._get_model() is None
+
 
 class TestBuildArticleChunkId:
     def test_pads_chunk_index(self):

--- a/tests/test_services/test_article_search.py
+++ b/tests/test_services/test_article_search.py
@@ -1,13 +1,25 @@
+import sys
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
 from intelstream.database.vector_store import ArticleChunkSearchResult
+from intelstream.services import article_search as article_search_module
 from intelstream.services.article_search import (
     ArticleChunker,
     ArticleReranker,
     RankedArticleChunk,
     aggregate_article_hits,
+    build_article_chunk_id,
 )
 
 
 class TestArticleChunker:
+    def test_build_chunks_returns_empty_without_text(self):
+        chunker = ArticleChunker()
+
+        assert chunker.build_chunks(title="Title", raw_content=None, summary=None) == []
+        assert chunker.build_chunks(title="Title", raw_content="", summary="   ") == []
+
     def test_build_chunks_prefers_raw_content_and_includes_title(self):
         chunker = ArticleChunker(chunk_size_chars=80, overlap_chars=10)
 
@@ -32,8 +44,79 @@ class TestArticleChunker:
 
         assert [chunk.text for chunk in chunks] == ["Summary fallback content."]
 
+    def test_build_chunks_omits_blank_title_from_search_text(self):
+        chunker = ArticleChunker(chunk_size_chars=80, overlap_chars=0)
+
+        [chunk] = chunker.build_chunks(
+            title="   ",
+            raw_content="Searchable article content.",
+            summary=None,
+        )
+
+        assert chunk.search_text == "Searchable article content."
+
+    def test_build_chunks_splits_long_sentence_by_words(self):
+        chunker = ArticleChunker(chunk_size_chars=20, overlap_chars=0)
+
+        chunks = chunker.build_chunks(
+            title="",
+            raw_content="alpha beta gamma delta epsilon zeta",
+            summary=None,
+        )
+
+        assert [chunk.text for chunk in chunks] == [
+            "alpha beta gamma",
+            "delta epsilon zeta",
+        ]
+
+    def test_build_chunks_adds_overlap_from_previous_chunk(self):
+        chunker = ArticleChunker(chunk_size_chars=35, overlap_chars=10)
+
+        chunks = chunker.build_chunks(
+            title="",
+            raw_content="First sentence. Second sentence. Third sentence.",
+            summary=None,
+        )
+
+        assert [chunk.text for chunk in chunks] == [
+            "First sentence. Second sentence.",
+            "Second sentence. Third sentence.",
+        ]
+
+    def test_chunk_text_returns_empty_after_normalization(self):
+        chunker = ArticleChunker()
+
+        assert chunker._chunk_text(" \t \n ") == []
+
+    def test_chunk_text_falls_back_when_sentence_splitter_returns_no_units(self, monkeypatch):
+        chunker = ArticleChunker(chunk_size_chars=5, overlap_chars=0)
+        splitter = SimpleNamespace(split=lambda _text: ["", ""])
+
+        monkeypatch.setattr(article_search_module, "_SENTENCE_SPLIT_RE", splitter)
+
+        assert chunker._chunk_text("abcdef") == ["abcde"]
+
+    def test_build_overlap_returns_empty_for_no_units_or_disabled_overlap(self):
+        assert ArticleChunker(overlap_chars=10)._build_overlap([]) == []
+        assert ArticleChunker(overlap_chars=0)._build_overlap(["first"]) == []
+
+    def test_build_overlap_can_include_all_units_when_budget_large(self):
+        chunker = ArticleChunker(overlap_chars=10_000)
+
+        assert chunker._build_overlap(["first", "second"]) == ["first", "second"]
+
+    def test_split_long_unit_returns_empty_for_whitespace(self):
+        chunker = ArticleChunker(chunk_size_chars=10, overlap_chars=0)
+
+        assert chunker._split_long_unit("   ") == []
+
 
 class TestArticleReranker:
+    async def test_rerank_returns_empty_for_no_candidates(self):
+        reranker = ArticleReranker(enabled=True, model_name="unused")
+
+        assert await reranker.rerank("query", []) == []
+
     async def test_disabled_reranker_uses_vector_scores(self):
         reranker = ArticleReranker(enabled=False, model_name="unused")
         candidates = [
@@ -51,6 +134,84 @@ class TestArticleReranker:
 
         assert ranked[0].relevance_score == 0.73
         assert ranked[0].vector_score == 0.73
+
+    async def test_rerank_uses_loaded_model_scores_and_sorts(self):
+        reranker = ArticleReranker(enabled=True, model_name="unused")
+        model = MagicMock()
+        model.predict.return_value = [-2.0, 2.0]
+        reranker._model = model
+        candidates = [
+            ArticleChunkSearchResult(
+                chunk_id="item-1__0000",
+                content_item_id="item-1",
+                chunk_index=0,
+                text="weak text",
+                search_text="weak search",
+                score=0.99,
+            ),
+            ArticleChunkSearchResult(
+                chunk_id="item-2__0000",
+                content_item_id="item-2",
+                chunk_index=0,
+                text="strong text",
+                search_text="strong search",
+                score=0.1,
+            ),
+        ]
+
+        ranked = await reranker.rerank("query", candidates)
+
+        assert [chunk.content_item_id for chunk in ranked] == ["item-2", "item-1"]
+        assert ranked[0].relevance_score > ranked[1].relevance_score
+        model.predict.assert_called_once_with(
+            [("query", "weak search"), ("query", "strong search")]
+        )
+
+    async def test_load_failed_reranker_falls_back_to_vector_scores(self):
+        reranker = ArticleReranker(enabled=True, model_name="unused")
+        reranker._load_failed = True
+        candidates = [
+            ArticleChunkSearchResult(
+                chunk_id="item-1__0000",
+                content_item_id="item-1",
+                chunk_index=0,
+                text="chunk text",
+                search_text="search text",
+                score=1.5,
+            )
+        ]
+
+        ranked = await reranker.rerank("query", candidates)
+
+        assert ranked[0].relevance_score == 1.0
+
+    async def test_get_model_loads_cross_encoder_once(self, monkeypatch):
+        created_models = []
+
+        class FakeCrossEncoder:
+            def __init__(self, model_name: str) -> None:
+                self.model_name = model_name
+                created_models.append(self)
+
+        monkeypatch.setitem(
+            sys.modules,
+            "sentence_transformers",
+            SimpleNamespace(CrossEncoder=FakeCrossEncoder),
+        )
+        reranker = ArticleReranker(enabled=True, model_name="rerank-model")
+
+        first = await reranker._get_model()
+        second = await reranker._get_model()
+
+        assert isinstance(first, FakeCrossEncoder)
+        assert first is second
+        assert first.model_name == "rerank-model"
+        assert created_models == [first]
+
+
+class TestBuildArticleChunkId:
+    def test_pads_chunk_index(self):
+        assert build_article_chunk_id("content-id", 7) == "content-id__0007"
 
 
 class TestAggregateArticleHits:
@@ -84,3 +245,49 @@ class TestAggregateArticleHits:
         assert hits[0].content_item_id == "item-1"
         assert hits[0].supporting_chunks == 2
         assert hits[0].score > 0.9
+
+    def test_filters_sorts_limits_and_caps_scores(self):
+        ranked_chunks = [
+            RankedArticleChunk(
+                chunk_id="low__0000",
+                content_item_id="low",
+                chunk_index=0,
+                text="low chunk",
+                vector_score=0.99,
+                relevance_score=0.49,
+            ),
+            RankedArticleChunk(
+                chunk_id="first__0000",
+                content_item_id="first",
+                chunk_index=0,
+                text="first chunk",
+                vector_score=0.4,
+                relevance_score=0.99,
+            ),
+            RankedArticleChunk(
+                chunk_id="first__0001",
+                content_item_id="first",
+                chunk_index=1,
+                text="supporting chunk",
+                vector_score=0.3,
+                relevance_score=0.9,
+            ),
+            RankedArticleChunk(
+                chunk_id="second__0000",
+                content_item_id="second",
+                chunk_index=0,
+                text="second chunk",
+                vector_score=0.95,
+                relevance_score=0.8,
+            ),
+        ]
+
+        hits = aggregate_article_hits(
+            ranked_chunks,
+            limit=1,
+            min_relevance_score=0.5,
+        )
+
+        assert [hit.content_item_id for hit in hits] == ["first"]
+        assert hits[0].score == 1.0
+        assert hits[0].best_chunk_text == "first chunk"

--- a/tests/test_services/test_content_extractor.py
+++ b/tests/test_services/test_content_extractor.py
@@ -1,5 +1,5 @@
 from datetime import UTC, datetime
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import httpx
 import pytest
@@ -31,6 +31,16 @@ class TestContentExtractor:
         result = await extractor.extract("http://localhost/admin")
 
         assert result.text == ""
+
+    async def test_extract_rejects_ssrf_blocked_url_before_fetching(self):
+        mock_client = MagicMock(spec=httpx.AsyncClient)
+        mock_client.get = AsyncMock()
+        extractor = ContentExtractor(http_client=mock_client)
+
+        result = await extractor.extract("http://localhost/admin")
+
+        assert result.text == ""
+        mock_client.get.assert_not_called()
 
     @respx.mock
     async def test_extract_article_content(self, extractor: ContentExtractor):
@@ -691,6 +701,13 @@ class TestLargestTextBlock:
         soup = BeautifulSoup("<html><body><div>Body fallback text</div></body></html>", "lxml")
 
         assert extractor._extract_largest_text_block(soup) == "Body fallback text"
+
+    def test_extract_largest_text_block_truncates_body_fallback(self, extractor: ContentExtractor):
+        soup = BeautifulSoup(f"<html><body>{'x' * 12000}</body></html>", "lxml")
+
+        text = extractor._extract_largest_text_block(soup)
+
+        assert text == "x" * 10000
 
     def test_extract_largest_text_block_without_body_uses_document_text(
         self, extractor: ContentExtractor

--- a/tests/test_services/test_content_extractor.py
+++ b/tests/test_services/test_content_extractor.py
@@ -181,9 +181,7 @@ class TestContentExtractor:
         assert result.published_at is None
 
     @respx.mock
-    async def test_extract_uses_recall_trafilatura_result(
-        self, extractor: ContentExtractor
-    ):
+    async def test_extract_uses_recall_trafilatura_result(self, extractor: ContentExtractor):
         respx.get("https://example.com/article").mock(
             return_value=httpx.Response(200, text="<html><body>Article</body></html>")
         )
@@ -561,9 +559,7 @@ class TestMetadataFallbacks:
 
         assert extractor._extract_author(soup) == "Jane Doe"
 
-    def test_extract_author_falls_back_when_author_meta_is_empty(
-        self, extractor: ContentExtractor
-    ):
+    def test_extract_author_falls_back_when_author_meta_is_empty(self, extractor: ContentExtractor):
         soup = BeautifulSoup(
             """
             <html><head>

--- a/tests/test_services/test_content_extractor.py
+++ b/tests/test_services/test_content_extractor.py
@@ -1,6 +1,10 @@
+from datetime import UTC, datetime
+from unittest.mock import MagicMock, patch
+
 import httpx
 import pytest
 import respx
+from bs4 import BeautifulSoup
 
 from intelstream.services.content_extractor import (
     MIN_CONTENT_LENGTH,
@@ -13,7 +17,21 @@ def extractor():
     return ContentExtractor()
 
 
+def valid_article_text() -> str:
+    return (
+        "This article contains a complete first sentence with enough detail for validation. "
+        "The second sentence adds more context and supporting evidence for the reader. "
+        "A third sentence completes the minimum structure required for article content. "
+        "A final sentence provides extra length so validation has enough material."
+    )
+
+
 class TestContentExtractor:
+    async def test_extract_rejects_ssrf_blocked_url(self, extractor: ContentExtractor):
+        result = await extractor.extract("http://localhost/admin")
+
+        assert result.text == ""
+
     @respx.mock
     async def test_extract_article_content(self, extractor: ContentExtractor):
         html = """
@@ -137,6 +155,167 @@ class TestContentExtractor:
 
         assert result.text == "" or result.text is not None
 
+    @respx.mock
+    async def test_extract_uses_primary_trafilatura_result_without_metadata(
+        self, extractor: ContentExtractor
+    ):
+        respx.get("https://example.com/article").mock(
+            return_value=httpx.Response(200, text="<html><body>Article</body></html>")
+        )
+
+        with (
+            patch(
+                "intelstream.services.content_extractor.trafilatura.extract",
+                return_value=valid_article_text(),
+            ),
+            patch(
+                "intelstream.services.content_extractor.trafilatura.extract_metadata",
+                return_value=None,
+            ),
+        ):
+            result = await extractor.extract("https://example.com/article")
+
+        assert result.text == valid_article_text()
+        assert result.title is None
+        assert result.author is None
+        assert result.published_at is None
+
+    @respx.mock
+    async def test_extract_uses_recall_trafilatura_result(
+        self, extractor: ContentExtractor
+    ):
+        respx.get("https://example.com/article").mock(
+            return_value=httpx.Response(200, text="<html><body>Article</body></html>")
+        )
+        metadata = MagicMock(title="Recall Title", author="Recall Author", date="2024-01-02")
+
+        with (
+            patch(
+                "intelstream.services.content_extractor.trafilatura.extract",
+                side_effect=[None, valid_article_text()],
+            ),
+            patch(
+                "intelstream.services.content_extractor.trafilatura.extract_metadata",
+                return_value=metadata,
+            ),
+        ):
+            result = await extractor.extract("https://example.com/article")
+
+        assert result.text == valid_article_text()
+        assert result.title == "Recall Title"
+        assert result.author == "Recall Author"
+        assert result.published_at == datetime(2024, 1, 2)
+
+    @respx.mock
+    async def test_extract_falls_back_to_article_element(self, extractor: ContentExtractor):
+        html = f"""
+        <html>
+        <head><title>Article Title</title></head>
+        <body><article><p>{valid_article_text()}</p></article></body>
+        </html>
+        """
+        respx.get("https://example.com/article").mock(return_value=httpx.Response(200, text=html))
+
+        with patch("intelstream.services.content_extractor.trafilatura.extract", return_value=None):
+            result = await extractor.extract("https://example.com/article")
+
+        assert result.text
+        assert result.title == "Article Title"
+
+    @respx.mock
+    async def test_extract_falls_back_to_main_element(self, extractor: ContentExtractor):
+        html = f"""
+        <html>
+        <head><meta name="author" content="Main Author"></head>
+        <body><main><p>{valid_article_text()}</p></main></body>
+        </html>
+        """
+        respx.get("https://example.com/main").mock(return_value=httpx.Response(200, text=html))
+
+        with patch("intelstream.services.content_extractor.trafilatura.extract", return_value=None):
+            result = await extractor.extract("https://example.com/main")
+
+        assert result.text
+        assert result.author == "Main Author"
+
+    @respx.mock
+    async def test_extract_falls_back_to_css_selector_after_short_semantic_blocks(
+        self, extractor: ContentExtractor
+    ):
+        html = f"""
+        <html>
+        <head><title>CSS Fallback</title></head>
+        <body>
+            <article>Too short.</article>
+            <main>Also too short.</main>
+            <div class="post-content"><p>{valid_article_text()}</p></div>
+        </body>
+        </html>
+        """
+        respx.get("https://example.com/css-fallback").mock(
+            return_value=httpx.Response(200, text=html)
+        )
+
+        with patch("intelstream.services.content_extractor.trafilatura.extract", return_value=None):
+            result = await extractor.extract("https://example.com/css-fallback")
+
+        assert result.text == valid_article_text()
+        assert result.title == "CSS Fallback"
+
+    @respx.mock
+    async def test_extract_falls_back_to_largest_block_when_no_structured_match(
+        self, extractor: ContentExtractor
+    ):
+        html = """
+        <html>
+        <body>
+            <article>Too short.</article>
+            <main>Still short.</main>
+            <p>This first paragraph is long enough to be treated as significant article content. It has useful detail.</p>
+            <p>The second paragraph adds supporting evidence and gives the fallback extractor enough text to validate.</p>
+            <p>A final paragraph completes the article structure and gives readers a clear closing sentence.</p>
+        </body>
+        </html>
+        """
+        respx.get("https://example.com/largest-block").mock(
+            return_value=httpx.Response(200, text=html)
+        )
+
+        with patch("intelstream.services.content_extractor.trafilatura.extract", return_value=None):
+            result = await extractor.extract("https://example.com/largest-block")
+
+        assert "first paragraph" in result.text
+        assert "second paragraph" in result.text
+        assert "final paragraph" in result.text
+
+    async def test_fetch_html_uses_injected_client(self):
+        class FakeClient:
+            def __init__(self) -> None:
+                self.calls = []
+
+            async def get(self, url: str, **kwargs):
+                self.calls.append((url, kwargs))
+                request = httpx.Request("GET", url)
+                return httpx.Response(200, request=request, text="<html>Fetched</html>")
+
+        client = FakeClient()
+        extractor = ContentExtractor(http_client=client)
+
+        html = await extractor._fetch_html("https://example.com/injected")
+
+        assert html == "<html>Fetched</html>"
+        assert client.calls == [
+            (
+                "https://example.com/injected",
+                {
+                    "headers": {
+                        "User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36"
+                    },
+                    "follow_redirects": True,
+                },
+            )
+        ]
+
     def test_parse_date_iso_format(self, extractor: ContentExtractor):
         result = extractor._parse_date("2024-01-15T12:00:00Z")
         assert result is not None
@@ -154,6 +333,23 @@ class TestContentExtractor:
         assert result is not None
         assert result.year == 2024
 
+    @pytest.mark.parametrize(
+        ("date_text", "expected"),
+        [
+            ("Jan 15, 2024", datetime(2024, 1, 15, tzinfo=UTC)),
+            ("15 January 2024", datetime(2024, 1, 15, tzinfo=UTC)),
+            ("15 Jan 2024", datetime(2024, 1, 15, tzinfo=UTC)),
+            ("01/15/2024", datetime(2024, 1, 15, tzinfo=UTC)),
+        ],
+    )
+    def test_parse_date_additional_formats(
+        self,
+        extractor: ContentExtractor,
+        date_text: str,
+        expected: datetime,
+    ):
+        assert extractor._parse_date(date_text) == expected
+
     def test_parse_date_invalid(self, extractor: ContentExtractor):
         result = extractor._parse_date("not a date")
         assert result is None
@@ -161,6 +357,25 @@ class TestContentExtractor:
     def test_parse_date_none(self, extractor: ContentExtractor):
         result = extractor._parse_date(None)
         assert result is None
+
+    def test_parse_date_preserves_timezone_when_strptime_returns_aware_datetime(
+        self, extractor: ContentExtractor
+    ):
+        expected = datetime(2024, 1, 15, 12, 0, tzinfo=UTC)
+
+        class FakeDateTime:
+            @staticmethod
+            def fromisoformat(_date_text: str):
+                raise ValueError
+
+            @staticmethod
+            def strptime(_date_text: str, fmt: str):
+                if fmt == "%Y-%m-%dT%H:%M:%S%z":
+                    return expected
+                raise ValueError
+
+        with patch("intelstream.services.content_extractor.datetime", FakeDateTime):
+            assert extractor._parse_date("custom-date") == expected
 
 
 class TestContentValidation:
@@ -173,6 +388,9 @@ class TestContentValidation:
     def test_validate_rejects_text_below_min_length(self, extractor: ContentExtractor):
         short_text = "A" * (MIN_CONTENT_LENGTH - 1)
         assert extractor._validate_content(short_text) is False
+
+    def test_validate_rejects_whitespace_only_text(self, extractor: ContentExtractor):
+        assert extractor._validate_content(" " * (MIN_CONTENT_LENGTH + 10)) is False
 
     def test_validate_rejects_too_few_sentences(self, extractor: ContentExtractor):
         text = "A" * (MIN_CONTENT_LENGTH + 50) + ". Second sentence."
@@ -211,6 +429,26 @@ class TestContentValidation:
 
 
 class TestCssSelectorFallback:
+    def test_extract_via_css_selectors_returns_none_when_no_match(
+        self, extractor: ContentExtractor
+    ):
+        soup = BeautifulSoup("<html><body><div>Plain</div></body></html>", "lxml")
+
+        assert extractor._extract_via_css_selectors(soup) is None
+
+    def test_extract_via_css_selectors_skips_empty_match(self, extractor: ContentExtractor):
+        soup = BeautifulSoup(
+            """
+            <html><body>
+              <div class="post-content"></div>
+              <div class="entry-content">Fallback selector text</div>
+            </body></html>
+            """,
+            "lxml",
+        )
+
+        assert extractor._extract_via_css_selectors(soup) == "Fallback selector text"
+
     @respx.mock
     async def test_extract_via_post_content_class(self, extractor: ContentExtractor):
         html = """
@@ -294,3 +532,155 @@ class TestCssSelectorFallback:
         result = await extractor.extract("https://example.com/nav-heavy")
 
         assert result.text == ""
+
+
+class TestMetadataFallbacks:
+    def test_extract_title_falls_back_to_h1(self, extractor: ContentExtractor):
+        soup = BeautifulSoup("<html><body><h1>Article Heading</h1></body></html>", "lxml")
+
+        assert extractor._extract_title(soup) == "Article Heading"
+
+    def test_extract_title_ignores_empty_og_title(self, extractor: ContentExtractor):
+        soup = BeautifulSoup(
+            '<html><head><meta property="og:title" content=""><title>Fallback</title></head></html>',
+            "lxml",
+        )
+
+        assert extractor._extract_title(soup) == "Fallback"
+
+    def test_extract_title_returns_none_without_title_sources(self, extractor: ContentExtractor):
+        soup = BeautifulSoup("<html><body><p>No title here</p></body></html>", "lxml")
+
+        assert extractor._extract_title(soup) is None
+
+    def test_extract_author_uses_article_author_meta(self, extractor: ContentExtractor):
+        soup = BeautifulSoup(
+            '<html><head><meta property="article:author" content="Jane Doe"></head></html>',
+            "lxml",
+        )
+
+        assert extractor._extract_author(soup) == "Jane Doe"
+
+    def test_extract_author_falls_back_when_author_meta_is_empty(
+        self, extractor: ContentExtractor
+    ):
+        soup = BeautifulSoup(
+            """
+            <html><head>
+              <meta name="author" content="">
+              <meta property="article:author" content="Fallback Author">
+            </head></html>
+            """,
+            "lxml",
+        )
+
+        assert extractor._extract_author(soup) == "Fallback Author"
+
+    def test_extract_author_ignores_empty_fallbacks(self, extractor: ContentExtractor):
+        soup = BeautifulSoup(
+            """
+            <html><head>
+              <meta name="author" content="">
+              <meta property="article:author" content="">
+            </head><body><div class="author"></div></body></html>
+            """,
+            "lxml",
+        )
+
+        assert extractor._extract_author(soup) is None
+
+    def test_extract_author_uses_short_author_class(self, extractor: ContentExtractor):
+        soup = BeautifulSoup('<div class="by-author">Staff Writer</div>', "lxml")
+
+        assert extractor._extract_author(soup) == "Staff Writer"
+
+    def test_extract_author_ignores_long_author_class_text(self, extractor: ContentExtractor):
+        soup = BeautifulSoup(f'<div class="author">{"A" * 120}</div>', "lxml")
+
+        assert extractor._extract_author(soup) is None
+
+    def test_extract_date_falls_back_from_invalid_time_to_og_date(
+        self, extractor: ContentExtractor
+    ):
+        soup = BeautifulSoup(
+            """
+            <html><head>
+              <meta property="article:published_time" content="2024-02-03T04:05:06Z">
+            </head><body><time datetime="not-a-date">bad</time></body></html>
+            """,
+            "lxml",
+        )
+
+        assert extractor._extract_date(soup) == datetime(2024, 2, 3, 4, 5, 6, tzinfo=UTC)
+
+    def test_extract_date_uses_name_date_meta(self, extractor: ContentExtractor):
+        soup = BeautifulSoup(
+            '<html><head><meta name="datePublished" content="2024-03-04"></head></html>',
+            "lxml",
+        )
+
+        assert extractor._extract_date(soup) == datetime(2024, 3, 4)
+
+    def test_extract_date_returns_none_when_all_candidates_invalid(
+        self, extractor: ContentExtractor
+    ):
+        soup = BeautifulSoup(
+            """
+            <html><head>
+              <meta property="article:published_time" content="bad-og">
+              <meta name="datePublished" content="bad-meta">
+            </head><body><time datetime="bad-time">bad</time></body></html>
+            """,
+            "lxml",
+        )
+
+        assert extractor._extract_date(soup) is None
+
+    def test_extract_date_skips_empty_candidates(self, extractor: ContentExtractor):
+        soup = BeautifulSoup(
+            """
+            <html><head>
+              <meta property="article:published_time" content="">
+              <meta name="datePublished" content="">
+            </head><body><time>No datetime attribute</time></body></html>
+            """,
+            "lxml",
+        )
+
+        assert extractor._extract_date(soup) is None
+
+
+class TestLargestTextBlock:
+    def test_extract_largest_text_block_joins_significant_paragraphs(
+        self, extractor: ContentExtractor
+    ):
+        soup = BeautifulSoup(
+            """
+            <html><body>
+              <nav>This navigation should be removed before extraction.</nav>
+              <p>short</p>
+              <p>This paragraph is long enough to be included as significant article text.</p>
+              <p>This second paragraph is also long enough to be included in the block.</p>
+            </body></html>
+            """,
+            "lxml",
+        )
+
+        text = extractor._extract_largest_text_block(soup)
+
+        assert "navigation" not in text.lower()
+        assert "short" not in text
+        assert "significant article text" in text
+        assert "second paragraph" in text
+
+    def test_extract_largest_text_block_falls_back_to_body(self, extractor: ContentExtractor):
+        soup = BeautifulSoup("<html><body><div>Body fallback text</div></body></html>", "lxml")
+
+        assert extractor._extract_largest_text_block(soup) == "Body fallback text"
+
+    def test_extract_largest_text_block_without_body_uses_document_text(
+        self, extractor: ContentExtractor
+    ):
+        soup = BeautifulSoup("<root>Loose text</root>", "xml")
+
+        assert extractor._extract_largest_text_block(soup) == "Loose text"

--- a/tests/test_services/test_content_extractor.py
+++ b/tests/test_services/test_content_extractor.py
@@ -390,6 +390,24 @@ class TestContentValidation:
     def test_validate_rejects_whitespace_only_text(self, extractor: ContentExtractor):
         assert extractor._validate_content(" " * (MIN_CONTENT_LENGTH + 10)) is False
 
+    def test_validate_rejects_text_without_split_words(self, extractor: ContentExtractor):
+        class TextWithoutWords(str):
+            def lower(self):
+                return self
+
+            def split(self):
+                return []
+
+        text = TextWithoutWords(
+            "This sentence makes the string long enough for validation. "
+            "This second sentence keeps the sentence count above the minimum. "
+            "This third sentence ensures the word extraction branch is reached. "
+            "Additional detail pushes the total content beyond the minimum length check. "
+            "A final sentence keeps the fixture realistic while still returning no split words."
+        )
+
+        assert extractor._validate_content(text) is False
+
     def test_validate_rejects_too_few_sentences(self, extractor: ContentExtractor):
         text = "A" * (MIN_CONTENT_LENGTH + 50) + ". Second sentence."
         assert len(text) >= MIN_CONTENT_LENGTH

--- a/tests/test_services/test_content_poster.py
+++ b/tests/test_services/test_content_poster.py
@@ -150,6 +150,20 @@ class TestContentPosterFormatMessage:
 
         assert "*Unknown | Test*" in message
 
+    def test_format_message_handles_overhead_longer_than_limit(self, sample_content_item):
+        poster = ContentPoster(MagicMock(), max_message_length=80)
+        sample_content_item.title = "A very long title " * 12
+        sample_content_item.summary = "Short summary"
+
+        message = poster.format_message(
+            content_item=sample_content_item,
+            source_type=SourceType.RSS,
+            source_name="Very long source name " * 6,
+        )
+
+        assert TRUNCATION_NOTICE.strip() in message
+        assert "RSS" in message
+
 
 class TestContentPosterPostContent:
     async def test_post_content_sends_message(self, content_poster, sample_content_item):
@@ -321,6 +335,58 @@ class TestContentPosterPostUnpostedItems:
         assert result == 1
         mock_bot.get_channel.assert_called_with(999)
 
+    async def test_skips_when_guild_config_inactive(
+        self, content_poster, mock_bot, sample_content_item
+    ):
+        mock_config = MagicMock()
+        mock_config.is_active = False
+        mock_bot.repository.get_discord_config = AsyncMock(return_value=mock_config)
+        mock_bot.repository.get_unposted_content_items = AsyncMock(
+            return_value=[sample_content_item]
+        )
+
+        mock_source = MagicMock()
+        mock_source.type = SourceType.SUBSTACK
+        mock_source.name = "Test Source"
+        mock_source.skip_summary = False
+        mock_source.guild_id = None
+        mock_source.channel_id = None
+        mock_bot.repository.get_sources_by_ids = AsyncMock(
+            return_value={sample_content_item.source_id: mock_source}
+        )
+
+        result = await content_poster.post_unposted_items(guild_id=123)
+
+        assert result == 0
+        mock_bot.get_channel.assert_not_called()
+
+    async def test_posts_to_thread_channel(self, content_poster, mock_bot, sample_content_item):
+        mock_channel = MagicMock(spec=discord.Thread)
+        mock_message = MagicMock(spec=discord.Message)
+        mock_message.id = 789
+        mock_channel.send = AsyncMock(return_value=mock_message)
+        mock_bot.get_channel = MagicMock(return_value=mock_channel)
+        mock_bot.repository.get_unposted_content_items = AsyncMock(
+            return_value=[sample_content_item]
+        )
+
+        mock_source = MagicMock()
+        mock_source.type = SourceType.RSS
+        mock_source.name = "Thread Source"
+        mock_source.skip_summary = False
+        mock_source.guild_id = "123"
+        mock_source.channel_id = "456"
+        mock_bot.repository.get_sources_by_ids = AsyncMock(
+            return_value={sample_content_item.source_id: mock_source}
+        )
+        mock_bot.repository.mark_content_item_posted = AsyncMock()
+
+        result = await content_poster.post_unposted_items(guild_id=123)
+
+        assert result == 1
+        mock_channel.send.assert_awaited_once()
+        mock_bot.repository.mark_content_item_posted.assert_awaited_once()
+
     async def test_skips_item_from_different_guild(
         self, content_poster, mock_bot, sample_content_item
     ):
@@ -414,6 +480,31 @@ class TestContentPosterPostUnpostedItems:
         result = await content_poster.post_unposted_items(guild_id=123)
 
         assert result == 0
+
+    async def test_continues_on_unexpected_posting_error(
+        self, content_poster, mock_bot, sample_content_item
+    ):
+        sample_content_item.original_url = None
+        mock_bot.repository.get_unposted_content_items = AsyncMock(
+            return_value=[sample_content_item]
+        )
+
+        mock_source = MagicMock()
+        mock_source.type = SourceType.YOUTUBE
+        mock_source.name = "URL Only Source"
+        mock_source.skip_summary = True
+        mock_source.guild_id = "123"
+        mock_source.channel_id = "456"
+        mock_bot.repository.get_sources_by_ids = AsyncMock(
+            return_value={sample_content_item.source_id: mock_source}
+        )
+        mock_bot.get_channel = MagicMock(return_value=MagicMock(spec=discord.TextChannel))
+        mock_bot.repository.mark_content_item_posted = AsyncMock()
+
+        result = await content_poster.post_unposted_items(guild_id=123)
+
+        assert result == 0
+        mock_bot.repository.mark_content_item_posted.assert_not_awaited()
 
     async def test_skips_item_when_source_not_found(
         self, content_poster, mock_bot, sample_content_item

--- a/tests/test_services/test_content_poster.py
+++ b/tests/test_services/test_content_poster.py
@@ -1,5 +1,5 @@
 from datetime import UTC, datetime
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import discord
 import pytest
@@ -163,6 +163,23 @@ class TestContentPosterFormatMessage:
 
         assert TRUNCATION_NOTICE.strip() in message
         assert "RSS" in message
+
+    def test_format_message_adds_notice_when_second_pass_truncates(self, sample_content_item):
+        poster = ContentPoster(MagicMock(), max_message_length=120)
+        sample_content_item.summary = "Original summary that is too long" * 20
+
+        with patch(
+            "intelstream.services.content_poster.truncate_summary_at_bullet",
+            return_value="A" * 200,
+        ):
+            message = poster.format_message(
+                content_item=sample_content_item,
+                source_type=SourceType.RSS,
+                source_name="Test RSS",
+            )
+
+        assert len(message) <= 120
+        assert TRUNCATION_NOTICE.strip() in message
 
 
 class TestContentPosterPostContent:

--- a/tests/test_services/test_content_poster.py
+++ b/tests/test_services/test_content_poster.py
@@ -1,5 +1,5 @@
 from datetime import UTC, datetime
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, call, patch
 
 import discord
 import pytest
@@ -316,6 +316,54 @@ class TestContentPosterPostUnpostedItems:
         mock_bot.repository.mark_content_item_posted.assert_called_once_with(
             content_id=sample_content_item.id,
             discord_message_id="789",
+        )
+
+    async def test_posts_multiple_items_with_one_source_lookup(
+        self, content_poster, mock_bot, sample_content_item
+    ):
+        second_item = MagicMock(spec=ContentItem)
+        second_item.id = "second-item-id"
+        second_item.title = "Second Article"
+        second_item.summary = "Second summary"
+        second_item.original_url = "https://example.com/second"
+        second_item.author = "Second Author"
+        second_item.source_id = sample_content_item.source_id
+
+        first_message = MagicMock(spec=discord.Message)
+        first_message.id = 101
+        second_message = MagicMock(spec=discord.Message)
+        second_message.id = 202
+        mock_channel = MagicMock(spec=discord.TextChannel)
+        mock_channel.send = AsyncMock(side_effect=[first_message, second_message])
+        mock_bot.get_channel = MagicMock(return_value=mock_channel)
+
+        mock_bot.repository.get_unposted_content_items = AsyncMock(
+            return_value=[sample_content_item, second_item]
+        )
+
+        mock_source = MagicMock()
+        mock_source.type = SourceType.SUBSTACK
+        mock_source.name = "Shared Source"
+        mock_source.skip_summary = False
+        mock_source.guild_id = "123"
+        mock_source.channel_id = "456"
+        mock_bot.repository.get_sources_by_ids = AsyncMock(
+            return_value={sample_content_item.source_id: mock_source}
+        )
+        mock_bot.repository.mark_content_item_posted = AsyncMock()
+
+        result = await content_poster.post_unposted_items(guild_id=123)
+
+        assert result == 2
+        mock_bot.repository.get_sources_by_ids.assert_awaited_once_with(
+            {sample_content_item.source_id}
+        )
+        assert mock_channel.send.await_count == 2
+        mock_bot.repository.mark_content_item_posted.assert_has_awaits(
+            [
+                call(content_id=sample_content_item.id, discord_message_id="101"),
+                call(content_id=second_item.id, discord_message_id="202"),
+            ]
         )
 
     async def test_falls_back_to_guild_config_when_no_source_channel(

--- a/tests/test_services/test_content_poster.py
+++ b/tests/test_services/test_content_poster.py
@@ -573,6 +573,19 @@ class TestTruncateSummaryAtBullet:
         assert len(result) <= 50
         assert TRUNCATION_NOTICE.strip() in result
 
+    def test_fallback_truncation_when_split_produces_no_lines(self):
+        class SplitlessSummary(str):
+            def __len__(self) -> int:
+                return 200
+
+            def split(self, *_args: object, **_kwargs: object) -> list[str]:
+                return []
+
+        result = truncate_summary_at_bullet(SplitlessSummary("A" * 200), 50)
+
+        assert len(result) <= 50
+        assert TRUNCATION_NOTICE.strip() in result
+
     def test_handles_empty_summary(self):
         result = truncate_summary_at_bullet("", 100)
         assert result == ""

--- a/tests/test_services/test_embedding_service.py
+++ b/tests/test_services/test_embedding_service.py
@@ -1,3 +1,4 @@
+import asyncio
 from unittest.mock import MagicMock, patch
 
 import numpy as np
@@ -31,6 +32,38 @@ class TestEmbedText:
         svc = EmbeddingService()
         with pytest.raises(RuntimeError, match="not initialized"):
             await svc.embed_text("hello")
+
+    async def test_serializes_concurrent_encode_calls(self, service, monkeypatch):
+        first_started = asyncio.Event()
+        release_first = asyncio.Event()
+        started_texts: list[str] = []
+
+        async def fake_to_thread(_func, text, *, show_progress_bar):
+            assert show_progress_bar is False
+            started_texts.append(text)
+            if text == "first":
+                first_started.set()
+                await release_first.wait()
+                return np.array([1.0])
+            return np.array([2.0])
+
+        monkeypatch.setattr(
+            "intelstream.services.embedding_service.asyncio.to_thread",
+            fake_to_thread,
+        )
+
+        first_task = asyncio.create_task(service.embed_text("first"))
+        await first_started.wait()
+        second_task = asyncio.create_task(service.embed_text("second"))
+
+        await asyncio.sleep(0)
+        assert started_texts == ["first"]
+
+        release_first.set()
+        results = await asyncio.gather(first_task, second_task)
+
+        assert results == [[1.0], [2.0]]
+        assert started_texts == ["first", "second"]
 
 
 class TestEmbedBatch:

--- a/tests/test_services/test_github_poster.py
+++ b/tests/test_services/test_github_poster.py
@@ -116,9 +116,7 @@ class TestCommitFormatting:
 
         assert embed.description is None
 
-    def test_format_commit_without_avatar_sets_author_name_only(
-        self, poster: GitHubPoster
-    ) -> None:
+    def test_format_commit_without_avatar_sets_author_name_only(self, poster: GitHubPoster) -> None:
         event = make_commit_event(author="testuser")
         event.author_avatar_url = ""
 
@@ -158,9 +156,7 @@ class TestPRFormatting:
         assert embed.color == GitHubPoster.COLORS["pull_request"]
         assert any(field.value == "draft" for field in embed.fields)
 
-    def test_format_pr_long_title_without_description_or_avatar(
-        self, poster: GitHubPoster
-    ) -> None:
+    def test_format_pr_long_title_without_description_or_avatar(self, poster: GitHubPoster) -> None:
         event = make_pr_event(title="A" * 300, state=None)
         event.description = None
         event.author_avatar_url = ""

--- a/tests/test_services/test_github_poster.py
+++ b/tests/test_services/test_github_poster.py
@@ -1,4 +1,5 @@
 from datetime import UTC, datetime
+from unittest.mock import AsyncMock, MagicMock
 
 import discord
 import pytest
@@ -101,6 +102,31 @@ class TestCommitFormatting:
 
         assert len(embed.title) <= 256
 
+    def test_format_commit_keeps_single_line_description(self, poster: GitHubPoster) -> None:
+        event = make_commit_event(title="Fix bug", description="Detailed body without newline")
+
+        embed = poster.format_event(event)
+
+        assert embed.description == "Detailed body without newline"
+
+    def test_format_commit_omits_empty_body_after_subject(self, poster: GitHubPoster) -> None:
+        event = make_commit_event(title="Fix bug", description="Fix bug\n\n   ")
+
+        embed = poster.format_event(event)
+
+        assert embed.description is None
+
+    def test_format_commit_without_avatar_sets_author_name_only(
+        self, poster: GitHubPoster
+    ) -> None:
+        event = make_commit_event(author="testuser")
+        event.author_avatar_url = ""
+
+        embed = poster.format_event(event)
+
+        assert embed.author.name == "testuser"
+        assert embed.author.icon_url is None
+
 
 class TestPRFormatting:
     def test_format_pr_open(self, poster: GitHubPoster) -> None:
@@ -125,6 +151,27 @@ class TestPRFormatting:
         assert embed.color == GitHubPoster.COLORS["pull_request_closed"]
         assert any(field.value == "Closed" for field in embed.fields)
 
+    def test_format_pr_unknown_state_uses_raw_status(self, poster: GitHubPoster) -> None:
+        event = make_pr_event(state="draft")
+        embed = poster.format_event(event)
+
+        assert embed.color == GitHubPoster.COLORS["pull_request"]
+        assert any(field.value == "draft" for field in embed.fields)
+
+    def test_format_pr_long_title_without_description_or_avatar(
+        self, poster: GitHubPoster
+    ) -> None:
+        event = make_pr_event(title="A" * 300, state=None)
+        event.description = None
+        event.author_avatar_url = ""
+
+        embed = poster.format_event(event)
+
+        assert len(embed.title) <= 256
+        assert embed.description is None
+        assert embed.author.icon_url is None
+        assert any(field.value == "Open" for field in embed.fields)
+
 
 class TestIssueFormatting:
     def test_format_issue_open(self, poster: GitHubPoster) -> None:
@@ -140,6 +187,20 @@ class TestIssueFormatting:
         embed = poster.format_event(event)
 
         assert embed.color == GitHubPoster.COLORS["issue_closed"]
+        assert any(field.value == "Closed" for field in embed.fields)
+
+    def test_format_issue_long_title_without_description_or_avatar(
+        self, poster: GitHubPoster
+    ) -> None:
+        event = make_issue_event(title="B" * 300, state="triaged")
+        event.description = None
+        event.author_avatar_url = ""
+
+        embed = poster.format_event(event)
+
+        assert len(embed.title) <= 256
+        assert embed.description is None
+        assert embed.author.icon_url is None
         assert any(field.value == "Closed" for field in embed.fields)
 
 
@@ -161,3 +222,79 @@ class TestEmbedCommonProperties:
         embed = poster.format_event(event)
 
         assert embed.timestamp is not None
+
+
+class TestGenericFormatting:
+    def test_format_unknown_event_uses_generic_embed(self, poster: GitHubPoster) -> None:
+        event = GitHubEvent(
+            event_type="release",
+            repo_full_name="owner/repo",
+            number=None,
+            sha=None,
+            title="v1.0 " + ("release notes " * 30),
+            description="details " * 100,
+            author="maintainer",
+            author_avatar_url=None,
+            url="https://github.com/owner/repo/releases/tag/v1.0",
+            created_at=datetime(2024, 1, 15, 10, 30, 0, tzinfo=UTC),
+            state=None,
+        )
+
+        embed = poster.format_event(event)
+
+        assert len(embed.title) == 256
+        assert len(embed.description or "") == 500
+        assert embed.author.name == "maintainer"
+        assert embed.footer.text == "owner/repo"
+
+    def test_format_generic_with_avatar_and_no_description(self, poster: GitHubPoster) -> None:
+        event = GitHubEvent(
+            event_type="release",
+            repo_full_name="owner/repo",
+            number=None,
+            sha=None,
+            title="v1.1",
+            description=None,
+            author="maintainer",
+            author_avatar_url="https://github.com/maintainer.png",
+            url="https://github.com/owner/repo/releases/tag/v1.1",
+            created_at=datetime(2024, 1, 15, 10, 30, 0, tzinfo=UTC),
+            state=None,
+        )
+
+        embed = poster.format_event(event)
+
+        assert embed.description is None
+        assert embed.author.name == "maintainer"
+        assert embed.author.icon_url == "https://github.com/maintainer.png"
+
+
+class TestPostingEvents:
+    async def test_post_events_sends_oldest_event_first(self, poster: GitHubPoster) -> None:
+        newest = make_commit_event(sha="newest123456", title="Newest")
+        oldest = make_commit_event(sha="oldest123456", title="Oldest")
+        channel = MagicMock(spec=discord.abc.Messageable)
+        channel.send = AsyncMock(side_effect=["oldest-message", "newest-message"])
+
+        posted = await poster.post_events(channel, [newest, oldest])
+
+        assert posted == ["oldest-message", "newest-message"]
+        sent_titles = [call.kwargs["embed"].title for call in channel.send.await_args_list]
+        assert "Oldest" in sent_titles[0]
+        assert "Newest" in sent_titles[1]
+
+    async def test_post_events_continues_after_http_exception(self, poster: GitHubPoster) -> None:
+        mock_response = MagicMock()
+        mock_response.status = 500
+        channel = MagicMock(spec=discord.abc.Messageable)
+        channel.send = AsyncMock(
+            side_effect=[discord.HTTPException(mock_response, "Server error"), "posted"]
+        )
+
+        posted = await poster.post_events(
+            channel,
+            [make_commit_event(sha="second123456"), make_commit_event(sha="first123456")],
+        )
+
+        assert posted == ["posted"]
+        assert channel.send.await_count == 2

--- a/tests/test_services/test_github_service.py
+++ b/tests/test_services/test_github_service.py
@@ -14,6 +14,13 @@ def github_service():
 
 
 class TestGitHubServiceClient:
+    async def test_get_client_reuses_injected_client(self) -> None:
+        client = AsyncMock(spec=httpx.AsyncClient)
+        service = GitHubService(token="test-token", http_client=client)
+
+        assert await service._get_client() is client
+        assert service._owns_client is False
+
     async def test_get_client_lazily_creates_owned_client(self) -> None:
         service = GitHubService(token="test-token")
 

--- a/tests/test_services/test_github_service.py
+++ b/tests/test_services/test_github_service.py
@@ -14,6 +14,16 @@ def github_service():
 
 
 class TestGitHubServiceClient:
+    def test_headers_include_auth_and_github_api_contract(self) -> None:
+        service = GitHubService(token="secret-token")
+
+        headers = service._headers()
+
+        assert headers["Authorization"] == "Bearer secret-token"
+        assert headers["Accept"] == "application/vnd.github+json"
+        assert headers["X-GitHub-Api-Version"] == "2022-11-28"
+        assert headers["User-Agent"] == "intelstream-bot"
+
     async def test_get_client_reuses_injected_client(self) -> None:
         client = AsyncMock(spec=httpx.AsyncClient)
         service = GitHubService(token="test-token", http_client=client)
@@ -208,6 +218,35 @@ class TestGitHubServiceCommits:
         assert events[0].author == "Committer Name"
         assert events[0].description is None
         assert events[0].created_at.tzinfo == UTC
+        await github_service.close()
+
+    @respx.mock
+    async def test_fetch_commits_uses_limit_and_truncates_long_title(
+        self, github_service: GitHubService
+    ) -> None:
+        long_subject = "x" * 300
+        route = respx.get("https://api.github.com/repos/owner/repo/commits").mock(
+            return_value=httpx.Response(
+                200,
+                json=[
+                    {
+                        "sha": "long123",
+                        "commit": {
+                            "message": f"{long_subject}\n\nDetailed body",
+                            "author": {"name": "Author", "date": "2024-01-15T10:30:00Z"},
+                        },
+                        "author": {"login": "author", "avatar_url": ""},
+                        "html_url": "",
+                    }
+                ],
+            )
+        )
+
+        [event] = await github_service.fetch_new_commits("owner", "repo", limit=3)
+
+        assert route.calls.last.request.url.params["per_page"] == "3"
+        assert event.title == long_subject[:256]
+        assert event.description == f"{long_subject}\n\nDetailed body"
         await github_service.close()
 
 
@@ -424,6 +463,16 @@ class TestGitHubServiceIssues:
 
 
 class TestGitHubServiceHelpers:
+    def test_parse_datetime_accepts_zulu_timestamp(self, github_service: GitHubService) -> None:
+        parsed = github_service._parse_datetime("2024-01-15T10:30:00Z")
+
+        assert parsed.year == 2024
+        assert parsed.month == 1
+        assert parsed.day == 15
+        assert parsed.hour == 10
+        assert parsed.minute == 30
+        assert parsed.tzinfo == UTC
+
     def test_parse_datetime_returns_now_for_empty_and_invalid_values(
         self, github_service: GitHubService
     ) -> None:

--- a/tests/test_services/test_github_service.py
+++ b/tests/test_services/test_github_service.py
@@ -1,3 +1,6 @@
+from datetime import UTC
+from unittest.mock import AsyncMock
+
 import httpx
 import pytest
 import respx
@@ -8,6 +11,29 @@ from intelstream.services.github_service import GitHubAPIError, GitHubService
 @pytest.fixture
 def github_service():
     return GitHubService(token="test-token")
+
+
+class TestGitHubServiceClient:
+    async def test_get_client_lazily_creates_owned_client(self) -> None:
+        service = GitHubService(token="test-token")
+
+        client = await service._get_client()
+
+        assert service._client is client
+        assert service._owns_client is True
+
+        await service.close()
+
+        assert service._client is None
+
+    async def test_close_does_not_close_injected_client(self) -> None:
+        client = AsyncMock(spec=httpx.AsyncClient)
+        service = GitHubService(token="test-token", http_client=client)
+
+        await service.close()
+
+        client.aclose.assert_not_called()
+        assert service._client is client
 
 
 class TestGitHubServiceValidation:
@@ -43,6 +69,31 @@ class TestGitHubServiceValidation:
             await github_service.validate_repo("owner", "repo")
 
         assert exc_info.value.status_code == 401
+        await github_service.close()
+
+    @pytest.mark.parametrize(
+        ("status_code", "message"),
+        [
+            (403, "Rate limit exceeded or access denied"),
+            (500, "server exploded"),
+        ],
+    )
+    @respx.mock
+    async def test_request_normalizes_additional_error_statuses(
+        self,
+        github_service: GitHubService,
+        status_code: int,
+        message: str,
+    ) -> None:
+        respx.get("https://api.github.com/repos/owner/repo").mock(
+            return_value=httpx.Response(status_code, text=message)
+        )
+
+        with pytest.raises(GitHubAPIError) as exc_info:
+            await github_service.validate_repo("owner", "repo")
+
+        assert exc_info.value.status_code == status_code
+        assert exc_info.value.message == message
         await github_service.close()
 
 
@@ -117,6 +168,41 @@ class TestGitHubServiceCommits:
         assert events[0].sha == "new123"
         await github_service.close()
 
+    async def test_fetch_commits_returns_empty_for_non_list_response(
+        self, github_service: GitHubService
+    ) -> None:
+        github_service._request = AsyncMock(return_value={"message": "unexpected"})
+
+        assert await github_service.fetch_new_commits("owner", "repo") == []
+
+    @respx.mock
+    async def test_fetch_commits_uses_committer_author_fallback(
+        self, github_service: GitHubService
+    ) -> None:
+        respx.get("https://api.github.com/repos/owner/repo/commits").mock(
+            return_value=httpx.Response(
+                200,
+                json=[
+                    {
+                        "sha": "abc123",
+                        "commit": {
+                            "message": "Commit from detached identity",
+                            "author": {"name": "Committer Name", "date": ""},
+                        },
+                        "author": None,
+                        "html_url": "",
+                    }
+                ],
+            )
+        )
+
+        events = await github_service.fetch_new_commits("owner", "repo")
+
+        assert events[0].author == "Committer Name"
+        assert events[0].description is None
+        assert events[0].created_at.tzinfo == UTC
+        await github_service.close()
+
 
 class TestGitHubServicePRs:
     @respx.mock
@@ -172,6 +258,54 @@ class TestGitHubServicePRs:
 
         assert len(events) == 1
         assert events[0].state == "merged"
+        await github_service.close()
+
+    async def test_fetch_prs_returns_empty_for_non_list_response(
+        self, github_service: GitHubService
+    ) -> None:
+        github_service._request = AsyncMock(return_value={"message": "unexpected"})
+
+        assert await github_service.fetch_new_prs("owner", "repo") == []
+
+    @respx.mock
+    async def test_fetch_prs_stops_at_since_number_and_uses_defaults(
+        self, github_service: GitHubService
+    ) -> None:
+        prs_response = [
+            {
+                "number": 44,
+                "title": "New PR",
+                "body": None,
+                "state": "open",
+                "merged_at": None,
+                "head": {},
+                "html_url": "",
+                "created_at": "not-a-date",
+            },
+            {
+                "number": 43,
+                "title": "Old PR",
+                "body": "old",
+                "state": "open",
+                "merged_at": None,
+                "head": {},
+                "user": {"login": "old", "avatar_url": ""},
+                "html_url": "",
+                "created_at": "2024-01-15T10:30:00Z",
+            },
+        ]
+
+        respx.get("https://api.github.com/repos/owner/repo/pulls").mock(
+            return_value=httpx.Response(200, json=prs_response)
+        )
+
+        events = await github_service.fetch_new_prs("owner", "repo", since_number=43)
+
+        assert len(events) == 1
+        assert events[0].number == 44
+        assert events[0].author == "Unknown"
+        assert events[0].description is None
+        assert events[0].created_at.tzinfo == UTC
         await github_service.close()
 
 
@@ -235,3 +369,66 @@ class TestGitHubServiceIssues:
         assert len(events) == 1
         assert events[0].number == 10
         await github_service.close()
+
+    async def test_fetch_issues_returns_empty_for_non_list_response(
+        self, github_service: GitHubService
+    ) -> None:
+        github_service._request = AsyncMock(return_value={"message": "unexpected"})
+
+        assert await github_service.fetch_new_issues("owner", "repo") == []
+
+    @respx.mock
+    async def test_fetch_issues_stops_at_since_number_and_uses_defaults(
+        self, github_service: GitHubService
+    ) -> None:
+        issues_response = [
+            {
+                "number": 12,
+                "title": "New issue",
+                "body": "X" * 600,
+                "html_url": "",
+                "created_at": "",
+            },
+            {
+                "number": 11,
+                "title": "Old issue",
+                "body": "old",
+                "state": "closed",
+                "user": {"login": "old", "avatar_url": ""},
+                "html_url": "",
+                "created_at": "2024-01-15T10:30:00Z",
+            },
+        ]
+
+        respx.get("https://api.github.com/repos/owner/repo/issues").mock(
+            return_value=httpx.Response(200, json=issues_response)
+        )
+
+        events = await github_service.fetch_new_issues("owner", "repo", since_number=11)
+
+        assert len(events) == 1
+        assert events[0].number == 12
+        assert events[0].author == "Unknown"
+        assert events[0].state == "open"
+        assert events[0].description is not None
+        assert events[0].description.endswith("...")
+        assert events[0].created_at.tzinfo == UTC
+        await github_service.close()
+
+
+class TestGitHubServiceHelpers:
+    def test_parse_datetime_returns_now_for_empty_and_invalid_values(
+        self, github_service: GitHubService
+    ) -> None:
+        assert github_service._parse_datetime("").tzinfo == UTC
+        assert github_service._parse_datetime("not-a-date").tzinfo == UTC
+
+    @pytest.mark.parametrize("text", [None, ""])
+    def test_truncate_returns_none_for_empty_values(
+        self, github_service: GitHubService, text: str | None
+    ) -> None:
+        assert github_service._truncate(text, 10) is None
+
+    def test_truncate_short_and_long_values(self, github_service: GitHubService) -> None:
+        assert github_service._truncate("short", 10) == "short"
+        assert github_service._truncate("abcdefghijk", 10) == "abcdefg..."

--- a/tests/test_services/test_llm_client.py
+++ b/tests/test_services/test_llm_client.py
@@ -36,6 +36,27 @@ class TestCreateLLMClient:
         assert client == client_cls.return_value
         client_cls.assert_called_once_with(api_key="key", model="claude")
 
+    def test_anthropic_provider_enum_creates_anthropic_client(self) -> None:
+        with patch("anthropic.AsyncAnthropic") as anthropic_cls:
+            client = create_llm_client(LLMProvider.ANTHROPIC, api_key="key", model="claude")
+
+        assert isinstance(client, AnthropicLLMClient)
+        anthropic_cls.assert_called_once_with(api_key="key")
+
+    def test_openai_provider_enum_creates_openai_client(self) -> None:
+        with patch("openai.AsyncOpenAI") as openai_cls:
+            client = create_llm_client(LLMProvider.OPENAI, api_key="key", model="gpt-4o")
+
+        assert isinstance(client, OpenAILLMClient)
+        openai_cls.assert_called_once_with(api_key="key")
+
+    def test_gemini_provider_enum_creates_gemini_client(self) -> None:
+        with patch("google.genai.Client") as gemini_cls:
+            client = create_llm_client(LLMProvider.GEMINI, api_key="key", model="gemini-pro")
+
+        assert isinstance(client, GeminiLLMClient)
+        gemini_cls.assert_called_once_with(api_key="key")
+
     def test_kimi_uses_moonshot_openai_base_url(self) -> None:
         with patch("openai.AsyncOpenAI") as openai_cls:
             client = create_llm_client(LLMProvider.KIMI, api_key="key", model="moonshot")

--- a/tests/test_services/test_llm_client.py
+++ b/tests/test_services/test_llm_client.py
@@ -1,14 +1,146 @@
 from __future__ import annotations
 
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, PropertyMock, patch
 
 import pytest
 
 from intelstream.services.llm_client import (
+    AnthropicLLMClient,
     GeminiLLMClient,
+    LLMClient,
     LLMError,
+    LLMProvider,
+    LLMRateLimitError,
     OpenAILLMClient,
+    create_llm_client,
 )
+
+
+class TestBaseLLMClient:
+    @pytest.mark.asyncio
+    async def test_complete_must_be_implemented(self) -> None:
+        with pytest.raises(NotImplementedError):
+            await LLMClient().complete("system", "hello", 100)
+
+    @pytest.mark.asyncio
+    async def test_close_is_noop(self) -> None:
+        await LLMClient().close()
+
+
+class TestCreateLLMClient:
+    def test_creates_provider_from_string(self) -> None:
+        with patch("intelstream.services.llm_client.AnthropicLLMClient") as client_cls:
+            client = create_llm_client("anthropic", api_key="key", model="claude")
+
+        assert client == client_cls.return_value
+        client_cls.assert_called_once_with(api_key="key", model="claude")
+
+    def test_kimi_uses_moonshot_openai_base_url(self) -> None:
+        with patch("openai.AsyncOpenAI") as openai_cls:
+            client = create_llm_client(LLMProvider.KIMI, api_key="key", model="moonshot")
+
+        assert isinstance(client, OpenAILLMClient)
+        openai_cls.assert_called_once_with(
+            api_key="key",
+            base_url="https://api.moonshot.cn/v1",
+        )
+
+    def test_rejects_invalid_provider_string(self) -> None:
+        with pytest.raises(ValueError, match="not-a-provider"):
+            create_llm_client("not-a-provider", api_key="key", model="model")
+
+
+class TestAnthropicLLMClient:
+    @pytest.mark.asyncio
+    async def test_valid_response_joins_text_blocks(self) -> None:
+        with patch("anthropic.AsyncAnthropic"):
+            client = AnthropicLLMClient(api_key="test-key", model="claude")
+
+        mock_message = MagicMock()
+        mock_message.content = [
+            SimpleNamespace(text="  first  "),
+            object(),
+            SimpleNamespace(text="second"),
+        ]
+        client._client.messages.create = AsyncMock(return_value=mock_message)
+
+        result = await client.complete("system", "hello", 100)
+
+        assert result == "first  \n\nsecond"
+        client._client.messages.create.assert_awaited_once_with(
+            model="claude",
+            max_tokens=100,
+            system="system",
+            messages=[{"role": "user", "content": "hello"}],
+        )
+
+    @pytest.mark.asyncio
+    async def test_empty_content_raises_llm_error(self) -> None:
+        with patch("anthropic.AsyncAnthropic"):
+            client = AnthropicLLMClient(api_key="test-key", model="claude")
+
+        mock_message = MagicMock()
+        mock_message.content = []
+        client._client.messages.create = AsyncMock(return_value=mock_message)
+
+        with pytest.raises(LLMError, match="Empty response from Anthropic"):
+            await client.complete("system", "hello", 100)
+
+    @pytest.mark.asyncio
+    async def test_no_text_blocks_raises_llm_error(self) -> None:
+        with patch("anthropic.AsyncAnthropic"):
+            client = AnthropicLLMClient(api_key="test-key", model="claude")
+
+        mock_message = MagicMock()
+        mock_message.content = [object()]
+        client._client.messages.create = AsyncMock(return_value=mock_message)
+
+        with pytest.raises(LLMError, match="No text content"):
+            await client.complete("system", "hello", 100)
+
+    @pytest.mark.asyncio
+    async def test_rate_limit_error_is_normalized(self) -> None:
+        class FakeRateLimitError(Exception):
+            pass
+
+        with patch("anthropic.AsyncAnthropic"):
+            client = AnthropicLLMClient(api_key="test-key", model="claude")
+
+        client._client.messages.create = AsyncMock(side_effect=FakeRateLimitError("slow down"))
+
+        with (
+            patch("anthropic.RateLimitError", FakeRateLimitError),
+            pytest.raises(LLMRateLimitError, match="slow down"),
+        ):
+            await client.complete("system", "hello", 100)
+
+    @pytest.mark.asyncio
+    async def test_api_error_is_normalized(self) -> None:
+        class FakeAPIError(Exception):
+            pass
+
+        with patch("anthropic.AsyncAnthropic"):
+            client = AnthropicLLMClient(api_key="test-key", model="claude")
+
+        client._client.messages.create = AsyncMock(side_effect=FakeAPIError("bad gateway"))
+
+        with (
+            patch("anthropic.APIError", FakeAPIError),
+            pytest.raises(LLMError, match="Anthropic API error: bad gateway"),
+        ):
+            await client.complete("system", "hello", 100)
+
+    @pytest.mark.asyncio
+    async def test_close_closes_underlying_client(self) -> None:
+        with patch("anthropic.AsyncAnthropic"):
+            client = AnthropicLLMClient(api_key="test-key", model="claude")
+
+        client._client.close = AsyncMock()
+
+        await client.close()
+
+        client._client.close.assert_awaited_once()
 
 
 class TestOpenAILLMClientEmptyChoices:
@@ -52,6 +184,73 @@ class TestOpenAILLMClientEmptyChoices:
         result = await client.complete("system", "hello", 100)
         assert result == "Hello world"
 
+    @pytest.mark.asyncio
+    async def test_request_includes_system_and_user_messages(self) -> None:
+        with patch("openai.AsyncOpenAI"):
+            client = OpenAILLMClient(api_key="test-key", model="gpt-4")
+
+        mock_choice = MagicMock()
+        mock_choice.message.content = "ok"
+        mock_response = MagicMock()
+        mock_response.choices = [mock_choice]
+        client._client.chat.completions.create = AsyncMock(return_value=mock_response)
+
+        await client.complete("system prompt", "user prompt", 321)
+
+        client._client.chat.completions.create.assert_awaited_once_with(
+            model="gpt-4",
+            max_tokens=321,
+            messages=[
+                {"role": "system", "content": "system prompt"},
+                {"role": "user", "content": "user prompt"},
+            ],
+        )
+
+    @pytest.mark.asyncio
+    async def test_rate_limit_error_is_normalized(self) -> None:
+        class FakeRateLimitError(Exception):
+            pass
+
+        with patch("openai.AsyncOpenAI"):
+            client = OpenAILLMClient(api_key="test-key", model="gpt-4")
+
+        client._client.chat.completions.create = AsyncMock(
+            side_effect=FakeRateLimitError("limited")
+        )
+
+        with (
+            patch("openai.RateLimitError", FakeRateLimitError),
+            pytest.raises(LLMRateLimitError, match="limited"),
+        ):
+            await client.complete("system", "hello", 100)
+
+    @pytest.mark.asyncio
+    async def test_api_error_is_normalized(self) -> None:
+        class FakeAPIError(Exception):
+            pass
+
+        with patch("openai.AsyncOpenAI"):
+            client = OpenAILLMClient(api_key="test-key", model="gpt-4")
+
+        client._client.chat.completions.create = AsyncMock(side_effect=FakeAPIError("bad"))
+
+        with (
+            patch("openai.APIError", FakeAPIError),
+            pytest.raises(LLMError, match="OpenAI API error: bad"),
+        ):
+            await client.complete("system", "hello", 100)
+
+    @pytest.mark.asyncio
+    async def test_close_closes_underlying_client(self) -> None:
+        with patch("openai.AsyncOpenAI"):
+            client = OpenAILLMClient(api_key="test-key", model="gpt-4")
+
+        client._client.close = AsyncMock()
+
+        await client.close()
+
+        client._client.close.assert_awaited_once()
+
 
 class TestGeminiLLMClientSafetyFilter:
     @pytest.mark.asyncio
@@ -91,3 +290,40 @@ class TestGeminiLLMClientSafetyFilter:
 
         result = await client.complete("system", "hello", 100)
         assert result == "Hello world"
+
+    @pytest.mark.asyncio
+    async def test_resource_exhausted_error_is_rate_limit(self) -> None:
+        class ResourceExhaustedError(Exception):
+            pass
+
+        with patch("google.genai.Client"):
+            client = GeminiLLMClient(api_key="test-key", model="gemini-pro")
+
+        client._client.aio.models.generate_content = AsyncMock(
+            side_effect=ResourceExhaustedError("quota exhausted")
+        )
+
+        with pytest.raises(LLMRateLimitError, match="quota exhausted"):
+            await client.complete("system", "hello", 100)
+
+    @pytest.mark.asyncio
+    async def test_429_error_is_rate_limit(self) -> None:
+        with patch("google.genai.Client"):
+            client = GeminiLLMClient(api_key="test-key", model="gemini-pro")
+
+        client._client.aio.models.generate_content = AsyncMock(side_effect=RuntimeError("429"))
+
+        with pytest.raises(LLMRateLimitError, match="429"):
+            await client.complete("system", "hello", 100)
+
+    @pytest.mark.asyncio
+    async def test_generic_error_is_normalized(self) -> None:
+        with patch("google.genai.Client"):
+            client = GeminiLLMClient(api_key="test-key", model="gemini-pro")
+
+        client._client.aio.models.generate_content = AsyncMock(
+            side_effect=RuntimeError("backend down")
+        )
+
+        with pytest.raises(LLMError, match="Gemini API error: backend down"):
+            await client.complete("system", "hello", 100)

--- a/tests/test_services/test_llm_client.py
+++ b/tests/test_services/test_llm_client.py
@@ -321,6 +321,23 @@ class TestGeminiLLMClientSafetyFilter:
         assert result == "Hello world"
 
     @pytest.mark.asyncio
+    async def test_request_includes_system_instruction_and_max_tokens(self) -> None:
+        with patch("google.genai.Client"):
+            client = GeminiLLMClient(api_key="test-key", model="gemini-pro")
+
+        mock_response = MagicMock()
+        type(mock_response).text = PropertyMock(return_value="ok")
+        client._client.aio.models.generate_content = AsyncMock(return_value=mock_response)
+
+        await client.complete("system prompt", "user prompt", 321)
+
+        call_kwargs = client._client.aio.models.generate_content.await_args.kwargs
+        assert call_kwargs["model"] == "gemini-pro"
+        assert call_kwargs["contents"] == "user prompt"
+        assert call_kwargs["config"].system_instruction == "system prompt"
+        assert call_kwargs["config"].max_output_tokens == 321
+
+    @pytest.mark.asyncio
     async def test_resource_exhausted_error_is_rate_limit(self) -> None:
         class ResourceExhaustedError(Exception):
             pass

--- a/tests/test_services/test_llm_client.py
+++ b/tests/test_services/test_llm_client.py
@@ -71,6 +71,14 @@ class TestCreateLLMClient:
         with pytest.raises(ValueError, match="not-a-provider"):
             create_llm_client("not-a-provider", api_key="key", model="model")
 
+    def test_rejects_unknown_provider_object(self) -> None:
+        class UnknownProvider:
+            def __str__(self) -> str:
+                return "custom-provider"
+
+        with pytest.raises(ValueError, match="custom-provider"):
+            create_llm_client(UnknownProvider(), api_key="key", model="model")  # type: ignore[arg-type]
+
 
 class TestAnthropicLLMClient:
     @pytest.mark.asyncio

--- a/tests/test_services/test_message_forwarder.py
+++ b/tests/test_services/test_message_forwarder.py
@@ -192,6 +192,33 @@ class TestDownloadAttachments:
         first_attachment.to_file.assert_awaited_once()
         second_attachment.to_file.assert_not_called()
 
+    async def test_download_attachments_only_reads_first_ten_attachments(self, forwarder):
+        attachments = []
+        files = []
+        for index in range(12):
+            mock_file = MagicMock(spec=discord.File)
+            attachment = MagicMock()
+            attachment.filename = f"file-{index}.txt"
+            attachment.size = 1000
+            attachment.to_file = AsyncMock(return_value=mock_file)
+            attachments.append(attachment)
+            files.append(mock_file)
+
+        message = MagicMock(spec=discord.Message)
+        message.attachments = attachments
+
+        destination = MagicMock(spec=discord.TextChannel)
+        destination.guild = MagicMock()
+        destination.guild.filesize_limit = 8_000_000
+
+        result = await forwarder._download_attachments(message, destination)
+
+        assert result == files[:10]
+        for attachment in attachments[:10]:
+            attachment.to_file.assert_awaited_once()
+        for attachment in attachments[10:]:
+            attachment.to_file.assert_not_called()
+
     async def test_download_attachments_http_error(self, forwarder):
         mock_attachment = MagicMock()
         mock_attachment.size = 1000
@@ -435,6 +462,32 @@ class TestForwardMessage:
         assert call_kwargs["embeds"] == [mock_embed]
         assert "content" not in call_kwargs
         assert "files" not in call_kwargs
+
+    async def test_forward_embed_only_message_caps_embeds_at_discord_limit(
+        self, forwarder, mock_bot
+    ):
+        mock_destination = MagicMock(spec=discord.TextChannel)
+        mock_destination.guild = MagicMock()
+        mock_destination.guild.filesize_limit = 8_000_000
+        mock_forwarded = MagicMock(spec=discord.Message)
+        mock_destination.send = AsyncMock(return_value=mock_forwarded)
+
+        mock_bot.get_channel = MagicMock(return_value=mock_destination)
+
+        embeds = [MagicMock(spec=discord.Embed) for _ in range(12)]
+        message = MagicMock(spec=discord.Message)
+        message.channel = MagicMock()
+        message.channel.id = 111
+        message.id = 222
+        message.content = ""
+        message.embeds = embeds
+        message.attachments = []
+
+        result = await forwarder.forward_message(message, 333, "channel")
+
+        assert result == mock_forwarded
+        call_kwargs = mock_destination.send.call_args.kwargs
+        assert call_kwargs["embeds"] == embeds[:10]
 
     async def test_forward_empty_message_returns_none(self, forwarder, mock_bot):
         """Messages with no content, no attachments, and no embeds are skipped."""

--- a/tests/test_services/test_message_forwarder.py
+++ b/tests/test_services/test_message_forwarder.py
@@ -3,7 +3,7 @@ from unittest.mock import AsyncMock, MagicMock
 import discord
 import pytest
 
-from intelstream.services.message_forwarder import MessageForwarder
+from intelstream.services.message_forwarder import MAX_TOTAL_ATTACHMENT_SIZE, MessageForwarder
 
 
 @pytest.fixture
@@ -103,6 +103,35 @@ class TestGetDestination:
         assert result == mock_thread
         mock_guild.fetch_channel.assert_called_once_with(12345)
 
+    async def test_get_thread_destination_ignores_forbidden_api_fetch(self, forwarder, mock_bot):
+        mock_guild = MagicMock()
+        mock_guild.id = 123456
+        mock_guild.get_thread = MagicMock(return_value=None)
+        mock_guild.fetch_channel = AsyncMock(
+            side_effect=discord.Forbidden(MagicMock(), "Forbidden")
+        )
+        mock_bot.guilds = [mock_guild]
+        mock_bot.get_channel = MagicMock(return_value=None)
+
+        result = await forwarder._get_destination(12345, "thread")
+
+        assert result is None
+        mock_guild.fetch_channel.assert_called_once_with(12345)
+
+    async def test_get_thread_destination_ignores_fetched_non_thread(self, forwarder, mock_bot):
+        mock_channel = MagicMock(spec=discord.TextChannel)
+        mock_guild = MagicMock()
+        mock_guild.id = 123456
+        mock_guild.get_thread = MagicMock(return_value=None)
+        mock_guild.fetch_channel = AsyncMock(return_value=mock_channel)
+        mock_bot.guilds = [mock_guild]
+        mock_bot.get_channel = MagicMock(return_value=None)
+
+        result = await forwarder._get_destination(12345, "thread")
+
+        assert result is None
+        mock_guild.fetch_channel.assert_called_once_with(12345)
+
 
 class TestDownloadAttachments:
     async def test_download_attachments_success(self, forwarder):
@@ -139,6 +168,29 @@ class TestDownloadAttachments:
 
         assert len(files) == 0
         mock_attachment.to_file.assert_not_called()
+
+    async def test_download_attachments_stops_at_total_size_limit(self, forwarder):
+        mock_file = MagicMock(spec=discord.File)
+        first_attachment = MagicMock()
+        first_attachment.filename = "first.bin"
+        first_attachment.size = MAX_TOTAL_ATTACHMENT_SIZE - 100
+        first_attachment.to_file = AsyncMock(return_value=mock_file)
+        second_attachment = MagicMock()
+        second_attachment.filename = "second.bin"
+        second_attachment.size = 200
+
+        message = MagicMock(spec=discord.Message)
+        message.attachments = [first_attachment, second_attachment]
+
+        destination = MagicMock(spec=discord.TextChannel)
+        destination.guild = MagicMock()
+        destination.guild.filesize_limit = MAX_TOTAL_ATTACHMENT_SIZE
+
+        files = await forwarder._download_attachments(message, destination)
+
+        assert files == [mock_file]
+        first_attachment.to_file.assert_awaited_once()
+        second_attachment.to_file.assert_not_called()
 
     async def test_download_attachments_http_error(self, forwarder):
         mock_attachment = MagicMock()
@@ -302,6 +354,28 @@ class TestForwardMessage:
 
         assert result == mock_forwarded
         mock_destination.edit.assert_called_once_with(archived=False)
+
+    async def test_forward_message_returns_none_when_thread_unarchive_forbidden(
+        self, forwarder, mock_bot
+    ):
+        mock_destination = MagicMock(spec=discord.Thread)
+        mock_destination.archived = True
+        mock_destination.guild = MagicMock()
+        mock_destination.guild.filesize_limit = 8_000_000
+        mock_destination.edit = AsyncMock(
+            side_effect=discord.Forbidden(MagicMock(), "No permission")
+        )
+        mock_destination.send = AsyncMock()
+
+        mock_bot.get_channel = MagicMock(return_value=mock_destination)
+
+        message = MagicMock(spec=discord.Message)
+
+        result = await forwarder.forward_message(message, 333, "thread")
+
+        assert result is None
+        mock_destination.edit.assert_awaited_once_with(archived=False)
+        mock_destination.send.assert_not_called()
 
     async def test_forward_message_does_not_include_embeds(self, forwarder, mock_bot):
         """Embeds are not forwarded so Discord can generate native URL previews."""

--- a/tests/test_services/test_message_ingestion.py
+++ b/tests/test_services/test_message_ingestion.py
@@ -546,10 +546,20 @@ class TestMessageIngestionService:
         channel = FakeHistoryChannel(messages)
         service.store_chunks = AsyncMock(return_value=1)
         checkpoint_chunks = [
-            Chunk(messages=raw_messages[:2], guild_id="guild-1", channel_id="222", channel_name="general")
+            Chunk(
+                messages=raw_messages[:2],
+                guild_id="guild-1",
+                channel_id="222",
+                channel_name="general",
+            )
         ]
         final_chunks = [
-            Chunk(messages=raw_messages[2:], guild_id="guild-1", channel_id="222", channel_name="general")
+            Chunk(
+                messages=raw_messages[2:],
+                guild_id="guild-1",
+                channel_id="222",
+                channel_name="general",
+            )
         ]
         service._chunker.chunk_messages = MagicMock(side_effect=[checkpoint_chunks, final_chunks])
 

--- a/tests/test_services/test_message_ingestion.py
+++ b/tests/test_services/test_message_ingestion.py
@@ -1,6 +1,8 @@
+import asyncio
 from datetime import UTC, datetime, timedelta
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
+import discord
 import pytest
 
 from intelstream.services.message_ingestion import (
@@ -11,6 +13,8 @@ from intelstream.services.message_ingestion import (
     _is_trivial,
     _should_discard_chunk,
     _should_skip_message,
+    clean_message_chunk_text,
+    discord_message_to_raw,
 )
 
 
@@ -30,6 +34,42 @@ def _make_raw(
         created_at=created_at or datetime(2024, 6, 1, 12, 0, tzinfo=UTC),
         is_system=is_system,
     )
+
+
+class FakeHistoryChannel:
+    def __init__(self, messages: list[MagicMock], *, channel_id: int = 222) -> None:
+        self.id = channel_id
+        self.name = "general"
+        self.messages = messages
+        self.history_kwargs: dict[str, object] | None = None
+
+    def history(self, **kwargs):
+        self.history_kwargs = kwargs
+
+        async def _iter_messages():
+            for msg in self.messages:
+                yield msg
+
+        return _iter_messages()
+
+
+def _make_discord_message(message_id: int = 1) -> MagicMock:
+    msg = MagicMock(spec=discord.Message)
+    msg.id = message_id
+    return msg
+
+
+def _make_progress(
+    *,
+    status: str = "pending",
+    last_message_id: str | None = None,
+    total_fetched: int | None = 0,
+) -> MagicMock:
+    progress = MagicMock()
+    progress.status = status
+    progress.last_message_id = last_message_id
+    progress.total_fetched = total_fetched
+    return progress
 
 
 class TestIsTrivial:
@@ -164,6 +204,45 @@ class TestChunk:
             channel_name="test",
         )
         assert chunk.meaningful_count == 2
+
+
+class TestDiscordMessageToRaw:
+    def test_converts_naive_created_at_to_utc(self):
+        msg = MagicMock(spec=discord.Message)
+        msg.id = 123
+        msg.content = "hello"
+        msg.author.display_name = "Alice"
+        msg.author.bot = False
+        msg.created_at = datetime(2026, 5, 25, 12, 0)
+        msg.type = discord.MessageType.default
+
+        raw = discord_message_to_raw(msg)
+
+        assert raw.id == 123
+        assert raw.created_at.tzinfo == UTC
+        assert raw.author_name == "Alice"
+        assert raw.is_system is False
+
+    def test_marks_non_default_message_types_as_system(self):
+        msg = MagicMock(spec=discord.Message)
+        msg.id = 123
+        msg.content = None
+        msg.author.display_name = "Alice"
+        msg.author.bot = False
+        msg.created_at = datetime(2026, 5, 25, 12, 0, tzinfo=UTC)
+        msg.type = discord.MessageType.pins_add
+
+        raw = discord_message_to_raw(msg)
+
+        assert raw.content == ""
+        assert raw.is_system is True
+
+
+class TestCleanMessageChunkText:
+    def test_removes_timestamp_prefixes_and_blank_lines(self):
+        text = "\n[2026-05-25 12:00] Alice: hello\n   \nBob: no timestamp\n"
+
+        assert clean_message_chunk_text(text) == "Alice: hello\nBob: no timestamp"
 
 
 class TestMessageChunker:
@@ -362,3 +441,279 @@ class TestMessageIngestionService:
         assert service.is_paused is True
         service.resume()
         assert service.is_paused is False
+
+    async def test_ingest_channel_skips_completed_progress(self, service, mock_deps):
+        repository, _, _ = mock_deps
+        repository.get_or_create_ingestion_progress = AsyncMock(
+            return_value=_make_progress(status="completed", total_fetched=5)
+        )
+        channel = FakeHistoryChannel([])
+
+        await service.ingest_channel(channel, "guild-1")
+
+        repository.update_ingestion_progress.assert_not_called()
+        assert channel.history_kwargs is None
+
+    async def test_ingest_channel_completes_and_stores_final_buffer(self, service, mock_deps):
+        repository, _, _ = mock_deps
+        repository.get_or_create_ingestion_progress = AsyncMock(return_value=_make_progress())
+        repository.update_ingestion_progress = AsyncMock()
+        messages = [_make_discord_message(i) for i in [1, 2, 3]]
+        raw_messages = [
+            _make_raw(
+                id=i,
+                content=f"Message {i} has enough content to keep this chunk",
+                created_at=datetime(2026, 5, 25, 12, i, tzinfo=UTC),
+            )
+            for i in [1, 2, 3]
+        ]
+        channel = FakeHistoryChannel(messages)
+        service.store_chunks = AsyncMock(return_value=1)
+
+        with patch(
+            "intelstream.services.message_ingestion.discord_message_to_raw",
+            side_effect=raw_messages,
+        ):
+            await service.ingest_channel(channel, "guild-1", channel_index=1, total_channels=2)
+
+        service.store_chunks.assert_awaited_once()
+        stored_chunks = service.store_chunks.await_args.args[0]
+        assert len(stored_chunks) == 1
+        assert stored_chunks[0].start_message_id == "1"
+        assert stored_chunks[0].end_message_id == "3"
+        repository.update_ingestion_progress.assert_any_await(
+            "guild-1",
+            "222",
+            status="completed",
+            total_fetched=3,
+            last_message_id="3",
+        )
+
+    async def test_ingest_channel_resumes_after_last_message_id(self, service, mock_deps):
+        repository, _, _ = mock_deps
+        repository.get_or_create_ingestion_progress = AsyncMock(
+            return_value=_make_progress(last_message_id="99", total_fetched=4)
+        )
+        repository.update_ingestion_progress = AsyncMock()
+        channel = FakeHistoryChannel([])
+
+        await service.ingest_channel(channel, "guild-1")
+
+        assert channel.history_kwargs is not None
+        after = channel.history_kwargs["after"]
+        assert isinstance(after, discord.Object)
+        assert after.id == 99
+        repository.update_ingestion_progress.assert_any_await(
+            "guild-1",
+            "222",
+            status="completed",
+            total_fetched=4,
+            last_message_id="99",
+        )
+
+    async def test_ingest_channel_pauses_before_processing_next_message(self, service, mock_deps):
+        repository, _, _ = mock_deps
+        repository.get_or_create_ingestion_progress = AsyncMock(return_value=_make_progress())
+        repository.update_ingestion_progress = AsyncMock()
+        channel = FakeHistoryChannel([_make_discord_message(10)])
+        service.pause()
+        service.store_chunks = AsyncMock()
+
+        await service.ingest_channel(channel, "guild-1")
+
+        service.store_chunks.assert_not_called()
+        repository.update_ingestion_progress.assert_any_await(
+            "guild-1",
+            "222",
+            status="paused",
+            last_message_id="10",
+            total_fetched=0,
+        )
+
+    async def test_ingest_channel_checkpoints_and_keeps_leftover_buffer(self, service, mock_deps):
+        repository, _, _ = mock_deps
+        repository.get_or_create_ingestion_progress = AsyncMock(return_value=_make_progress())
+        repository.update_ingestion_progress = AsyncMock()
+        messages = [_make_discord_message(i) for i in [1, 2, 3]]
+        raw_messages = [
+            _make_raw(
+                id=i,
+                content=f"Checkpoint message {i} has enough useful text",
+                created_at=datetime(2026, 5, 25, 12, i, tzinfo=UTC),
+            )
+            for i in [1, 2, 3]
+        ]
+        channel = FakeHistoryChannel(messages)
+        service.store_chunks = AsyncMock(return_value=1)
+        checkpoint_chunks = [
+            Chunk(messages=raw_messages[:2], guild_id="guild-1", channel_id="222", channel_name="general")
+        ]
+        final_chunks = [
+            Chunk(messages=raw_messages[2:], guild_id="guild-1", channel_id="222", channel_name="general")
+        ]
+        service._chunker.chunk_messages = MagicMock(side_effect=[checkpoint_chunks, final_chunks])
+
+        with (
+            patch("intelstream.services.message_ingestion.CHECKPOINT_INTERVAL", 2),
+            patch("intelstream.services.message_ingestion.YIELD_INTERVAL", 1000),
+            patch(
+                "intelstream.services.message_ingestion.discord_message_to_raw",
+                side_effect=raw_messages,
+            ),
+        ):
+            await service.ingest_channel(channel, "guild-1")
+
+        assert service.store_chunks.await_count == 2
+        repository.update_ingestion_progress.assert_any_await(
+            "guild-1",
+            "222",
+            last_message_id="2",
+            total_fetched=2,
+        )
+        first_final_chunk = service.store_chunks.await_args_list[-1].args[0][0]
+        assert first_final_chunk.start_message_id == "3"
+
+    async def test_ingest_channel_yields_periodically(self, service, mock_deps):
+        repository, _, _ = mock_deps
+        repository.get_or_create_ingestion_progress = AsyncMock(return_value=_make_progress())
+        repository.update_ingestion_progress = AsyncMock()
+        messages = [_make_discord_message(i) for i in [1, 2, 3]]
+        raw_messages = [_make_raw(id=i, content=f"Message {i} with enough text") for i in [1, 2, 3]]
+        channel = FakeHistoryChannel(messages)
+        service.store_chunks = AsyncMock(return_value=0)
+
+        with (
+            patch("intelstream.services.message_ingestion.YIELD_INTERVAL", 2),
+            patch("intelstream.services.message_ingestion.asyncio.sleep", AsyncMock()) as sleep,
+            patch(
+                "intelstream.services.message_ingestion.discord_message_to_raw",
+                side_effect=raw_messages,
+            ),
+        ):
+            await service.ingest_channel(channel, "guild-1")
+
+        sleep.assert_awaited_once_with(0.1)
+
+    async def test_ingest_channel_records_pause_state_on_error(self, service, mock_deps):
+        repository, _, _ = mock_deps
+        repository.get_or_create_ingestion_progress = AsyncMock(
+            return_value=_make_progress(last_message_id="5", total_fetched=7)
+        )
+        repository.update_ingestion_progress = AsyncMock()
+        channel = FakeHistoryChannel([_make_discord_message(10)])
+
+        with patch(
+            "intelstream.services.message_ingestion.discord_message_to_raw",
+            side_effect=RuntimeError("convert failed"),
+        ):
+            await service.ingest_channel(channel, "guild-1")
+
+        repository.update_ingestion_progress.assert_any_await(
+            "guild-1",
+            "222",
+            status="paused",
+            total_fetched=7,
+            last_message_id="5",
+        )
+
+    async def test_run_backfill_filters_sorts_and_ingests_readable_channels(self, service):
+        guild = MagicMock(spec=discord.Guild)
+        guild.id = 123
+        guild.name = "Guild"
+        guild.me = MagicMock()
+
+        def make_channel(name: str, last_message_id: int | None, readable: bool) -> MagicMock:
+            channel = MagicMock(spec=discord.TextChannel)
+            channel.name = name
+            channel.last_message_id = last_message_id
+            channel.permissions_for.return_value.read_message_history = readable
+            return channel
+
+        older = make_channel("older", 10, True)
+        newest = make_channel("newest", 30, True)
+        unreadable = make_channel("secret", 999, False)
+        none_last = make_channel("none", None, True)
+        guild.text_channels = [older, unreadable, newest, none_last]
+        service.ingest_channel = AsyncMock()
+
+        await service.run_backfill(guild)
+
+        assert [call.args[0].name for call in service.ingest_channel.await_args_list] == [
+            "newest",
+            "older",
+            "none",
+        ]
+        assert all(call.args[1] == "123" for call in service.ingest_channel.await_args_list)
+
+    async def test_run_backfill_stops_when_paused_between_channels(self, service):
+        guild = MagicMock(spec=discord.Guild)
+        guild.id = 123
+        guild.name = "Guild"
+        guild.me = MagicMock()
+        channels = []
+        for name in ["first", "second"]:
+            channel = MagicMock(spec=discord.TextChannel)
+            channel.name = name
+            channel.last_message_id = 1
+            channel.permissions_for.return_value.read_message_history = True
+            channels.append(channel)
+        guild.text_channels = channels
+
+        async def ingest_and_pause(*_args, **_kwargs):
+            service.pause()
+
+        service.ingest_channel = AsyncMock(side_effect=ingest_and_pause)
+
+        await service.run_backfill(guild)
+
+        service.ingest_channel.assert_awaited_once()
+
+    def test_start_backfill_creates_named_task(self, service):
+        guild = MagicMock(spec=discord.Guild)
+        guild.id = 123
+        task = MagicMock(spec=asyncio.Task)
+        task.done.return_value = False
+        service._paused = True
+
+        def fake_create_task(coro, *, name: str):
+            coro.close()
+            fake_create_task.name = name
+            return task
+
+        fake_create_task.name = ""
+
+        with patch(
+            "intelstream.services.message_ingestion.asyncio.create_task",
+            side_effect=fake_create_task,
+        ) as create_task:
+            service.start_backfill(guild)
+
+        assert service._paused is False
+        assert service._backfill_task is task
+        create_task.assert_called_once()
+        assert fake_create_task.name == "lore-backfill-123"
+
+    def test_start_backfill_noops_when_task_already_running(self, service):
+        task = MagicMock(spec=asyncio.Task)
+        task.done.return_value = False
+        service._backfill_task = task
+        guild = MagicMock(spec=discord.Guild)
+
+        with patch("intelstream.services.message_ingestion.asyncio.create_task") as create_task:
+            service.start_backfill(guild)
+
+        create_task.assert_not_called()
+
+    async def test_run_backfill_safe_swallows_errors(self, service):
+        guild = MagicMock(spec=discord.Guild)
+        guild.name = "Guild"
+        service.run_backfill = AsyncMock(side_effect=RuntimeError("boom"))
+
+        await service._run_backfill_safe(guild)
+
+        service.run_backfill.assert_awaited_once_with(guild)
+
+    def test_stop_backfill_sets_paused(self, service):
+        service.stop_backfill()
+
+        assert service.is_paused is True

--- a/tests/test_services/test_message_ingestion.py
+++ b/tests/test_services/test_message_ingestion.py
@@ -85,6 +85,10 @@ class TestIsTrivial:
     def test_emoji_only(self):
         assert _is_trivial("\U0001f600") is True
 
+    @pytest.mark.parametrize("emoji", ["<:party:123456789>", "<a:dance:987654321>"])
+    def test_discord_custom_emoji_only(self, emoji):
+        assert _is_trivial(emoji) is True
+
     def test_normal_text(self):
         assert _is_trivial("This is a normal message") is False
 
@@ -193,6 +197,20 @@ class TestChunk:
         assert chunk.authors == ["alice", "bob"]
         assert "alice: first" in chunk.text
         assert "bob: second" in chunk.text
+
+    def test_embedding_text_strips_content_and_skips_blank_lines(self):
+        chunk = Chunk(
+            messages=[
+                _make_raw(content="  first message  ", author_name="alice"),
+                _make_raw(content="   ", author_name="ignored"),
+                _make_raw(content="\nsecond message\n", author_name="bob"),
+            ],
+            guild_id="1",
+            channel_id="2",
+            channel_name="test",
+        )
+
+        assert chunk.embedding_text == "alice: first message\nbob: second message"
 
     def test_meaningful_count(self):
         chunk = Chunk(
@@ -306,6 +324,33 @@ class TestMessageChunker:
         assert len(result) == 2
         assert len(result[0].messages) == 5
         assert len(result[1].messages) == 5
+
+    def test_time_gap_at_threshold_stays_in_same_chunk(self):
+        chunker = MessageChunker(gap_minutes=10, max_messages=100)
+        base = datetime(2024, 6, 1, 12, 0, tzinfo=UTC)
+        messages = [
+            _make_raw(
+                id=1,
+                content="First meaningful message with enough words",
+                created_at=base,
+            ),
+            _make_raw(
+                id=2,
+                content="Second meaningful message with enough words",
+                created_at=base + timedelta(minutes=10),
+            ),
+            _make_raw(
+                id=3,
+                content="Third meaningful message with enough words",
+                created_at=base + timedelta(minutes=20),
+            ),
+        ]
+
+        result = chunker.chunk_messages(messages, "1", "2", "test")
+
+        assert len(result) == 1
+        assert result[0].start_message_id == "1"
+        assert result[0].end_message_id == "3"
 
     def test_max_messages_split(self):
         chunker = MessageChunker(gap_minutes=60, max_messages=5)

--- a/tests/test_services/test_message_ingestion.py
+++ b/tests/test_services/test_message_ingestion.py
@@ -82,6 +82,9 @@ class TestIsTrivial:
     def test_url_only(self):
         assert _is_trivial("https://example.com/page") is True
 
+    def test_emoji_only(self):
+        assert _is_trivial("\U0001f600") is True
+
     def test_normal_text(self):
         assert _is_trivial("This is a normal message") is False
 
@@ -320,6 +323,34 @@ class TestMessageChunker:
         ]
         result = chunker.chunk_messages(messages, "1", "2", "test")
         assert result == []
+
+    def test_discards_current_chunk_before_gap_and_keeps_next_valid_chunk(self):
+        chunker = MessageChunker(gap_minutes=10, max_messages=20)
+        base = datetime(2024, 6, 1, 12, 0, tzinfo=UTC)
+        messages = [
+            _make_raw(id=1, content="short setup", created_at=base),
+            _make_raw(id=2, content="another short setup", created_at=base + timedelta(minutes=1)),
+            _make_raw(
+                id=3,
+                content="Fresh thread with enough detail to keep as a chunk",
+                created_at=base + timedelta(minutes=30),
+            ),
+            _make_raw(
+                id=4,
+                content="Second useful message that belongs to the later thread",
+                created_at=base + timedelta(minutes=31),
+            ),
+            _make_raw(
+                id=5,
+                content="Third useful message that makes the later chunk meaningful",
+                created_at=base + timedelta(minutes=32),
+            ),
+        ]
+
+        result = chunker.chunk_messages(messages, "1", "2", "test")
+
+        assert len(result) == 1
+        assert [msg.id for msg in result[0].messages] == [3, 4, 5]
 
 
 class TestMessageIngestionService:
@@ -583,6 +614,47 @@ class TestMessageIngestionService:
         first_final_chunk = service.store_chunks.await_args_list[-1].args[0][0]
         assert first_final_chunk.start_message_id == "3"
 
+    async def test_ingest_channel_checkpoints_without_chunks_and_logs_progress(
+        self, service, mock_deps
+    ):
+        repository, _, _ = mock_deps
+        repository.get_or_create_ingestion_progress = AsyncMock(return_value=_make_progress())
+        repository.update_ingestion_progress = AsyncMock()
+        messages = [_make_discord_message(i) for i in [1, 2]]
+        raw_messages = [
+            _make_raw(
+                id=i,
+                content=f"Checkpoint message {i} remains buffered",
+                created_at=datetime(2026, 5, 25, 12, i, tzinfo=UTC),
+            )
+            for i in [1, 2]
+        ]
+        channel = FakeHistoryChannel(messages)
+        service.store_chunks = AsyncMock(return_value=0)
+        service._chunker.chunk_messages = MagicMock(return_value=[])
+
+        with (
+            patch("intelstream.services.message_ingestion.CHECKPOINT_INTERVAL", 1),
+            patch("intelstream.services.message_ingestion.LOG_INTERVAL", 1),
+            patch("intelstream.services.message_ingestion.YIELD_INTERVAL", 1000),
+            patch("intelstream.services.message_ingestion.logger.info") as log_info,
+            patch(
+                "intelstream.services.message_ingestion.discord_message_to_raw",
+                side_effect=raw_messages,
+            ),
+        ):
+            await service.ingest_channel(channel, "guild-1")
+
+        service.store_chunks.assert_not_awaited()
+        assert service._chunker.chunk_messages.call_count == 3
+        repository.update_ingestion_progress.assert_any_await(
+            "guild-1",
+            "222",
+            last_message_id="2",
+            total_fetched=2,
+        )
+        assert any(call.args[0] == "Ingestion progress" for call in log_info.call_args_list)
+
     async def test_ingest_channel_yields_periodically(self, service, mock_deps):
         repository, _, _ = mock_deps
         repository.get_or_create_ingestion_progress = AsyncMock(return_value=_make_progress())
@@ -624,6 +696,55 @@ class TestMessageIngestionService:
             status="paused",
             total_fetched=7,
             last_message_id="5",
+        )
+
+    async def test_ingest_channel_records_buffer_last_id_on_error(self, service, mock_deps):
+        repository, _, _ = mock_deps
+        repository.get_or_create_ingestion_progress = AsyncMock(return_value=_make_progress())
+        repository.update_ingestion_progress = AsyncMock()
+        channel = FakeHistoryChannel([_make_discord_message(10)])
+        raw = _make_raw(id=10, content="Buffered message with enough context to store")
+        chunk = Chunk(
+            messages=[raw],
+            guild_id="guild-1",
+            channel_id="222",
+            channel_name="general",
+        )
+        service._chunker.chunk_messages = MagicMock(return_value=[chunk])
+        service.store_chunks = AsyncMock(side_effect=RuntimeError("store failed"))
+
+        with patch(
+            "intelstream.services.message_ingestion.discord_message_to_raw",
+            return_value=raw,
+        ):
+            await service.ingest_channel(channel, "guild-1")
+
+        repository.update_ingestion_progress.assert_any_await(
+            "guild-1",
+            "222",
+            status="paused",
+            total_fetched=1,
+            last_message_id="10",
+        )
+
+    async def test_ingest_channel_records_none_last_id_on_early_error(self, service, mock_deps):
+        repository, _, _ = mock_deps
+        repository.get_or_create_ingestion_progress = AsyncMock(return_value=_make_progress())
+        repository.update_ingestion_progress = AsyncMock()
+        channel = FakeHistoryChannel([_make_discord_message(10)])
+
+        with patch(
+            "intelstream.services.message_ingestion.discord_message_to_raw",
+            side_effect=RuntimeError("convert failed"),
+        ):
+            await service.ingest_channel(channel, "guild-1")
+
+        repository.update_ingestion_progress.assert_any_await(
+            "guild-1",
+            "222",
+            status="paused",
+            total_fetched=0,
+            last_message_id=None,
         )
 
     async def test_run_backfill_filters_sorts_and_ingests_readable_channels(self, service):

--- a/tests/test_services/test_page_analyzer.py
+++ b/tests/test_services/test_page_analyzer.py
@@ -113,6 +113,21 @@ class TestPageAnalyzer:
         with pytest.raises(PageAnalysisError, match="network down"):
             await analyzer._fetch_html("https://example.com/blog")
 
+    async def test_fetch_html_uses_browser_user_agent_and_follows_redirects(self) -> None:
+        mock_http_client = MagicMock(spec=httpx.AsyncClient)
+        mock_response = MagicMock()
+        mock_response.text = "<html></html>"
+        mock_response.raise_for_status = MagicMock()
+        mock_http_client.get = AsyncMock(return_value=mock_response)
+        analyzer = PageAnalyzer(api_key="test-key", http_client=mock_http_client)
+
+        result = await analyzer._fetch_html("https://example.com/blog")
+
+        assert result == "<html></html>"
+        call_kwargs = mock_http_client.get.await_args.kwargs
+        assert "Mozilla/5.0" in call_kwargs["headers"]["User-Agent"]
+        assert call_kwargs["follow_redirects"] is True
+
     async def test_analyze_llm_returns_error(self, sample_html: str) -> None:
         mock_http_client = MagicMock(spec=httpx.AsyncClient)
         mock_response = MagicMock()
@@ -387,6 +402,27 @@ class TestPageAnalyzer:
         )
 
         assert result["site_name"] == "Test Blog"
+
+    async def test_extract_profile_sanitizes_control_characters_from_url(
+        self, valid_llm_response: dict
+    ) -> None:
+        mock_anthropic_response = MagicMock()
+        mock_text_block = MagicMock()
+        mock_text_block.text = json.dumps(valid_llm_response)
+        mock_anthropic_response.content = [mock_text_block]
+
+        analyzer = PageAnalyzer(api_key="test-key")
+        analyzer._client.messages.create = AsyncMock(return_value=mock_anthropic_response)
+
+        await analyzer._extract_profile_with_llm(
+            "https://example.com/\x00blog\x7f",
+            "<html></html>",
+        )
+
+        user_prompt = analyzer._client.messages.create.await_args.kwargs["messages"][0]["content"]
+        assert "URL: https://example.com/blog" in user_prompt
+        assert "\x00" not in user_prompt
+        assert "\x7f" not in user_prompt
 
     def test_validate_profile_invalid_post_selector(self, sample_html: str) -> None:
         profile = ExtractionProfile(

--- a/tests/test_services/test_page_analyzer.py
+++ b/tests/test_services/test_page_analyzer.py
@@ -105,6 +105,14 @@ class TestPageAnalyzer:
         with pytest.raises(PageAnalysisError, match="Failed to fetch page"):
             await analyzer.analyze("https://example.com/blog")
 
+    async def test_fetch_html_wraps_request_error(self) -> None:
+        mock_http_client = MagicMock(spec=httpx.AsyncClient)
+        mock_http_client.get = AsyncMock(side_effect=httpx.ConnectError("network down"))
+        analyzer = PageAnalyzer(api_key="test-key", http_client=mock_http_client)
+
+        with pytest.raises(PageAnalysisError, match="network down"):
+            await analyzer._fetch_html("https://example.com/blog")
+
     async def test_analyze_llm_returns_error(self, sample_html: str) -> None:
         mock_http_client = MagicMock(spec=httpx.AsyncClient)
         mock_response = MagicMock()
@@ -276,6 +284,17 @@ class TestPageAnalyzer:
         assert 'datetime="2024-01-15"' in cleaned
         assert "data-tracking" not in cleaned
 
+    def test_clean_html_truncates_long_html(self) -> None:
+        html = "<html><body>" + ("x" * 200) + "</body></html>"
+        analyzer = PageAnalyzer(api_key="test-key")
+        settings = MagicMock()
+        settings.max_html_length = 50
+
+        with patch("intelstream.services.page_analyzer.get_settings", return_value=settings):
+            cleaned = analyzer._clean_html(html)
+
+        assert len(cleaned) == 50
+
     def test_validate_profile_valid(self, sample_html: str) -> None:
         profile = ExtractionProfile(
             site_name="Test",
@@ -348,6 +367,27 @@ class TestPageAnalyzer:
 
         assert profile.site_name == "Test Blog"
 
+    async def test_extract_profile_ignores_content_blocks_without_text(
+        self, valid_llm_response: dict
+    ) -> None:
+        class EmptyBlock:
+            pass
+
+        mock_anthropic_response = MagicMock()
+        mock_text_block = MagicMock()
+        mock_text_block.text = json.dumps(valid_llm_response)
+        mock_anthropic_response.content = [EmptyBlock(), mock_text_block]
+
+        analyzer = PageAnalyzer(api_key="test-key")
+        analyzer._client.messages.create = AsyncMock(return_value=mock_anthropic_response)
+
+        result = await analyzer._extract_profile_with_llm(
+            "https://example.com/blog",
+            "<html></html>",
+        )
+
+        assert result["site_name"] == "Test Blog"
+
     def test_validate_profile_invalid_post_selector(self, sample_html: str) -> None:
         profile = ExtractionProfile(
             site_name="Test",
@@ -361,6 +401,31 @@ class TestPageAnalyzer:
 
         assert result["valid"] is False
         assert "Invalid CSS selector" in result["reason"]
+
+    def test_validate_profile_rejects_posts_with_links_missing_url_attribute(self) -> None:
+        html = """
+        <html>
+        <body>
+            <article class="post">
+                <h2 class="title">Title</h2>
+                <a class="post-link">Read</a>
+            </article>
+        </body>
+        </html>
+        """
+        profile = ExtractionProfile(
+            site_name="Test",
+            post_selector="article.post",
+            title_selector="h2.title",
+            url_selector="a.post-link",
+            url_attribute="href",
+        )
+        analyzer = PageAnalyzer(api_key="test-key")
+
+        result = analyzer._validate_profile(html, profile)
+
+        assert result["valid"] is False
+        assert "Could not extract" in result["reason"]
 
     def test_validate_profile_invalid_title_selector(self, sample_html: str) -> None:
         profile = ExtractionProfile(

--- a/tests/test_services/test_pipeline.py
+++ b/tests/test_services/test_pipeline.py
@@ -5,6 +5,7 @@ import pytest
 
 from intelstream.adapters.base import ContentData
 from intelstream.config import Settings
+from intelstream.database.exceptions import DuplicateContentError
 from intelstream.database.models import ContentItem, Source, SourceType
 from intelstream.database.repository import Repository
 from intelstream.services.pipeline import ContentPipeline
@@ -81,6 +82,11 @@ def sample_content_item(sample_source):
 
 
 class TestContentPipelineInitialization:
+    async def test_close_without_initialized_client(self, pipeline: ContentPipeline):
+        await pipeline.close()
+
+        assert pipeline._http_client is None
+
     async def test_initialize_creates_http_client(self, pipeline: ContentPipeline):
         await pipeline.initialize()
 
@@ -596,6 +602,95 @@ class TestFetchAllSources:
 
         await pipeline.close()
 
+    @pytest.mark.parametrize("status_code", [401, 403])
+    async def test_fetch_auth_error_increments_failure_count(
+        self,
+        pipeline: ContentPipeline,
+        mock_repository: AsyncMock,
+        sample_source,
+        status_code: int,
+    ):
+        import httpx
+
+        await pipeline.initialize()
+
+        mock_repository.get_all_sources.return_value = [sample_source]
+
+        mock_response = MagicMock()
+        mock_response.status_code = status_code
+        mock_request = MagicMock()
+
+        with patch.object(
+            pipeline._adapters[SourceType.SUBSTACK],
+            "fetch_latest",
+            new_callable=AsyncMock,
+            side_effect=httpx.HTTPStatusError(
+                "Unauthorized", request=mock_request, response=mock_response
+            ),
+        ):
+            result = await pipeline.fetch_all_sources()
+
+        assert result == 0
+        mock_repository.increment_failure_count.assert_called_once_with(sample_source.id)
+
+        await pipeline.close()
+
+    async def test_fetch_unhandled_http_status_does_not_increment_failure_count(
+        self,
+        pipeline: ContentPipeline,
+        mock_repository: AsyncMock,
+        sample_source,
+    ):
+        import httpx
+
+        await pipeline.initialize()
+
+        mock_repository.get_all_sources.return_value = [sample_source]
+
+        mock_response = MagicMock()
+        mock_response.status_code = 418
+        mock_request = MagicMock()
+
+        with patch.object(
+            pipeline._adapters[SourceType.SUBSTACK],
+            "fetch_latest",
+            new_callable=AsyncMock,
+            side_effect=httpx.HTTPStatusError(
+                "Teapot", request=mock_request, response=mock_response
+            ),
+        ):
+            result = await pipeline.fetch_all_sources()
+
+        assert result == 0
+        mock_repository.increment_failure_count.assert_not_called()
+
+        await pipeline.close()
+
+    async def test_fetch_request_error_increments_failure_count(
+        self,
+        pipeline: ContentPipeline,
+        mock_repository: AsyncMock,
+        sample_source,
+    ):
+        import httpx
+
+        await pipeline.initialize()
+
+        mock_repository.get_all_sources.return_value = [sample_source]
+
+        with patch.object(
+            pipeline._adapters[SourceType.SUBSTACK],
+            "fetch_latest",
+            new_callable=AsyncMock,
+            side_effect=httpx.ConnectError("network down"),
+        ):
+            result = await pipeline.fetch_all_sources()
+
+        assert result == 0
+        mock_repository.increment_failure_count.assert_called_once_with(sample_source.id)
+
+        await pipeline.close()
+
     async def test_fetch_success_resets_failure_count(
         self,
         pipeline: ContentPipeline,
@@ -684,6 +779,31 @@ class TestFetchAllSources:
 
         await pipeline.close()
 
+    async def test_skips_source_not_yet_due_with_naive_last_polled_at(
+        self,
+        pipeline: ContentPipeline,
+        mock_settings: MagicMock,
+        mock_repository: AsyncMock,
+        sample_source,
+    ):
+        await pipeline.initialize()
+
+        sample_source.last_polled_at = datetime(2099, 1, 1, 0, 0, 0)
+        mock_settings.get_poll_interval.return_value = 20
+        mock_repository.get_all_sources.return_value = [sample_source]
+
+        with patch.object(
+            pipeline._adapters[SourceType.SUBSTACK],
+            "fetch_latest",
+            new_callable=AsyncMock,
+        ) as mock_fetch:
+            result = await pipeline.fetch_all_sources()
+
+        assert result == 0
+        mock_fetch.assert_not_called()
+
+        await pipeline.close()
+
     async def test_fetches_source_when_interval_elapsed(
         self,
         pipeline: ContentPipeline,
@@ -739,6 +859,129 @@ class TestFetchAllSources:
 
         assert result == 1
         mock_settings.get_poll_interval.assert_not_called()
+
+        await pipeline.close()
+
+    async def test_fetch_source_page_missing_extraction_profile(
+        self,
+        pipeline: ContentPipeline,
+        mock_repository: AsyncMock,
+    ):
+        page_source = MagicMock(spec=Source)
+        page_source.id = "page-source"
+        page_source.name = "Page Source"
+        page_source.type = SourceType.PAGE
+        page_source.extraction_profile = None
+
+        assert await pipeline._fetch_source(page_source) == 0
+        mock_repository.update_source_last_polled.assert_not_called()
+
+    @pytest.mark.parametrize("profile", ["{", "{}"])
+    async def test_fetch_source_page_invalid_extraction_profile(
+        self,
+        pipeline: ContentPipeline,
+        mock_repository: AsyncMock,
+        profile: str,
+    ):
+        page_source = MagicMock(spec=Source)
+        page_source.id = "page-source"
+        page_source.name = "Page Source"
+        page_source.type = SourceType.PAGE
+        page_source.extraction_profile = profile
+
+        assert await pipeline._fetch_source(page_source) == 0
+        mock_repository.update_source_last_polled.assert_not_called()
+
+    async def test_fetch_source_page_uses_stored_extraction_profile(
+        self,
+        pipeline: ContentPipeline,
+        mock_repository: AsyncMock,
+        sample_content_data,
+    ):
+        page_source = MagicMock(spec=Source)
+        page_source.id = "page-source"
+        page_source.name = "Page Source"
+        page_source.type = SourceType.PAGE
+        page_source.identifier = "https://example.com/news"
+        page_source.feed_url = None
+        page_source.skip_summary = False
+        page_source.last_polled_at = datetime(2024, 1, 1, tzinfo=UTC)
+        page_source.extraction_profile = (
+            '{"site_name":"Example","post_selector":"article",'
+            '"title_selector":"h2","url_selector":"a","url_attribute":"href"}'
+        )
+        mock_repository.content_item_exists.return_value = False
+
+        with patch(
+            "intelstream.adapters.page.PageAdapter.fetch_latest",
+            new_callable=AsyncMock,
+            return_value=[sample_content_data],
+        ) as fetch_latest:
+            result = await pipeline._fetch_source(page_source)
+
+        assert result == 1
+        fetch_latest.assert_awaited_once_with(
+            page_source.identifier,
+            feed_url=None,
+            skip_content=False,
+        )
+        mock_repository.update_source_last_polled.assert_called_once_with(page_source.id)
+
+    async def test_fetch_source_continues_when_add_races_duplicate(
+        self,
+        pipeline: ContentPipeline,
+        mock_repository: AsyncMock,
+        sample_source,
+        sample_content_data,
+    ):
+        await pipeline.initialize()
+
+        mock_repository.content_item_exists.return_value = False
+
+        with (
+            patch.object(
+                pipeline._adapters[SourceType.SUBSTACK],
+                "fetch_latest",
+                new_callable=AsyncMock,
+                return_value=[sample_content_data],
+            ),
+            patch.object(
+                pipeline,
+                "_store_content_item",
+                new_callable=AsyncMock,
+                side_effect=DuplicateContentError("duplicate"),
+            ),
+        ):
+            result = await pipeline._fetch_source(sample_source)
+
+        assert result == 0
+        mock_repository.update_source_last_polled.assert_called_once_with(sample_source.id)
+
+        await pipeline.close()
+
+    async def test_fetch_source_first_poll_without_most_recent_skips_backfill(
+        self,
+        pipeline: ContentPipeline,
+        mock_repository: AsyncMock,
+        sample_source,
+        sample_content_data,
+    ):
+        await pipeline.initialize()
+
+        sample_source.last_polled_at = None
+        mock_repository.content_item_exists.return_value = False
+        mock_repository.get_most_recent_item_for_source.return_value = None
+
+        with patch.object(
+            pipeline._adapters[SourceType.SUBSTACK],
+            "fetch_latest",
+            new_callable=AsyncMock,
+            return_value=[sample_content_data],
+        ):
+            result = await pipeline._fetch_source(sample_source)
+
+        assert result == 1
+        mock_repository.mark_items_as_backfilled.assert_not_called()
 
         await pipeline.close()
 
@@ -1036,6 +1279,144 @@ class TestEmbedItem:
         result = await pipeline.summarize_pending()
 
         assert result == 1
+
+    async def test_embed_item_returns_when_search_service_half_configured(
+        self,
+        mock_settings,
+        mock_repository: AsyncMock,
+    ):
+        mock_vector_store = AsyncMock()
+        pipeline = ContentPipeline(
+            settings=mock_settings,
+            repository=mock_repository,
+            summarizer=None,
+            get_search_services=lambda: (None, mock_vector_store),
+        )
+
+        await pipeline._embed_item("item-1", "Title", "Summary", "Raw")
+
+        mock_repository.delete_article_chunk_metas_for_content_item.assert_not_called()
+        mock_vector_store.upsert_article_chunks_batch.assert_not_called()
+
+    async def test_embed_item_returns_when_chunker_builds_no_chunks(
+        self,
+        mock_settings,
+        mock_repository: AsyncMock,
+    ):
+        mock_embedding = AsyncMock()
+        mock_vector_store = AsyncMock()
+        pipeline = ContentPipeline(
+            settings=mock_settings,
+            repository=mock_repository,
+            summarizer=None,
+            get_search_services=lambda: (mock_embedding, mock_vector_store),
+        )
+        pipeline._article_chunker.build_chunks = MagicMock(return_value=[])
+
+        await pipeline._embed_item("item-1", "Title", "Summary", None)
+
+        mock_embedding.embed_text.assert_not_called()
+        mock_vector_store.upsert_article_chunks_batch.assert_not_called()
+
+    async def test_embed_item_uses_batch_embeddings_and_deletes_stale_chunks(
+        self,
+        mock_settings,
+        mock_repository: AsyncMock,
+    ):
+        chunk_0 = MagicMock(chunk_index=0, text="first", search_text="Title\n\nfirst")
+        chunk_1 = MagicMock(chunk_index=1, text="second", search_text="Title\n\nsecond")
+        mock_embedding = AsyncMock()
+        mock_embedding.embed_batch = AsyncMock(return_value=[[0.1], [0.2]])
+        mock_vector_store = AsyncMock()
+        mock_repository.delete_article_chunk_metas_for_content_item.return_value = [
+            "item-1__0000"
+        ]
+        pipeline = ContentPipeline(
+            settings=mock_settings,
+            repository=mock_repository,
+            summarizer=None,
+            get_search_services=lambda: (mock_embedding, mock_vector_store),
+        )
+        pipeline._article_chunker.build_chunks = MagicMock(return_value=[chunk_0, chunk_1])
+
+        await pipeline._embed_item("item-1", "Title", "Summary", "Raw")
+
+        mock_embedding.embed_batch.assert_awaited_once_with(
+            ["Title\n\nfirst", "Title\n\nsecond"]
+        )
+        mock_vector_store.delete_article_chunks.assert_awaited_once_with(["item-1__0000"])
+        mock_repository.add_article_chunk_metas_batch.assert_awaited_once()
+        mock_vector_store.upsert_article_chunks_batch.assert_awaited_once()
+
+
+class TestFirstPostingBackfill:
+    async def test_backfill_skips_duplicate_source_ids(
+        self,
+        pipeline: ContentPipeline,
+        mock_repository: AsyncMock,
+        sample_content_item,
+    ):
+        duplicate = MagicMock(spec=ContentItem)
+        duplicate.source_id = sample_content_item.source_id
+        duplicate.id = "duplicate-item"
+        mock_repository.has_source_posted_content.return_value = True
+
+        await pipeline._handle_first_posting_backfill([sample_content_item, duplicate])
+
+        mock_repository.has_source_posted_content.assert_awaited_once_with(
+            sample_content_item.source_id
+        )
+
+    async def test_backfill_skips_when_no_most_recent_item(
+        self,
+        pipeline: ContentPipeline,
+        mock_repository: AsyncMock,
+        sample_content_item,
+    ):
+        mock_repository.has_source_posted_content.return_value = False
+        mock_repository.get_most_recent_item_for_source.return_value = None
+
+        await pipeline._handle_first_posting_backfill([sample_content_item])
+
+        mock_repository.mark_items_as_backfilled.assert_not_called()
+
+    async def test_backfill_allows_zero_marked_items(
+        self,
+        pipeline: ContentPipeline,
+        mock_repository: AsyncMock,
+        sample_content_item,
+    ):
+        most_recent = MagicMock(spec=ContentItem)
+        most_recent.id = "most-recent"
+        mock_repository.has_source_posted_content.return_value = False
+        mock_repository.get_most_recent_item_for_source.return_value = most_recent
+        mock_repository.mark_items_as_backfilled.return_value = 0
+
+        await pipeline._handle_first_posting_backfill([sample_content_item])
+
+        mock_repository.mark_items_as_backfilled.assert_awaited_once_with(
+            source_id=sample_content_item.source_id,
+            exclude_item_id=most_recent.id,
+        )
+        mock_repository.get_source_by_id.assert_not_called()
+
+    async def test_backfill_logs_unknown_source_when_source_lookup_missing(
+        self,
+        pipeline: ContentPipeline,
+        mock_repository: AsyncMock,
+        sample_content_item,
+    ):
+        most_recent = MagicMock(spec=ContentItem)
+        most_recent.id = "most-recent"
+        most_recent.title = "Most Recent"
+        mock_repository.has_source_posted_content.return_value = False
+        mock_repository.get_most_recent_item_for_source.return_value = most_recent
+        mock_repository.mark_items_as_backfilled.return_value = 1
+        mock_repository.get_source_by_id.return_value = None
+
+        await pipeline._handle_first_posting_backfill([sample_content_item])
+
+        mock_repository.get_source_by_id.assert_awaited_once_with(sample_content_item.source_id)
 
 
 class TestRunCycle:

--- a/tests/test_services/test_pipeline.py
+++ b/tests/test_services/test_pipeline.py
@@ -1328,9 +1328,7 @@ class TestEmbedItem:
         mock_embedding = AsyncMock()
         mock_embedding.embed_batch = AsyncMock(return_value=[[0.1], [0.2]])
         mock_vector_store = AsyncMock()
-        mock_repository.delete_article_chunk_metas_for_content_item.return_value = [
-            "item-1__0000"
-        ]
+        mock_repository.delete_article_chunk_metas_for_content_item.return_value = ["item-1__0000"]
         pipeline = ContentPipeline(
             settings=mock_settings,
             repository=mock_repository,
@@ -1341,9 +1339,7 @@ class TestEmbedItem:
 
         await pipeline._embed_item("item-1", "Title", "Summary", "Raw")
 
-        mock_embedding.embed_batch.assert_awaited_once_with(
-            ["Title\n\nfirst", "Title\n\nsecond"]
-        )
+        mock_embedding.embed_batch.assert_awaited_once_with(["Title\n\nfirst", "Title\n\nsecond"])
         mock_vector_store.delete_article_chunks.assert_awaited_once_with(["item-1__0000"])
         mock_repository.add_article_chunk_metas_batch.assert_awaited_once()
         mock_vector_store.upsert_article_chunks_batch.assert_awaited_once()

--- a/tests/test_services/test_pipeline.py
+++ b/tests/test_services/test_pipeline.py
@@ -1344,6 +1344,31 @@ class TestEmbedItem:
         mock_repository.add_article_chunk_metas_batch.assert_awaited_once()
         mock_vector_store.upsert_article_chunks_batch.assert_awaited_once()
 
+    async def test_embed_item_skips_stale_vector_delete_when_none_removed(
+        self,
+        mock_settings,
+        mock_repository: AsyncMock,
+    ):
+        chunk = MagicMock(chunk_index=0, text="first", search_text="Title\n\nfirst")
+        mock_embedding = AsyncMock()
+        mock_embedding.embed_text = AsyncMock(return_value=[0.1])
+        mock_vector_store = AsyncMock()
+        mock_repository.delete_article_chunk_metas_for_content_item.return_value = []
+        pipeline = ContentPipeline(
+            settings=mock_settings,
+            repository=mock_repository,
+            summarizer=None,
+            get_search_services=lambda: (mock_embedding, mock_vector_store),
+        )
+        pipeline._article_chunker.build_chunks = MagicMock(return_value=[chunk])
+
+        await pipeline._embed_item("item-1", "Title", "Summary", "Raw")
+
+        mock_embedding.embed_text.assert_awaited_once_with("Title\n\nfirst")
+        mock_vector_store.delete_article_chunks.assert_not_awaited()
+        mock_repository.add_article_chunk_metas_batch.assert_awaited_once()
+        mock_vector_store.upsert_article_chunks_batch.assert_awaited_once()
+
 
 class TestFirstPostingBackfill:
     async def test_backfill_skips_duplicate_source_ids(

--- a/tests/test_services/test_search_eval.py
+++ b/tests/test_services/test_search_eval.py
@@ -25,6 +25,81 @@ class TestLoadEvalCases:
         assert cases[0].expected_ids == ("item-1",)
         assert cases[1].expected_ids == ("item-2", "item-3")
 
+    def test_trims_query_expected_ids_and_optional_label(self, tmp_path):
+        path = tmp_path / "eval.json"
+        path.write_text(
+            json.dumps(
+                [
+                    {
+                        "query": "  query text  ",
+                        "expected_ids": [" item-1 ", "", None, "item-2"],
+                        "label": "  smoke  ",
+                    }
+                ]
+            )
+        )
+
+        [case] = load_eval_cases(path)
+
+        assert case.query == "query text"
+        assert case.expected_ids == ("item-1", "item-2")
+        assert case.label == "smoke"
+
+    def test_rejects_non_array_eval_file(self, tmp_path):
+        path = tmp_path / "eval.json"
+        path.write_text(json.dumps({"query": "not a list"}))
+
+        try:
+            load_eval_cases(path)
+        except ValueError as exc:
+            assert str(exc) == "Evaluation file must contain a JSON array of cases"
+        else:
+            raise AssertionError("Expected ValueError")
+
+    def test_rejects_invalid_cases_with_indexed_errors(self, tmp_path):
+        path = tmp_path / "eval.json"
+        path.write_text(json.dumps([{"query": "ok", "expected_ids": ["item"]}, "bad"]))
+
+        try:
+            load_eval_cases(path)
+        except ValueError as exc:
+            assert str(exc) == "Case #2 must be a JSON object"
+        else:
+            raise AssertionError("Expected ValueError")
+
+    def test_rejects_missing_query(self, tmp_path):
+        path = tmp_path / "eval.json"
+        path.write_text(json.dumps([{"expected_ids": ["item"]}]))
+
+        try:
+            load_eval_cases(path)
+        except ValueError as exc:
+            assert str(exc) == "Case #1 is missing a non-empty 'query'"
+        else:
+            raise AssertionError("Expected ValueError")
+
+    def test_rejects_missing_expected_ids(self, tmp_path):
+        path = tmp_path / "eval.json"
+        path.write_text(json.dumps([{"query": "query"}]))
+
+        try:
+            load_eval_cases(path)
+        except ValueError as exc:
+            assert str(exc) == "Case #1 must provide 'expected_ids' or 'expected_content_item_id'"
+        else:
+            raise AssertionError("Expected ValueError")
+
+    def test_rejects_expected_ids_without_valid_strings(self, tmp_path):
+        path = tmp_path / "eval.json"
+        path.write_text(json.dumps([{"query": "query", "expected_ids": ["", None]}]))
+
+        try:
+            load_eval_cases(path)
+        except ValueError as exc:
+            assert str(exc) == "Case #1 has no valid expected ids"
+        else:
+            raise AssertionError("Expected ValueError")
+
 
 class TestEvaluateCase:
     def test_computes_rank_and_reciprocal_rank(self):
@@ -36,6 +111,18 @@ class TestEvaluateCase:
         assert result.hit is True
         assert result.rank == 2
         assert result.reciprocal_rank == 0.5
+
+    def test_miss_has_no_rank_or_matched_id(self):
+        result = evaluate_case(
+            case=SearchEvalCase(query="query", expected_ids=("item-2",), label="case"),
+            returned_ids=("item-9", "item-3"),
+        )
+
+        assert result.hit is False
+        assert result.matched_id is None
+        assert result.rank is None
+        assert result.reciprocal_rank == 0.0
+        assert result.to_dict()["label"] == "case"
 
 
 class TestSummarizeResults:
@@ -54,3 +141,18 @@ class TestSummarizeResults:
         assert summary.hits == 1
         assert summary.hit_rate == 0.5
         assert summary.mean_reciprocal_rank == 0.5
+
+    def test_empty_results_summary_has_zero_rates(self):
+        summary = summarize_results([])
+
+        assert summary.cases == 0
+        assert summary.hits == 0
+        assert summary.hit_rate == 0.0
+        assert summary.mean_reciprocal_rank == 0.0
+        assert summary.to_dict() == {
+            "cases": 0,
+            "hits": 0,
+            "hit_rate": 0.0,
+            "mean_reciprocal_rank": 0.0,
+            "results": [],
+        }

--- a/tests/test_services/test_search_eval.py
+++ b/tests/test_services/test_search_eval.py
@@ -25,6 +25,14 @@ class TestLoadEvalCases:
         assert cases[0].expected_ids == ("item-1",)
         assert cases[1].expected_ids == ("item-2", "item-3")
 
+    def test_trims_legacy_expected_content_item_id(self, tmp_path):
+        path = tmp_path / "eval.json"
+        path.write_text(json.dumps([{"query": "query", "expected_content_item_id": " item-1 "}]))
+
+        [case] = load_eval_cases(path)
+
+        assert case.expected_ids == ("item-1",)
+
     def test_trims_query_expected_ids_and_optional_label(self, tmp_path):
         path = tmp_path / "eval.json"
         path.write_text(
@@ -124,6 +132,17 @@ class TestEvaluateCase:
         assert result.reciprocal_rank == 0.0
         assert result.to_dict()["label"] == "case"
 
+    def test_coerces_returned_ids_to_strings_before_matching(self):
+        result = evaluate_case(
+            case=SearchEvalCase(query="query", expected_ids=("42",)),
+            returned_ids=["item-9", 42],
+        )
+
+        assert result.hit is True
+        assert result.matched_id == "42"
+        assert result.rank == 2
+        assert result.returned_ids == ("item-9", "42")
+
 
 class TestSummarizeResults:
     def test_summarizes_hits_and_mrr(self):
@@ -141,6 +160,28 @@ class TestSummarizeResults:
         assert summary.hits == 1
         assert summary.hit_rate == 0.5
         assert summary.mean_reciprocal_rank == 0.5
+
+    def test_to_dict_serializes_nested_results(self):
+        result = evaluate_case(
+            SearchEvalCase(query="query", expected_ids=("item-1",), label="smoke"),
+            ["item-1"],
+        )
+
+        summary_dict = summarize_results([result]).to_dict()
+
+        assert summary_dict["cases"] == 1
+        assert summary_dict["results"] == [
+            {
+                "query": "query",
+                "expected_ids": ("item-1",),
+                "returned_ids": ("item-1",),
+                "hit": True,
+                "matched_id": "item-1",
+                "rank": 1,
+                "reciprocal_rank": 1.0,
+                "label": "smoke",
+            }
+        ]
 
     def test_empty_results_summary_has_zero_rates(self):
         summary = summarize_results([])

--- a/tests/test_services/test_summarizer.py
+++ b/tests/test_services/test_summarizer.py
@@ -30,6 +30,11 @@ def summarizer(mock_client):
 
 
 class TestSummarizationService:
+    async def test_close_delegates_to_client(self, summarizer: SummarizationService, mock_client):
+        await summarizer.close()
+
+        mock_client.close.assert_awaited_once()
+
     async def test_summarize_success(self, summarizer: SummarizationService, mock_client):
         result = await summarizer.summarize(
             content="This is the article content.",
@@ -200,6 +205,17 @@ class TestSummarizationService:
         assert "blog post" in prompt
         assert "from Blog Author" in prompt
 
+    def test_build_prompt_twitter(self, summarizer: SummarizationService):
+        prompt = summarizer._build_prompt(
+            content="Tweet content",
+            title="Tweet",
+            source_type="twitter",
+            author="Poster",
+        )
+
+        assert "tweet" in prompt
+        assert "from Poster" in prompt
+
     def test_build_prompt_has_content_delimiters(self, summarizer: SummarizationService):
         prompt = summarizer._build_prompt(
             content="User supplied content here",
@@ -311,6 +327,14 @@ class TestSummarizeChat:
 
         call_kwargs = mock_client.complete.call_args.kwargs
         assert "42 messages" in call_kwargs["user_message"]
+
+    async def test_summarize_chat_passes_max_tokens(self, mock_client):
+        summarizer = SummarizationService(client=mock_client, max_tokens=1024)
+
+        await summarizer.summarize_chat(messages_text="test messages", message_count=2)
+
+        call_kwargs = mock_client.complete.call_args.kwargs
+        assert call_kwargs["max_tokens"] == 1024
 
     async def test_summarize_chat_empty_raises_error(self, summarizer: SummarizationService):
         with pytest.raises(SummarizationError, match="Cannot summarize empty messages"):

--- a/tests/test_services/test_summarizer.py
+++ b/tests/test_services/test_summarizer.py
@@ -336,3 +336,15 @@ class TestSummarizeChat:
 
         with pytest.raises(SummarizationError, match="API error"):
             await summarizer.summarize_chat(messages_text="test", message_count=1)
+
+    async def test_summarize_chat_rate_limit_retries_then_fails(self, mock_client):
+        mock_client.complete = AsyncMock(side_effect=LLMRateLimitError("Rate limited"))
+        summarizer = SummarizationService(client=mock_client)
+        summarizer.summarize_chat.retry.wait = lambda *_a, **_kw: 0  # type: ignore[union-attr]
+
+        from tenacity import RetryError
+
+        with pytest.raises(RetryError):
+            await summarizer.summarize_chat(messages_text="test messages", message_count=2)
+
+        assert mock_client.complete.call_count == 3

--- a/tests/test_services/test_web_fetcher.py
+++ b/tests/test_services/test_web_fetcher.py
@@ -4,6 +4,7 @@ import httpx
 import pytest
 from bs4 import BeautifulSoup
 
+from intelstream.services import web_fetcher
 from intelstream.services.web_fetcher import MAX_REDIRECTS, WebContent, WebFetcher, WebFetchError
 
 
@@ -323,6 +324,45 @@ class TestWebFetcher:
             with pytest.raises(RuntimeError, match="Client creation failed"):
                 await fetcher.fetch("https://example.com/article")
 
+    async def test_fetch_truncates_oversized_html_before_parsing(self):
+        mock_response = MagicMock(spec=httpx.Response)
+        mock_response.is_redirect = False
+        mock_response.text = "<html>" + ("x" * 200) + "</html>"
+        mock_response.headers = {"content-type": "text/html"}
+        mock_response.raise_for_status = MagicMock()
+
+        mock_client = MagicMock(spec=httpx.AsyncClient)
+        mock_client.get = AsyncMock(return_value=mock_response)
+
+        fetcher = WebFetcher(http_client=mock_client)
+        expected = WebContent(url="https://example.com/article", title="Title", content="content")
+
+        with (
+            patch.object(web_fetcher, "MAX_CONTENT_LENGTH", 25),
+            patch.object(fetcher, "_parse_html", return_value=expected) as parse_html,
+        ):
+            result = await fetcher.fetch("https://example.com/article")
+
+        assert result is expected
+        assert len(parse_html.call_args.args[1]) == 25
+
+    async def test_fetch_closes_owned_client_after_success(self, sample_html):
+        mock_response = MagicMock(spec=httpx.Response)
+        mock_response.is_redirect = False
+        mock_response.text = sample_html
+        mock_response.headers = {"content-type": "text/html"}
+        mock_response.raise_for_status = MagicMock()
+
+        mock_client = MagicMock(spec=httpx.AsyncClient)
+        mock_client.get = AsyncMock(return_value=mock_response)
+        mock_client.aclose = AsyncMock()
+
+        with patch("intelstream.services.web_fetcher.httpx.AsyncClient", return_value=mock_client):
+            result = await WebFetcher().fetch("https://example.com/article")
+
+        assert isinstance(result, WebContent)
+        mock_client.aclose.assert_awaited_once()
+
     async def test_fetch_rejects_localhost_url(self):
         fetcher = WebFetcher()
         with pytest.raises(WebFetchError, match="SSRF"):
@@ -445,6 +485,11 @@ class TestWebFetcherParsingHelpers:
         assert fetcher._extract_content(content_div) == "Div text"
         assert fetcher._extract_content(body_only) == "Body text"
         assert fetcher._extract_content(loose_text) == "Loose text"
+
+    def test_extract_content_returns_document_text_without_body(self):
+        soup = BeautifulSoup("", "lxml")
+
+        assert WebFetcher()._extract_content(soup) == ""
 
     def test_extract_author_uses_article_author_meta(self):
         soup = BeautifulSoup(

--- a/tests/test_services/test_web_fetcher.py
+++ b/tests/test_services/test_web_fetcher.py
@@ -2,8 +2,9 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import httpx
 import pytest
+from bs4 import BeautifulSoup
 
-from intelstream.services.web_fetcher import WebContent, WebFetcher, WebFetchError
+from intelstream.services.web_fetcher import MAX_REDIRECTS, WebContent, WebFetcher, WebFetchError
 
 
 @pytest.fixture
@@ -360,6 +361,34 @@ class TestWebFetcher:
         with pytest.raises(WebFetchError, match="Redirect blocked by SSRF"):
             await fetcher.fetch("https://evil.com/redirect")
 
+    async def test_fetch_raises_on_redirect_without_target(self):
+        redirect_response = MagicMock(spec=httpx.Response)
+        redirect_response.is_redirect = True
+        redirect_response.next_request = None
+
+        mock_client = MagicMock(spec=httpx.AsyncClient)
+        mock_client.get = AsyncMock(return_value=redirect_response)
+
+        fetcher = WebFetcher(http_client=mock_client)
+        with pytest.raises(WebFetchError, match="Redirect without a target URL"):
+            await fetcher.fetch("https://example.com/redirect", skip_ssrf_check=True)
+
+    async def test_fetch_raises_after_too_many_redirects(self):
+        redirect_response = MagicMock(spec=httpx.Response)
+        redirect_response.is_redirect = True
+        mock_next_request = MagicMock()
+        mock_next_request.url = "https://example.com/again"
+        redirect_response.next_request = mock_next_request
+
+        mock_client = MagicMock(spec=httpx.AsyncClient)
+        mock_client.get = AsyncMock(return_value=redirect_response)
+
+        fetcher = WebFetcher(http_client=mock_client)
+        with pytest.raises(WebFetchError, match="Too many redirects"):
+            await fetcher.fetch("https://example.com/redirect", skip_ssrf_check=True)
+
+        assert mock_client.get.await_count == MAX_REDIRECTS
+
     async def test_fetch_follows_safe_redirect(self, sample_html):
         redirect_response = MagicMock(spec=httpx.Response)
         redirect_response.is_redirect = True
@@ -381,3 +410,67 @@ class TestWebFetcher:
 
         assert isinstance(result, WebContent)
         assert mock_client.get.call_count == 2
+
+
+class TestWebFetcherParsingHelpers:
+    def test_extract_title_prefers_twitter_title_after_og_title(self):
+        soup = BeautifulSoup(
+            """
+            <html><head>
+              <meta name="twitter:title" content="Twitter Title">
+              <title>Title Tag</title>
+            </head></html>
+            """,
+            "lxml",
+        )
+
+        assert WebFetcher()._extract_title(soup) == "Twitter Title"
+
+    def test_extract_title_falls_back_to_h1_then_untitled(self):
+        fetcher = WebFetcher()
+
+        assert fetcher._extract_title(BeautifulSoup("<h1>Heading</h1>", "lxml")) == "Heading"
+        assert fetcher._extract_title(BeautifulSoup("<p>No title</p>", "lxml")) == "Untitled"
+
+    def test_extract_content_uses_content_div_then_body_then_document(self):
+        fetcher = WebFetcher()
+
+        content_div = BeautifulSoup(
+            '<html><body><div class="post-content">Div text</div><p>Body text</p></body></html>',
+            "lxml",
+        )
+        body_only = BeautifulSoup("<html><body><p>Body text</p></body></html>", "lxml")
+        loose_text = BeautifulSoup("<span>Loose text</span>", "lxml")
+
+        assert fetcher._extract_content(content_div) == "Div text"
+        assert fetcher._extract_content(body_only) == "Body text"
+        assert fetcher._extract_content(loose_text) == "Loose text"
+
+    def test_extract_author_uses_article_author_meta(self):
+        soup = BeautifulSoup(
+            '<meta property="article:author" content="Editorial Team">',
+            "lxml",
+        )
+
+        assert WebFetcher()._extract_author(soup) == "Editorial Team"
+
+    def test_extract_published_date_uses_time_when_meta_missing(self):
+        soup = BeautifulSoup('<time datetime="2024-02-03T04:05:06Z">date</time>', "lxml")
+
+        published = WebFetcher()._extract_published_date(soup)
+
+        assert published is not None
+        assert published.year == 2024
+        assert published.month == 2
+        assert published.day == 3
+
+    def test_extract_published_date_ignores_invalid_dates(self):
+        soup = BeautifulSoup(
+            """
+            <html><head><meta property="article:published_time" content="bad"></head>
+            <body><time datetime="also-bad">date</time></body></html>
+            """,
+            "lxml",
+        )
+
+        assert WebFetcher()._extract_published_date(soup) is None

--- a/tests/test_utils/test_feed_utils.py
+++ b/tests/test_utils/test_feed_utils.py
@@ -137,3 +137,27 @@ class TestParseFeedDate:
         result = parse_feed_date(entry)
 
         assert result == datetime(2024, 2, 20, 14, 0, 0, tzinfo=UTC)
+
+    def test_invalid_updated_parsed_falls_back_to_updated_string(self) -> None:
+        entry = MagicMock()
+        entry.get.side_effect = lambda k: {
+            "updated_parsed": (2024, 13, 45, 25, 61, 99),
+            "updated": "Wed, 21 Feb 2024 12:00:00 GMT",
+        }.get(k)
+        entry.updated_parsed = (2024, 13, 45, 25, 61, 99)
+        entry.updated = "Wed, 21 Feb 2024 12:00:00 GMT"
+
+        result = parse_feed_date(entry)
+
+        assert result == datetime(2024, 2, 21, 12, 0, 0, tzinfo=UTC)
+
+    def test_invalid_updated_string_falls_back_to_now(self) -> None:
+        entry = MagicMock()
+        entry.get.side_effect = lambda k: "not a valid date" if k == "updated" else None
+        entry.updated = "not a valid date"
+
+        before = datetime.now(UTC)
+        result = parse_feed_date(entry)
+        after = datetime.now(UTC)
+
+        assert before <= result <= after

--- a/tests/test_utils/test_feed_utils.py
+++ b/tests/test_utils/test_feed_utils.py
@@ -138,6 +138,19 @@ class TestParseFeedDate:
 
         assert result == datetime(2024, 2, 20, 14, 0, 0, tzinfo=UTC)
 
+    def test_invalid_published_parsed_falls_back_to_published_string(self) -> None:
+        entry = MagicMock()
+        entry.get.side_effect = lambda k: {
+            "published_parsed": (2024, 13, 45, 25, 61, 99),
+            "published": "Tue, 16 Jan 2024 08:00:00 GMT",
+        }.get(k)
+        entry.published_parsed = (2024, 13, 45, 25, 61, 99)
+        entry.published = "Tue, 16 Jan 2024 08:00:00 GMT"
+
+        result = parse_feed_date(entry)
+
+        assert result == datetime(2024, 1, 16, 8, 0, 0, tzinfo=UTC)
+
     def test_invalid_updated_parsed_falls_back_to_updated_string(self) -> None:
         entry = MagicMock()
         entry.get.side_effect = lambda k: {

--- a/tests/test_utils/test_url_validation.py
+++ b/tests/test_utils/test_url_validation.py
@@ -13,6 +13,14 @@ from intelstream.utils.url_validation import (
 
 
 class TestUrlValidationHelpers:
+    def test_obfuscated_decimal_parse_error_is_not_blocked_as_obfuscated(self, monkeypatch):
+        def fake_int(_value: str) -> int:
+            raise ValueError("not parseable")
+
+        monkeypatch.setattr(url_validation_module, "int", fake_int, raising=False)
+
+        assert _is_obfuscated_ip("12345678") is False
+
     def test_obfuscated_decimal_outside_ipv4_range_is_not_blocked_as_obfuscated(self):
         assert _is_obfuscated_ip("9999999999") is False
 

--- a/tests/test_utils/test_url_validation.py
+++ b/tests/test_utils/test_url_validation.py
@@ -1,6 +1,46 @@
+import socket
+
 import pytest
 
-from intelstream.utils.url_validation import SSRFError, is_safe_url, validate_url_for_ssrf
+from intelstream.utils import url_validation as url_validation_module
+from intelstream.utils.url_validation import (
+    SSRFError,
+    _is_obfuscated_ip,
+    _is_private_ip,
+    is_safe_url,
+    validate_url_for_ssrf,
+)
+
+
+class TestUrlValidationHelpers:
+    def test_obfuscated_decimal_outside_ipv4_range_is_not_blocked_as_obfuscated(self):
+        assert _is_obfuscated_ip("9999999999") is False
+
+    def test_private_ip_accepts_bracketed_literal(self):
+        assert _is_private_ip("[10.0.0.1]") is True
+
+    def test_private_ip_ignores_invalid_bracketed_literal(self):
+        assert _is_private_ip("[not-an-ip]") is False
+
+    def test_private_ip_checks_ipv4_mapped_inner_value_after_parse_failure(self, monkeypatch):
+        real_ip_address = url_validation_module.ipaddress.ip_address
+
+        def fake_ip_address(value: str):
+            if value == "::ffff:127.0.0.1":
+                raise ValueError
+            return real_ip_address(value)
+
+        monkeypatch.setattr(url_validation_module.ipaddress, "ip_address", fake_ip_address)
+
+        assert _is_private_ip("[::ffff:127.0.0.1]") is True
+
+    def test_private_ip_ignores_invalid_ipv4_mapped_inner_value(self, monkeypatch):
+        def fake_ip_address(_value: str):
+            raise ValueError
+
+        monkeypatch.setattr(url_validation_module.ipaddress, "ip_address", fake_ip_address)
+
+        assert _is_private_ip("[::ffff:not-an-ip]") is False
 
 
 class TestValidateUrlForSsrf:
@@ -42,6 +82,10 @@ class TestValidateUrlForSsrf:
         with pytest.raises(SSRFError, match="localhost"):
             validate_url_for_ssrf("http://[::1]/admin")
 
+    def test_rejects_ipv4_mapped_ipv6_loopback(self):
+        with pytest.raises(SSRFError, match="private"):
+            validate_url_for_ssrf("http://[::ffff:127.0.0.1]/admin")
+
     def test_rejects_zero_address(self):
         with pytest.raises(SSRFError, match="localhost"):
             validate_url_for_ssrf("http://0.0.0.0/admin")
@@ -74,6 +118,32 @@ class TestValidateUrlForSsrf:
         with pytest.raises(SSRFError, match="hostname"):
             validate_url_for_ssrf("http:///path")
 
+    def test_rejects_hostname_that_resolves_to_private_ip(self, monkeypatch):
+        def fake_getaddrinfo(*_args, **_kwargs):
+            return [(socket.AF_INET, socket.SOCK_STREAM, 6, "", ("10.0.0.42", 443))]
+
+        monkeypatch.setattr(socket, "getaddrinfo", fake_getaddrinfo)
+
+        with pytest.raises(SSRFError, match=r"10\.0\.0\.42"):
+            validate_url_for_ssrf("https://public.example/article")
+
+    def test_allows_hostname_that_resolves_to_public_ip(self, monkeypatch):
+        def fake_getaddrinfo(*_args, **_kwargs):
+            return [(socket.AF_INET, socket.SOCK_STREAM, 6, "", ("93.184.216.34", 443))]
+
+        monkeypatch.setattr(socket, "getaddrinfo", fake_getaddrinfo)
+
+        validate_url_for_ssrf("https://example.com/article")
+
+    def test_rejects_unresolvable_hostname(self, monkeypatch):
+        def fake_getaddrinfo(*_args, **_kwargs):
+            raise socket.gaierror("no address")
+
+        monkeypatch.setattr(socket, "getaddrinfo", fake_getaddrinfo)
+
+        with pytest.raises(SSRFError, match="Could not resolve hostname"):
+            validate_url_for_ssrf("https://missing.example/article")
+
 
 class TestIsSafeUrl:
     def test_returns_true_for_safe_url(self):
@@ -95,3 +165,14 @@ class TestIsSafeUrl:
         safe, error = is_safe_url("http://169.254.169.254/latest/meta-data/")
         assert safe is False
         assert "private" in error.lower()
+
+    def test_returns_false_for_dns_resolution_failure(self, monkeypatch):
+        def fake_getaddrinfo(*_args, **_kwargs):
+            raise socket.gaierror("temporary failure")
+
+        monkeypatch.setattr(socket, "getaddrinfo", fake_getaddrinfo)
+
+        safe, error = is_safe_url("https://missing.example/")
+
+        assert safe is False
+        assert error == "Could not resolve hostname"

--- a/tests/test_utils/test_url_validation.py
+++ b/tests/test_utils/test_url_validation.py
@@ -62,6 +62,16 @@ class TestValidateUrlForSsrf:
         with pytest.raises(SSRFError, match="localhost"):
             validate_url_for_ssrf("http://localhost/admin")
 
+    @pytest.mark.parametrize("hostname", ["LOCALHOST", "localhost."])
+    def test_rejects_localhost_variants_without_dns_lookup(self, hostname, monkeypatch):
+        def fake_getaddrinfo(*_args, **_kwargs):
+            raise AssertionError("blocked hosts should not require DNS resolution")
+
+        monkeypatch.setattr(socket, "getaddrinfo", fake_getaddrinfo)
+
+        with pytest.raises(SSRFError, match="localhost"):
+            validate_url_for_ssrf(f"http://{hostname}/admin")
+
     def test_rejects_127_0_0_1(self):
         with pytest.raises(SSRFError, match="localhost"):
             validate_url_for_ssrf("http://127.0.0.1/admin")
@@ -93,6 +103,10 @@ class TestValidateUrlForSsrf:
     def test_rejects_ipv4_mapped_ipv6_loopback(self):
         with pytest.raises(SSRFError, match="private"):
             validate_url_for_ssrf("http://[::ffff:127.0.0.1]/admin")
+
+    def test_rejects_ipv6_unique_local_address(self):
+        with pytest.raises(SSRFError, match="private"):
+            validate_url_for_ssrf("http://[fd00::1]/admin")
 
     def test_rejects_zero_address(self):
         with pytest.raises(SSRFError, match="localhost"):
@@ -134,6 +148,18 @@ class TestValidateUrlForSsrf:
 
         with pytest.raises(SSRFError, match=r"10\.0\.0\.42"):
             validate_url_for_ssrf("https://public.example/article")
+
+    def test_rejects_hostname_when_any_resolved_address_is_private(self, monkeypatch):
+        def fake_getaddrinfo(*_args, **_kwargs):
+            return [
+                (socket.AF_INET, socket.SOCK_STREAM, 6, "", ("93.184.216.34", 443)),
+                (socket.AF_INET, socket.SOCK_STREAM, 6, "", ("172.16.0.9", 443)),
+            ]
+
+        monkeypatch.setattr(socket, "getaddrinfo", fake_getaddrinfo)
+
+        with pytest.raises(SSRFError, match=r"172\.16\.0\.9"):
+            validate_url_for_ssrf("https://mixed.example/article")
 
     def test_allows_hostname_that_resolves_to_public_ip(self, monkeypatch):
         def fake_getaddrinfo(*_args, **_kwargs):

--- a/tests/test_vector_store.py
+++ b/tests/test_vector_store.py
@@ -1,6 +1,6 @@
 import subprocess
 import sys
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -116,6 +116,154 @@ class TestInitialize:
         assert results == []
         await store2.close()
 
+    async def test_initialize_warns_when_legacy_message_collection_files_exist(self, tmp_path):
+        legacy_root = tmp_path / "vectors" / "message_chunks"
+        legacy_root.mkdir(parents=True)
+        (legacy_root / "manifest.0").write_text("legacy")
+        (legacy_root / "guild-1").mkdir()
+
+        store = VectorStore(data_dir=str(tmp_path / "vectors"), dimensions=4, model_name="model-a")
+
+        with patch("intelstream.database.vector_store.logger.warning") as warning:
+            await store.initialize()
+
+        warning.assert_called_once()
+        assert warning.call_args.kwargs["files"] == ["manifest.0"]
+        await store.close()
+
+
+class TestInternals:
+    def test_unknown_collection_attr_name_raises(self, tmp_path):
+        store = VectorStore(data_dir=str(tmp_path / "vectors"), dimensions=4, model_name="model-a")
+
+        with pytest.raises(ValueError, match="Unknown collection name"):
+            store._collection_attr_name("unknown")
+
+    def test_read_collection_metadata_returns_none_when_missing(self, tmp_path):
+        store = VectorStore(data_dir=str(tmp_path / "vectors"), dimensions=4, model_name="model-a")
+
+        assert store._read_collection_metadata("article_chunks") is None
+
+    def test_read_collection_metadata_rejects_non_object_json(self, tmp_path):
+        collection_dir = tmp_path / "vectors" / "article_chunks"
+        collection_dir.mkdir(parents=True)
+        (collection_dir / "intelstream-index.json").write_text("[]")
+        store = VectorStore(data_dir=str(tmp_path / "vectors"), dimensions=4, model_name="model-a")
+
+        assert store._read_collection_metadata("article_chunks") is None
+
+    def test_read_collection_metadata_rejects_invalid_json(self, tmp_path):
+        collection_dir = tmp_path / "vectors" / "article_chunks"
+        collection_dir.mkdir(parents=True)
+        (collection_dir / "intelstream-index.json").write_text("{")
+        store = VectorStore(data_dir=str(tmp_path / "vectors"), dimensions=4, model_name="model-a")
+
+        assert store._read_collection_metadata("article_chunks") is None
+
+    async def test_collection_needs_recreate_allows_missing_metadata(self, tmp_path):
+        store = VectorStore(data_dir=str(tmp_path / "vectors"), dimensions=4, model_name="model-a")
+        store._collection_dimension = MagicMock(return_value=4)
+        store._read_collection_metadata = MagicMock(return_value=None)
+
+        assert await store._collection_needs_recreate("article_chunks", MagicMock()) is None
+
+    async def test_collection_needs_recreate_detects_stored_dimension_mismatch(self, tmp_path):
+        store = VectorStore(data_dir=str(tmp_path / "vectors"), dimensions=4, model_name="model-a")
+        store._collection_dimension = MagicMock(return_value=4)
+        store._read_collection_metadata = MagicMock(
+            return_value={"dimensions": 3, "model_name": "model-a"}
+        )
+
+        reason = await store._collection_needs_recreate("article_chunks", MagicMock())
+
+        assert reason == "stored metadata dimensions mismatch (3 != 4)"
+
+    async def test_destroy_collection_falls_back_to_removing_files(self, tmp_path):
+        collection_dir = tmp_path / "vectors" / "article_chunks"
+        collection_dir.mkdir(parents=True)
+        (collection_dir / "manifest.0").write_text("data")
+        collection = MagicMock()
+        collection.destroy.side_effect = RuntimeError("destroy failed")
+        store = VectorStore(data_dir=str(tmp_path / "vectors"), dimensions=4, model_name="model-a")
+
+        await store._destroy_collection_at_path(
+            "article_chunks",
+            collection,
+            str(collection_dir),
+        )
+
+        assert not collection_dir.exists()
+
+    async def test_open_or_create_opens_existing_without_metadata_validation(self, tmp_path):
+        import zvec
+
+        opened = MagicMock()
+        store = VectorStore(data_dir=str(tmp_path / "vectors"), dimensions=4, model_name="model-a")
+
+        with (
+            patch("zvec.create_and_open", side_effect=RuntimeError("exists")),
+            patch("zvec.open", return_value=opened) as open_collection,
+        ):
+            result = await store._open_or_create_collection(
+                "message_chunks_guild-1",
+                path=str(tmp_path / "vectors" / "message_chunks" / "guild-1"),
+            )
+
+        assert result is opened
+        open_collection.assert_called_once()
+        assert isinstance(open_collection.call_args.kwargs["option"], zvec.CollectionOption)
+
+    async def test_open_or_create_rewrites_metadata_for_existing_compatible_collection(
+        self, tmp_path
+    ):
+        opened = MagicMock()
+        store = VectorStore(data_dir=str(tmp_path / "vectors"), dimensions=4, model_name="model-a")
+        store._collection_needs_recreate = AsyncMock(return_value=None)
+        store._write_collection_metadata = MagicMock()
+
+        with (
+            patch("zvec.create_and_open", side_effect=RuntimeError("exists")),
+            patch("zvec.open", return_value=opened),
+        ):
+            result = await store._open_or_create_collection(
+                "article_chunks",
+                validate_metadata=True,
+            )
+
+        assert result is opened
+        store._collection_needs_recreate.assert_awaited_once()
+        store._write_collection_metadata.assert_called_once()
+
+    async def test_open_or_create_recreates_incompatible_existing_collection(self, tmp_path):
+        opened = MagicMock()
+        recreated = MagicMock()
+        store = VectorStore(data_dir=str(tmp_path / "vectors"), dimensions=4, model_name="model-a")
+        store._collection_needs_recreate = AsyncMock(return_value="model mismatch")
+        store._destroy_collection_at_path = AsyncMock()
+        store._write_collection_metadata = MagicMock()
+
+        with (
+            patch(
+                "zvec.create_and_open",
+                side_effect=[RuntimeError("exists"), recreated],
+            ),
+            patch("zvec.open", return_value=opened),
+        ):
+            result = await store._open_or_create_collection(
+                "article_chunks",
+                validate_metadata=True,
+            )
+
+        assert result is recreated
+        store._destroy_collection_at_path.assert_awaited_once()
+        store._write_collection_metadata.assert_called_once()
+
+    async def test_doc_count_raises_for_missing_collection(self, tmp_path):
+        store = VectorStore(data_dir=str(tmp_path / "vectors"), dimensions=4, model_name="model-a")
+
+        with pytest.raises(RuntimeError, match="not initialized"):
+            await store._doc_count(None)
+
 
 class TestUpsertAndSearch:
     async def test_upsert_and_search(self, vector_store):
@@ -186,6 +334,14 @@ class TestUpsertAndSearch:
         assert results[0].content_item_id == "item-1"
         assert results[0].text == "Chunk text"
 
+    async def test_search_message_chunks_returns_empty_when_collection_absent(self, tmp_path):
+        store = VectorStore(data_dir=str(tmp_path / "vectors"), dimensions=4, model_name="model-a")
+        await store.initialize()
+
+        assert await store.search_message_chunks("guild-1", [1.0, 0.0, 0.0, 0.0]) == []
+
+        await store.close()
+
 
 class TestUpsertBatch:
     async def test_batch_upsert(self, vector_store):
@@ -202,6 +358,16 @@ class TestUpsertBatch:
 
     async def test_batch_upsert_empty(self, vector_store):
         await vector_store.upsert_articles_batch([])
+
+    async def test_upsert_article_chunks_raises_when_collection_creation_returns_none(
+        self, tmp_path
+    ):
+        store = VectorStore(data_dir=str(tmp_path / "vectors"), dimensions=4, model_name="model-a")
+        store._initialized = True
+        store._article_collection = AsyncMock(return_value=None)
+
+        with pytest.raises(RuntimeError, match="not initialized"):
+            await store.upsert_article_chunks_batch([])
 
     async def test_article_chunk_batch_upsert_splits_large_batches(self, tmp_path):
         store = VectorStore(data_dir=str(tmp_path / "vectors"), dimensions=4, model_name="model-a")
@@ -226,6 +392,51 @@ class TestUpsertBatch:
         assert len(store._articles.upsert.call_args_list[0].args[0]) == 256
         assert len(store._articles.upsert.call_args_list[1].args[0]) == 44
 
+    async def test_message_chunk_batch_upsert_empty_does_not_write(self, tmp_path):
+        store = VectorStore(data_dir=str(tmp_path / "vectors"), dimensions=4, model_name="model-a")
+        store._initialized = True
+        store._message_chunks["guild-1"] = MagicMock()
+
+        await store.upsert_message_chunks_batch("guild-1", [])
+
+        store._message_chunks["guild-1"].upsert.assert_not_called()
+
+    async def test_message_chunk_batch_upsert_splits_large_batches(self, tmp_path):
+        store = VectorStore(data_dir=str(tmp_path / "vectors"), dimensions=4, model_name="model-a")
+        store._initialized = True
+        store._message_chunks["guild-1"] = MagicMock()
+        items = [
+            (f"chunk-{index:04d}", [1.0, 0.0, 0.0, 0.0])
+            for index in range(300)
+        ]
+
+        await store.upsert_message_chunks_batch("guild-1", items)
+
+        collection = store._message_chunks["guild-1"]
+        assert collection.upsert.call_count == 2
+        assert len(collection.upsert.call_args_list[0].args[0]) == 256
+        assert len(collection.upsert.call_args_list[1].args[0]) == 44
+
+    async def test_upsert_message_chunk_raises_when_collection_creation_returns_none(
+        self, tmp_path
+    ):
+        store = VectorStore(data_dir=str(tmp_path / "vectors"), dimensions=4, model_name="model-a")
+        store._initialized = True
+        store._message_chunk_collection = AsyncMock(return_value=None)
+
+        with pytest.raises(RuntimeError, match="not initialized"):
+            await store.upsert_message_chunk("guild-1", "chunk-1", [1.0, 0.0, 0.0, 0.0])
+
+    async def test_upsert_message_chunks_batch_raises_when_collection_creation_returns_none(
+        self, tmp_path
+    ):
+        store = VectorStore(data_dir=str(tmp_path / "vectors"), dimensions=4, model_name="model-a")
+        store._initialized = True
+        store._message_chunk_collection = AsyncMock(return_value=None)
+
+        with pytest.raises(RuntimeError, match="not initialized"):
+            await store.upsert_message_chunks_batch("guild-1", [])
+
 
 class TestDelete:
     async def test_delete_article(self, vector_store):
@@ -234,6 +445,35 @@ class TestDelete:
 
         results = await vector_store.search_articles([1.0, 0.0, 0.0, 0.0], topk=1)
         assert len(results) == 0
+
+    async def test_delete_article_chunks_noops_when_collection_absent(self, tmp_path):
+        store = VectorStore(data_dir=str(tmp_path / "vectors"), dimensions=4, model_name="model-a")
+        await store.initialize()
+
+        await store.delete_article_chunks(["missing"])
+
+        await store.close()
+
+    async def test_delete_message_chunks_noops_when_collection_absent(self, tmp_path):
+        store = VectorStore(data_dir=str(tmp_path / "vectors"), dimensions=4, model_name="model-a")
+        await store.initialize()
+
+        await store.delete_message_chunks_by_ids("guild-1", ["missing"])
+
+        await store.close()
+
+    async def test_delete_message_chunks_deletes_each_id(self, tmp_path):
+        store = VectorStore(data_dir=str(tmp_path / "vectors"), dimensions=4, model_name="model-a")
+        store._initialized = True
+        collection = MagicMock()
+        store._message_chunks["guild-1"] = collection
+
+        await store.delete_message_chunks_by_ids("guild-1", ["chunk-1", "chunk-2"])
+
+        assert [call.args[0] for call in collection.delete.call_args_list] == [
+            "chunk-1",
+            "chunk-2",
+        ]
 
 
 class TestRecreateCollections:

--- a/tests/test_vector_store.py
+++ b/tests/test_vector_store.py
@@ -194,6 +194,31 @@ class TestInternals:
 
         assert not collection_dir.exists()
 
+    async def test_destroy_collection_removes_files_without_open_collection(self, tmp_path):
+        collection_dir = tmp_path / "vectors" / "article_chunks"
+        collection_dir.mkdir(parents=True)
+        (collection_dir / "manifest.0").write_text("data")
+        store = VectorStore(data_dir=str(tmp_path / "vectors"), dimensions=4, model_name="model-a")
+
+        await store._destroy_collection_at_path(
+            "article_chunks",
+            None,
+            str(collection_dir),
+        )
+
+        assert not collection_dir.exists()
+
+    async def test_open_or_create_new_collection_without_metadata_validation(self, tmp_path):
+        created = MagicMock()
+        store = VectorStore(data_dir=str(tmp_path / "vectors"), dimensions=4, model_name="model-a")
+        store._write_collection_metadata = MagicMock()
+
+        with patch("zvec.create_and_open", return_value=created):
+            result = await store._open_or_create_collection("article_chunks")
+
+        assert result is created
+        store._write_collection_metadata.assert_not_called()
+
     async def test_open_or_create_opens_existing_without_metadata_validation(self, tmp_path):
         import zvec
 

--- a/tests/test_vector_store.py
+++ b/tests/test_vector_store.py
@@ -405,10 +405,7 @@ class TestUpsertBatch:
         store = VectorStore(data_dir=str(tmp_path / "vectors"), dimensions=4, model_name="model-a")
         store._initialized = True
         store._message_chunks["guild-1"] = MagicMock()
-        items = [
-            (f"chunk-{index:04d}", [1.0, 0.0, 0.0, 0.0])
-            for index in range(300)
-        ]
+        items = [(f"chunk-{index:04d}", [1.0, 0.0, 0.0, 0.0]) for index in range(300)]
 
         await store.upsert_message_chunks_batch("guild-1", items)
 


### PR DESCRIPTION
## Summary
- Expand adapter and discovery-strategy tests across arXiv, RSS, Page, SmartBlog, Substack, YouTube, LLM extraction, RSS discovery, and sitemap discovery.
- Add broader service coverage for article search, content extraction/fetch guards, content-posting batch behavior, embedding serialization, GitHub posting/service behavior, LLM client/provider paths, message forwarding limits, message ingestion, page-analysis request contracts, pipeline handling, search evaluation, summarization, web fetching, URL validation, config validation, feed parsing, and vector store recovery/indexing paths.
- Cover Discord bot/cog command guards, error paths, lifecycle behavior, GitHub polling, lore/search/source-management flows, summarization, the main entrypoint, repository edge cases, queue ordering, message chunk boundaries, search-eval contracts, GitHub request contracts, LLM provider request contracts, Discord forwarding caps, page-analyzer fetch/prompt contracts, embedding encode locking, content-poster source lookup batching, content-extractor SSRF fetch short-circuiting, and SSRF regression assertions.

## Notes
- Test-only change; no production code was modified.
- Adds new test modules for `intelstream.main` and the Discord `suck_boobs` cog.
- This PR uses a clean branch based directly on the current `main`.

## Verification
- `uv run --extra dev ruff check .`
- `uv run --extra dev ruff format --check .`
- `uv run mypy src/`
- `uv run --extra dev pytest --cov=src --cov-report=term-missing` — 1523 passed, 1 warning, 100% statement and branch coverage
- GitHub Actions on PR #249: lint, security scan, tests, and type check passed