### PR TITLE
[codex] Optimize Discord bot safety and batching

### DIFF
--- a/src/intelstream/database/repository.py
+++ b/src/intelstream/database/repository.py
@@ -612,16 +612,17 @@ class Repository:
     async def cleanup_extraction_cache(self, max_age_days: int = 7) -> int:
         cutoff = datetime.now(UTC) - timedelta(days=max_age_days)
         async with self.session() as session:
+            expired = ExtractionCache.cached_at < cutoff
             result = await session.execute(
-                select(ExtractionCache).where(ExtractionCache.cached_at < cutoff)
+                select(func.count()).select_from(ExtractionCache).where(expired)
             )
-            entries = list(result.scalars().all())
-            for entry in entries:
-                await session.delete(entry)
+            removed = int(result.scalar_one())
+            if removed:
+                await session.execute(delete(ExtractionCache).where(expired))
             await session.commit()
-            if entries:
-                logger.info("Cleaned up extraction cache", removed=len(entries))
-            return len(entries)
+            if removed:
+                logger.info("Cleaned up extraction cache", removed=removed)
+            return removed
 
     async def get_known_urls_for_source(self, source_id: str) -> set[str]:
         async with self.session() as session:

--- a/src/intelstream/discord/cogs/source_management.py
+++ b/src/intelstream/discord/cogs/source_management.py
@@ -183,13 +183,21 @@ class SourceManagement(commands.Cog):
     def __init__(self, bot: "IntelStreamBot") -> None:
         self.bot = bot
         self._anthropic_client: anthropic.AsyncAnthropic | None = None
+        self._owns_anthropic_client = False
 
     def _get_anthropic_client(self) -> anthropic.AsyncAnthropic:
         if self._anthropic_client is None:
             self._anthropic_client = anthropic.AsyncAnthropic(
                 api_key=self.bot.settings.anthropic_api_key
             )
+            self._owns_anthropic_client = True
         return self._anthropic_client
+
+    async def cog_unload(self) -> None:
+        if self._anthropic_client is not None and self._owns_anthropic_client:
+            await self._anthropic_client.close()
+            self._anthropic_client = None
+            self._owns_anthropic_client = False
 
     async def _source_name_autocomplete(
         self,

--- a/src/intelstream/discord/cogs/summarize.py
+++ b/src/intelstream/discord/cogs/summarize.py
@@ -49,6 +49,7 @@ SOURCE_TYPE_ICONS = {
 
 MAX_EMBED_DESCRIPTION = 4096
 MAX_EMBED_TITLE = 256
+YOUTUBE_TRANSCRIPT_TIMEOUT_SECONDS = 30.0
 
 
 class Summarize(commands.Cog):
@@ -201,6 +202,21 @@ class Summarize(commands.Cog):
 
     async def _fetch_youtube_transcript(self, video_id: str) -> str | None:
         try:
+            return await asyncio.wait_for(
+                asyncio.to_thread(self._fetch_youtube_transcript_sync, video_id),
+                timeout=YOUTUBE_TRANSCRIPT_TIMEOUT_SECONDS,
+            )
+        except TimeoutError:
+            logger.warning("Transcript fetch timed out", video_id=video_id)
+            return None
+        except (TranscriptsDisabled, VideoUnavailable):
+            return None
+        except Exception as e:
+            logger.warning("Failed to fetch transcript", video_id=video_id, error=str(e))
+            return None
+
+    def _fetch_youtube_transcript_sync(self, video_id: str) -> str | None:
+        try:
             ytt_api = YouTubeTranscriptApi()
             transcript_list = ytt_api.list(video_id)
 
@@ -222,9 +238,6 @@ class Summarize(commands.Cog):
             return " ".join(str(entry.text) for entry in entries)
 
         except (TranscriptsDisabled, VideoUnavailable):
-            return None
-        except Exception as e:
-            logger.warning("Failed to fetch transcript", video_id=video_id, error=str(e))
             return None
 
     async def _fetch_substack_content(self, url: str) -> WebContent:

--- a/src/intelstream/services/pipeline.py
+++ b/src/intelstream/services/pipeline.py
@@ -46,6 +46,7 @@ class ContentPipeline:
         self._summarizer = summarizer
         self._get_search_services = get_search_services
         self._http_client: httpx.AsyncClient | None = None
+        self._owned_anthropic_clients: list[anthropic.AsyncAnthropic] = []
         self._adapters: dict[SourceType, BaseAdapter] = {}
         self._article_chunker = ArticleChunker(
             chunk_size_chars=getattr(self._settings, "article_chunk_size_chars", 1200),
@@ -60,6 +61,9 @@ class ContentPipeline:
     async def close(self) -> None:
         if self._http_client:
             await self._http_client.aclose()
+        for client in self._owned_anthropic_clients:
+            await client.close()
+        self._owned_anthropic_clients.clear()
         logger.debug("Content pipeline closed")
 
     def _create_adapters(self) -> dict[SourceType, BaseAdapter]:
@@ -83,6 +87,7 @@ class ContentPipeline:
 
         if self._settings.anthropic_api_key and self._settings.anthropic_api_key.strip():
             anthropic_client = anthropic.AsyncAnthropic(api_key=self._settings.anthropic_api_key)
+            self._owned_anthropic_clients.append(anthropic_client)
             adapters[SourceType.BLOG] = SmartBlogAdapter(
                 anthropic_client=anthropic_client,
                 repository=self._repository,
@@ -318,9 +323,12 @@ class ContentPipeline:
         logger.info("Summarizing pending items", count=len(items))
         summarize_start = time.monotonic()
         summarized_count = 0
+        sources_by_id = await self._repository.get_sources_by_ids(
+            {item.source_id for item in items}
+        )
 
         for item in items:
-            source = await self._repository.get_source_by_id(item.source_id)
+            source = sources_by_id.get(item.source_id)
             source_name = source.name if source else "unknown"
             source_type = source.type.value if source else "unknown"
 

--- a/src/intelstream/services/web_fetcher.py
+++ b/src/intelstream/services/web_fetcher.py
@@ -54,7 +54,7 @@ class WebFetcher:
 
             current_url = url
             for _ in range(MAX_REDIRECTS):
-                response = await client.get(current_url)
+                response = await client.get(current_url, follow_redirects=False)
 
                 if response.is_redirect:
                     redirect_url = str(response.next_request.url) if response.next_request else None

--- a/tests/test_discord/test_source_management.py
+++ b/tests/test_discord/test_source_management.py
@@ -1576,6 +1576,36 @@ class TestSourceManagementLifecycle:
         assert first is second
         cls.assert_called_once_with(api_key="anthropic-key")
 
+    async def test_cog_unload_closes_owned_anthropic_client_once(self, source_management, mock_bot):
+        mock_bot.settings.anthropic_api_key = "anthropic-key"
+        client = MagicMock()
+        client.close = AsyncMock()
+
+        with patch(
+            "intelstream.discord.cogs.source_management.anthropic.AsyncAnthropic",
+            return_value=client,
+        ):
+            source_management._get_anthropic_client()
+
+        await source_management.cog_unload()
+        await source_management.cog_unload()
+
+        client.close.assert_awaited_once()
+
+    async def test_cog_unload_does_not_close_external_anthropic_client(self, source_management):
+        client = MagicMock()
+        client.close = AsyncMock()
+        source_management._anthropic_client = client
+
+        await source_management.cog_unload()
+
+        client.close.assert_not_called()
+
+    async def test_cog_unload_noops_without_anthropic_client(self, source_management):
+        await source_management.cog_unload()
+
+        assert source_management._anthropic_client is None
+
     async def test_setup_adds_cog(self, mock_bot):
         from intelstream.discord.cogs.source_management import setup
 

--- a/tests/test_discord/test_summarize.py
+++ b/tests/test_discord/test_summarize.py
@@ -1,8 +1,11 @@
+import asyncio
+import time
 from datetime import UTC, datetime
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import discord
+import httpx
 import pytest
 from youtube_transcript_api._errors import (
     NoTranscriptFound,
@@ -335,6 +338,28 @@ class TestFetchYoutubeTranscript:
         assert result == "Manual transcript"
         transcript_list.find_manually_created_transcript.assert_called_once_with(["en"])
 
+    async def test_fetch_transcript_does_not_block_event_loop_with_slow_api(self, summarize_cog):
+        transcript = MagicMock()
+        transcript.fetch.return_value = [SimpleNamespace(text="Slow transcript")]
+        transcript_list = MagicMock()
+        transcript_list.find_manually_created_transcript.return_value = transcript
+
+        class SlowApi:
+            def list(self, _video_id):
+                time.sleep(0.2)
+                return transcript_list
+
+        with patch(
+            "intelstream.discord.cogs.summarize.YouTubeTranscriptApi", return_value=SlowApi()
+        ):
+            start = time.monotonic()
+            task = asyncio.create_task(summarize_cog._fetch_youtube_transcript("video-id"))
+            await asyncio.sleep(0)
+            elapsed = time.monotonic() - start
+
+            assert elapsed < 0.15
+            assert await task == "Slow transcript"
+
     async def test_fetch_transcript_falls_back_to_generated_transcript(self, summarize_cog):
         generated = MagicMock()
         generated.fetch.return_value = [SimpleNamespace(text="Generated transcript")]
@@ -436,6 +461,20 @@ class TestFetchYoutubeTranscript:
         api.list.side_effect = RuntimeError("boom")
 
         with patch("intelstream.discord.cogs.summarize.YouTubeTranscriptApi", return_value=api):
+            assert await summarize_cog._fetch_youtube_transcript("video-id") is None
+
+    async def test_fetch_transcript_returns_none_on_timeout(self, summarize_cog):
+        class SlowApi:
+            def list(self, _video_id):
+                time.sleep(0.05)
+                return MagicMock()
+
+        with (
+            patch(
+                "intelstream.discord.cogs.summarize.YouTubeTranscriptApi", return_value=SlowApi()
+            ),
+            patch("intelstream.discord.cogs.summarize.YOUTUBE_TRANSCRIPT_TIMEOUT_SECONDS", 0.01),
+        ):
             assert await summarize_cog._fetch_youtube_transcript("video-id") is None
 
 
@@ -640,6 +679,87 @@ class TestSummarizeCommand:
         embed = call_kwargs["embed"]
         assert embed.title == "Test Article"
         assert embed.description == "This is a test summary."
+
+    async def test_web_summarization_follows_safe_redirect_without_client_auto_follow(
+        self, summarize_cog, mock_interaction
+    ):
+        final_html = """
+        <html>
+        <head><title>Final Article</title></head>
+        <body><article><p>Final public content for summarization with enough detail to pass the content length checks and prove the redirected response body is summarized.</p></article></body>
+        </html>
+        """
+        requested_urls: list[str] = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            requested_urls.append(str(request.url))
+            if str(request.url) == "https://example.com/article":
+                return httpx.Response(
+                    302,
+                    headers={"location": "https://example.com/final"},
+                    request=request,
+                )
+            return httpx.Response(
+                200,
+                headers={"content-type": "text/html"},
+                text=final_html,
+                request=request,
+            )
+
+        async with httpx.AsyncClient(
+            transport=httpx.MockTransport(handler),
+            follow_redirects=True,
+        ) as client:
+            summarize_cog._http_client = client
+            await summarize_cog.summarize.callback(
+                summarize_cog,
+                mock_interaction,
+                "https://example.com/article",
+            )
+
+        assert requested_urls == [
+            "https://example.com/article",
+            "https://example.com/final",
+        ]
+        summarize_cog._summarizer.summarize.assert_awaited_once()
+        assert (
+            "Final public content"
+            in summarize_cog._summarizer.summarize.await_args.kwargs["content"]
+        )
+        embed = mock_interaction.followup.send.call_args.kwargs["embed"]
+        assert embed.title == "Final Article"
+
+    async def test_web_summarization_rejects_private_redirect_before_fetch(
+        self, summarize_cog, mock_interaction
+    ):
+        requested_urls: list[str] = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            requested_urls.append(str(request.url))
+            if str(request.url) != "https://evil.example/redirect":
+                raise AssertionError(f"unexpected fetch: {request.url}")
+            return httpx.Response(
+                302,
+                headers={"location": "http://127.0.0.1/admin"},
+                request=request,
+            )
+
+        async with httpx.AsyncClient(
+            transport=httpx.MockTransport(handler),
+            follow_redirects=True,
+        ) as client:
+            summarize_cog._http_client = client
+            await summarize_cog.summarize.callback(
+                summarize_cog,
+                mock_interaction,
+                "https://evil.example/redirect",
+            )
+
+        assert requested_urls == ["https://evil.example/redirect"]
+        summarize_cog._summarizer.summarize.assert_not_awaited()
+        call_args = mock_interaction.followup.send.call_args
+        assert "Redirect blocked by SSRF" in call_args.args[0]
+        assert call_args.kwargs["ephemeral"] is True
 
     async def test_defers_response(self, summarize_cog, mock_interaction):
         mock_content = WebContent(

--- a/tests/test_services/test_pipeline.py
+++ b/tests/test_services/test_pipeline.py
@@ -169,6 +169,47 @@ class TestContentPipelineInitialization:
 
         assert http_client.is_closed
 
+    async def test_close_closes_owned_anthropic_client_once(
+        self,
+        pipeline: ContentPipeline,
+    ):
+        anthropic_client = MagicMock()
+        anthropic_client.close = AsyncMock()
+
+        with patch(
+            "intelstream.services.pipeline.anthropic.AsyncAnthropic",
+            return_value=anthropic_client,
+        ):
+            await pipeline.initialize()
+
+        await pipeline.close()
+        await pipeline.close()
+
+        anthropic_client.close.assert_awaited_once()
+
+    async def test_close_does_not_create_anthropic_client_when_absent(
+        self,
+        mock_repository,
+        mock_summarizer,
+    ):
+        settings = MagicMock(spec=Settings)
+        settings.youtube_api_key = "test-key"
+        settings.anthropic_api_key = None
+        settings.twitter_bearer_token = None
+        settings.http_timeout_seconds = 30.0
+        settings.summarization_delay_seconds = 0.5
+        settings.fetch_delay_seconds = 0.0
+
+        pipeline = ContentPipeline(
+            settings=settings, repository=mock_repository, summarizer=mock_summarizer
+        )
+
+        with patch("intelstream.services.pipeline.anthropic.AsyncAnthropic") as cls:
+            await pipeline.initialize()
+            await pipeline.close()
+
+        cls.assert_not_called()
+
 
 class TestCreateAdaptersWithoutAnthropicKey:
     async def test_no_blog_adapter_without_anthropic_key(self, mock_repository, mock_summarizer):
@@ -998,7 +1039,7 @@ class TestSummarizePending:
         await pipeline.initialize()
 
         mock_repository.get_unsummarized_content_items.return_value = [sample_content_item]
-        mock_repository.get_source_by_id.return_value = sample_source
+        mock_repository.get_sources_by_ids.return_value = {sample_source.id: sample_source}
         mock_repository.has_source_posted_content.return_value = True
         mock_summarizer.summarize.return_value = "This is the summary."
 
@@ -1041,12 +1082,13 @@ class TestSummarizePending:
         item_without_content.raw_content = None
 
         skip_source = MagicMock(spec=Source)
+        skip_source.id = "source-456"
         skip_source.name = "Skip Source"
         skip_source.type = SourceType.BLOG
         skip_source.skip_summary = True
 
         mock_repository.get_unsummarized_content_items.return_value = [item_without_content]
-        mock_repository.get_source_by_id.return_value = skip_source
+        mock_repository.get_sources_by_ids.return_value = {skip_source.id: skip_source}
         mock_repository.has_source_posted_content.return_value = True
 
         result = await pipeline.summarize_pending()
@@ -1072,12 +1114,13 @@ class TestSummarizePending:
         item_without_content.raw_content = None
 
         source = MagicMock(spec=Source)
+        source.id = "source-789"
         source.name = "Blog Source"
         source.type = SourceType.BLOG
         source.skip_summary = False
 
         mock_repository.get_unsummarized_content_items.return_value = [item_without_content]
-        mock_repository.get_source_by_id.return_value = source
+        mock_repository.get_sources_by_ids.return_value = {source.id: source}
         mock_repository.has_source_posted_content.return_value = True
 
         result = await pipeline.summarize_pending()
@@ -1099,7 +1142,7 @@ class TestSummarizePending:
         await pipeline.initialize()
 
         mock_repository.get_unsummarized_content_items.return_value = [sample_content_item]
-        mock_repository.get_source_by_id.return_value = sample_source
+        mock_repository.get_sources_by_ids.return_value = {sample_source.id: sample_source}
         mock_repository.has_source_posted_content.return_value = True
         mock_summarizer.summarize.side_effect = SummarizationError("API error")
 
@@ -1121,7 +1164,7 @@ class TestSummarizePending:
         await pipeline.initialize()
 
         mock_repository.get_unsummarized_content_items.return_value = [sample_content_item]
-        mock_repository.get_source_by_id.return_value = sample_source
+        mock_repository.get_sources_by_ids.return_value = {sample_source.id: sample_source}
         mock_repository.has_source_posted_content.return_value = True
         mock_summarizer.summarize.side_effect = RuntimeError("Unexpected")
 
@@ -1141,7 +1184,7 @@ class TestSummarizePending:
         await pipeline.initialize()
 
         mock_repository.get_unsummarized_content_items.return_value = [sample_content_item]
-        mock_repository.get_source_by_id.return_value = None
+        mock_repository.get_sources_by_ids.return_value = {}
         mock_repository.has_source_posted_content.return_value = True
         mock_summarizer.summarize.return_value = "Summary"
 
@@ -1186,6 +1229,7 @@ class TestSummarizePending:
         mock_repository.get_most_recent_item_for_source.return_value = new_item
         mock_repository.mark_items_as_backfilled.return_value = 1
         mock_repository.get_source_by_id.return_value = sample_source
+        mock_repository.get_sources_by_ids.return_value = {sample_source.id: sample_source}
         mock_summarizer.summarize.return_value = "Summary"
 
         result = await pipeline.summarize_pending()
@@ -1196,6 +1240,79 @@ class TestSummarizePending:
         )
 
         assert result == 1
+
+        await pipeline.close()
+
+    async def test_summarize_pending_batches_source_lookup_and_preserves_item_order(
+        self,
+        pipeline: ContentPipeline,
+        mock_repository: AsyncMock,
+        mock_summarizer: AsyncMock,
+    ):
+        await pipeline.initialize()
+        pipeline._settings.summarization_delay_seconds = 0.0
+
+        source_a = MagicMock(spec=Source)
+        source_a.id = "source-a"
+        source_a.name = "Source A"
+        source_a.type = SourceType.SUBSTACK
+        source_a.skip_summary = False
+
+        source_b = MagicMock(spec=Source)
+        source_b.id = "source-b"
+        source_b.name = "Source B"
+        source_b.type = SourceType.BLOG
+        source_b.skip_summary = False
+
+        item_1 = MagicMock(spec=ContentItem)
+        item_1.id = "item-1"
+        item_1.source_id = source_a.id
+        item_1.title = "First"
+        item_1.author = "Author 1"
+        item_1.raw_content = "First raw content"
+
+        item_2 = MagicMock(spec=ContentItem)
+        item_2.id = "item-2"
+        item_2.source_id = source_a.id
+        item_2.title = "Second"
+        item_2.author = "Author 2"
+        item_2.raw_content = "Second raw content"
+
+        item_3 = MagicMock(spec=ContentItem)
+        item_3.id = "item-3"
+        item_3.source_id = source_b.id
+        item_3.title = "Third"
+        item_3.author = "Author 3"
+        item_3.raw_content = "Third raw content"
+
+        mock_repository.get_unsummarized_content_items.return_value = [item_1, item_2, item_3]
+        mock_repository.has_source_posted_content.return_value = True
+        mock_repository.get_sources_by_ids.return_value = {
+            source_a.id: source_a,
+            source_b.id: source_b,
+        }
+        mock_summarizer.summarize.side_effect = ["Summary 1", "Summary 2", "Summary 3"]
+
+        result = await pipeline.summarize_pending()
+
+        assert result == 3
+        mock_repository.get_sources_by_ids.assert_awaited_once_with({source_a.id, source_b.id})
+        mock_repository.get_source_by_id.assert_not_awaited()
+        assert [call.kwargs["title"] for call in mock_summarizer.summarize.await_args_list] == [
+            "First",
+            "Second",
+            "Third",
+        ]
+        assert [
+            call.kwargs["source_type"] for call in mock_summarizer.summarize.await_args_list
+        ] == ["substack", "substack", "blog"]
+        assert [
+            call.args for call in mock_repository.update_content_item_summary.await_args_list
+        ] == [
+            ("item-1", "Summary 1"),
+            ("item-2", "Summary 2"),
+            ("item-3", "Summary 3"),
+        ]
 
         await pipeline.close()
 
@@ -1221,7 +1338,7 @@ class TestEmbedItem:
         )
 
         mock_repository.get_unsummarized_content_items.return_value = [sample_content_item]
-        mock_repository.get_source_by_id.return_value = sample_source
+        mock_repository.get_sources_by_ids.return_value = {sample_source.id: sample_source}
         mock_repository.has_source_posted_content.return_value = True
         mock_summarizer.summarize.return_value = "This is the summary."
 
@@ -1254,7 +1371,7 @@ class TestEmbedItem:
         )
 
         mock_repository.get_unsummarized_content_items.return_value = [sample_content_item]
-        mock_repository.get_source_by_id.return_value = sample_source
+        mock_repository.get_sources_by_ids.return_value = {sample_source.id: sample_source}
         mock_repository.has_source_posted_content.return_value = True
         mock_summarizer.summarize.return_value = "Summary"
 
@@ -1272,7 +1389,7 @@ class TestEmbedItem:
         sample_source,
     ):
         mock_repository.get_unsummarized_content_items.return_value = [sample_content_item]
-        mock_repository.get_source_by_id.return_value = sample_source
+        mock_repository.get_sources_by_ids.return_value = {sample_source.id: sample_source}
         mock_repository.has_source_posted_content.return_value = True
         mock_summarizer.summarize.return_value = "Summary"
 


### PR DESCRIPTION
## Summary
- Harden WebFetcher redirect handling so `/summarize` revalidates each redirect before fetching.
- Move YouTube transcript lookup off the Discord event loop and add timeout behavior.
- Close owned Anthropic clients on shutdown, bulk-delete expired extraction cache rows, and batch source lookups during summarization.

## Validation
- `PYTHONDONTWRITEBYTECODE=1 .venv/bin/python -m pytest -p no:cacheprovider` (1533 passed, 1 warning)
- `.venv/bin/python -m ruff check --no-cache src tests`
- `.venv/bin/python -m ruff format --check --no-cache src tests`
- `.venv/bin/python -m mypy src/`
- `git diff --check`

## Notes
Smithers run `run-1781436096311` completed. Its final reviewer noted pre-existing unrelated Bandit and pip-audit findings outside this PR scope; no scoped implementation issues were reported.