### PR TITLE
Optimize bot internals and Discord UX

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,47 +1,71 @@
-# Discord Configuration
-DISCORD_BOT_TOKEN=your_bot_token_here
-DISCORD_GUILD_ID=your_guild_id_here
-DISCORD_CHANNEL_ID=your_channel_id_here
-DISCORD_OWNER_ID=your_discord_user_id_here
+# Required Discord configuration
+DISCORD_BOT_TOKEN=replace_with_discord_bot_token
+DISCORD_GUILD_ID=replace_with_discord_server_id
+DISCORD_OWNER_ID=replace_with_discord_user_id
 
-# AI/LLM Configuration
-# Provider: anthropic, openai, gemini, or kimi
+# Optional legacy command restriction/default channel
+# DISCORD_CHANNEL_ID=replace_with_discord_channel_id
+
+# LLM provider: anthropic, openai, gemini, or kimi
 LLM_PROVIDER=anthropic
-# Set the API key for your chosen provider:
-ANTHROPIC_API_KEY=your_anthropic_api_key_here
-# OPENAI_API_KEY=your_openai_api_key_here
-# GEMINI_API_KEY=your_gemini_api_key_here
-# KIMI_API_KEY=your_kimi_api_key_here
+ANTHROPIC_API_KEY=replace_with_anthropic_api_key
+# OPENAI_API_KEY=replace_with_openai_api_key
+# GEMINI_API_KEY=replace_with_gemini_api_key
+# KIMI_API_KEY=replace_with_kimi_api_key
 
-# YouTube API (optional - for YouTube channel monitoring)
-YOUTUBE_API_KEY=your_youtube_api_key_here
+# Optional integrations
+# YOUTUBE_API_KEY=replace_with_youtube_data_api_key
+# TWITTER_BEARER_TOKEN=replace_with_x_bearer_token
+# GITHUB_TOKEN=replace_with_github_token
 
-# Twitter/X API (optional - for Twitter account monitoring)
-# Get a Bearer Token from https://developer.x.com/en/portal/dashboard
-# TWITTER_BEARER_TOKEN=your_x_api_bearer_token_here
-
-# Database Configuration
+# Database (SQLite with the async aiosqlite driver is required)
 DATABASE_URL=sqlite+aiosqlite:///./data/intelstream.db
 
-# Semantic Search
-# EMBEDDING_MODEL=all-MiniLM-L6-v2
-# EMBEDDING_DIMENSIONS=384
-# SEARCH_RESULT_LIMIT=5
-# ARTICLE_CHUNK_SIZE_CHARS=1200
-# ARTICLE_CHUNK_OVERLAP_CHARS=200
-# ARTICLE_SEARCH_CANDIDATE_LIMIT=24
-# ARTICLE_SEARCH_MIN_RELEVANCE_SCORE=0.35
-# ARTICLE_SEARCH_RERANKER_ENABLED=true
-# ARTICLE_SEARCH_RERANKER_MODEL=cross-encoder/ms-marco-MiniLM-L6-v2
-# LORE_CHUNK_GAP_MINUTES=10
-# LORE_CHUNK_MAX_MESSAGES=20
-# LORE_SEARCH_RESULTS=15
-
-# Polling Configuration
+# Polling and rate controls
 DEFAULT_POLL_INTERVAL_MINUTES=5
-# Per-adapter overrides (optional, falls back to DEFAULT_POLL_INTERVAL_MINUTES)
-# TWITTER_POLL_INTERVAL_MINUTES=20
-# YOUTUBE_POLL_INTERVAL_MINUTES=10
+CONTENT_POLL_INTERVAL_MINUTES=5
+GITHUB_POLL_INTERVAL_MINUTES=5
+FETCH_DELAY_SECONDS=1.0
+SUMMARIZATION_DELAY_SECONDS=0.5
+MAX_CONSECUTIVE_FAILURES=3
+YOUTUBE_MAX_RESULTS=5
+MAX_CONCURRENT_FORWARDS=5
+
+# Optional per-source-type poll overrides
+# SUBSTACK_POLL_INTERVAL_MINUTES=5
+# YOUTUBE_POLL_INTERVAL_MINUTES=5
+# RSS_POLL_INTERVAL_MINUTES=5
+# ARXIV_POLL_INTERVAL_MINUTES=5
+# BLOG_POLL_INTERVAL_MINUTES=5
+# TWITTER_POLL_INTERVAL_MINUTES=5
+# PAGE_POLL_INTERVAL_MINUTES=5
+
+# Summarization and HTTP
+SUMMARY_MAX_TOKENS=2048
+SUMMARY_MAX_INPUT_LENGTH=100000
+# SUMMARY_MODEL=provider_default
+# SUMMARY_MODEL_INTERACTIVE=provider_default
+DISCORD_MAX_MESSAGE_LENGTH=2000
+HTTP_TIMEOUT_SECONDS=30.0
+MAX_HTML_LENGTH=50000
+
+# Semantic article search
+SEARCH_ENABLED=true
+EMBEDDING_MODEL=all-MiniLM-L6-v2
+EMBEDDING_DIMENSIONS=384
+ZVEC_DATA_DIR=data/vectors
+SEARCH_RESULT_LIMIT=5
+ARTICLE_CHUNK_SIZE_CHARS=1200
+ARTICLE_CHUNK_OVERLAP_CHARS=200
+ARTICLE_SEARCH_CANDIDATE_LIMIT=24
+ARTICLE_SEARCH_MIN_RELEVANCE_SCORE=0.35
+ARTICLE_SEARCH_RERANKER_ENABLED=true
+ARTICLE_SEARCH_RERANKER_MODEL=cross-encoder/ms-marco-MiniLM-L6-v2
+
+# Lore/message-history indexing
+LORE_CHUNK_GAP_MINUTES=10
+LORE_CHUNK_MAX_MESSAGES=20
+LORE_SEARCH_RESULTS=15
 
 # Logging
 LOG_LEVEL=INFO

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Start from the tracked example file:
 cp .env.example .env
 ```
 
-Then replace the placeholders you need. Remove or comment out `DISCORD_CHANNEL_ID` unless you intentionally want legacy command restriction to a single channel.
+Then replace the required placeholders. Leave `DISCORD_CHANNEL_ID` commented unless you intentionally want legacy command restriction to a single channel; uncomment optional integrations only when you configure them.
 
 Minimum Anthropic-based configuration:
 
@@ -136,17 +136,17 @@ To get IDs, enable Developer Mode in Discord, then right-click the server or use
 
 ## Configuration
 
-Configuration is loaded with `pydantic-settings` from environment variables and `.env`. Names are case-insensitive and unknown variables are ignored.
+Configuration is loaded with `pydantic-settings` from environment variables and `.env`. Names are case-insensitive and unknown variables are ignored. Credential values are trimmed, blank credentials are rejected, and secret values remain masked in settings representations and serialization.
 
-Do not commit `.env`. It is ignored by `.gitignore`; `.env.example` is the safe template.
+Do not commit `.env`. It is ignored by `.gitignore`; `.env.example` is the copy-safe template and lists every supported runtime setting. Optional values are commented out until you need them.
 
 ### Required Runtime Variables
 
 | Variable | Required | Default | Notes |
 | --- | --- | --- | --- |
 | `DISCORD_BOT_TOKEN` | Yes | None | Discord bot token. Empty strings are rejected. |
-| `DISCORD_GUILD_ID` | Yes | None | Guild where slash commands are synced. |
-| `DISCORD_OWNER_ID` | Yes | None | User ID for owner notifications. |
+| `DISCORD_GUILD_ID` | Yes | None | Positive guild ID where slash commands are synced. |
+| `DISCORD_OWNER_ID` | Yes | None | Positive user ID for owner notifications. |
 | `LLM_PROVIDER` | No | `anthropic` | One of `anthropic`, `openai`, `gemini`, or `kimi`. |
 | Provider API key | Yes | None | Must match `LLM_PROVIDER`; see the next table. |
 
@@ -192,7 +192,7 @@ Important: Blog and Page source setup uses Anthropic-specific analyzers. Set `AN
 | `YOUTUBE_MAX_RESULTS` | `5` | 1-50 | Videos fetched per YouTube poll. |
 | `MAX_CONCURRENT_FORWARDS` | `5` | 1-20 | Semaphore limit for forwarding. |
 
-The source table stores `poll_interval_minutes`, but the active fetch path currently uses the environment-driven per-source-type intervals above.
+At pipeline startup, the effective environment-driven intervals above are synchronized to each source's stored `poll_interval_minutes`. The fetch path then uses those stored values for due-time checks, so configuration changes take effect after restart without adding delay for sources that are not due.
 
 ### Summarization And HTTP
 
@@ -214,7 +214,7 @@ The source table stores `poll_interval_minutes`, but the active fetch path curre
 | `ZVEC_DATA_DIR` | `data/vectors` | path | Local vector collection directory. |
 | `SEARCH_RESULT_LIMIT` | `5` | 1-25 | Final article results returned. |
 | `ARTICLE_CHUNK_SIZE_CHARS` | `1200` | 200-4000 | Article chunk target size. |
-| `ARTICLE_CHUNK_OVERLAP_CHARS` | `200` | 0-1000 | Chunk overlap. |
+| `ARTICLE_CHUNK_OVERLAP_CHARS` | `200` | 0-1000 | Chunk overlap; must also be smaller than `ARTICLE_CHUNK_SIZE_CHARS`. |
 | `ARTICLE_SEARCH_CANDIDATE_LIMIT` | `24` | 5-100 | Vector candidates before reranking. |
 | `ARTICLE_SEARCH_MIN_RELEVANCE_SCORE` | `0.35` | 0.0-1.0 | Result cutoff. |
 | `ARTICLE_SEARCH_RERANKER_ENABLED` | `true` | bool | Uses a cross-encoder when available. |
@@ -229,9 +229,11 @@ Changing `EMBEDDING_MODEL` usually requires changing `EMBEDDING_DIMENSIONS`. The
 
 | Variable | Default | Notes |
 | --- | --- | --- |
-| `DATABASE_URL` | `sqlite+aiosqlite:///./data/intelstream.db` | Runtime repository supports SQLite only, even though `Settings` can parse other URLs. |
+| `DATABASE_URL` | `sqlite+aiosqlite:///./data/intelstream.db` | SQLite with the async `aiosqlite` driver is required; unsupported URLs fail during configuration loading. |
 | `DISCORD_CHANNEL_ID` | unset | Legacy default channel and command restriction. When set, commands are allowed only in that channel and legacy sources without channels are migrated to it. |
 | `LOG_LEVEL` | `INFO` | One of `DEBUG`, `INFO`, `WARNING`, `ERROR`, `CRITICAL`. |
+
+Log timestamps are emitted in UTC. Human-friendly ANSI colors are used only when standard output is attached to a terminal, so redirected logs remain plain text. The startup record includes the selected models, polling cadence, search state, and enabled optional integrations without including credentials.
 
 ## Commands
 
@@ -460,7 +462,7 @@ Use a separate local database:
 DATABASE_URL=sqlite+aiosqlite:///./data/dev-intelstream.db uv run intelstream
 ```
 
-For a long-running deployment, run the command under your process manager of choice and persist both `data/intelstream.db` and `data/vectors/`. There is no Dockerfile or migration tool in the current repository; SQLite tables are created at startup and selected `sources` columns are migrated opportunistically.
+For a long-running deployment, run the command under your process manager of choice and persist both `data/intelstream.db` and `data/vectors/`. There is no Dockerfile or standalone migration tool in the current repository; SQLite tables, selected `sources` columns, and content-query indexes are reconciled at startup.
 
 ## Development
 

--- a/src/intelstream/adapters/base.py
+++ b/src/intelstream/adapters/base.py
@@ -32,3 +32,7 @@ class BaseAdapter(ABC):
     @abstractmethod
     async def get_feed_url(self, identifier: str) -> str:
         pass
+
+    async def close(self) -> None:
+        """Release resources owned by the adapter."""
+        return None

--- a/src/intelstream/adapters/strategies/llm_extraction.py
+++ b/src/intelstream/adapters/strategies/llm_extraction.py
@@ -23,7 +23,7 @@ from intelstream.adapters.strategies.base import (
 from intelstream.config import get_settings
 from intelstream.database.repository import Repository
 from intelstream.utils.safe_http import SafeHTTPError, safe_request
-from intelstream.utils.url_validation import SSRFError, validate_url_for_ssrf
+from intelstream.utils.url_validation import SSRFError, async_validate_url_for_ssrf
 
 logger = structlog.get_logger()
 
@@ -215,7 +215,7 @@ class LLMExtractionStrategy(DiscoveryStrategy):
                 if not post_url.startswith(("http://", "https://")):
                     post_url = urljoin(base_url, post_url)
                 try:
-                    validate_url_for_ssrf(post_url)
+                    await async_validate_url_for_ssrf(post_url)
                 except SSRFError:
                     logger.warning(
                         "Skipping LLM-extracted URL blocked by SSRF protection",

--- a/src/intelstream/adapters/strategies/rss_discovery.py
+++ b/src/intelstream/adapters/strategies/rss_discovery.py
@@ -14,7 +14,7 @@ from intelstream.adapters.strategies.base import (
 from intelstream.config import get_settings
 from intelstream.utils.feed_utils import parse_feed_date
 from intelstream.utils.safe_http import SafeHTTPError, safe_request
-from intelstream.utils.url_validation import SSRFError, validate_url_for_ssrf
+from intelstream.utils.url_validation import SSRFError, async_validate_url_for_ssrf
 
 logger = structlog.get_logger()
 
@@ -52,7 +52,7 @@ class RSSDiscoveryStrategy(DiscoveryStrategy):
         if not html:
             return None
 
-        rss_url = self._find_rss_in_html(html, base_url)
+        rss_url = await self._find_rss_in_html(html, base_url)
 
         if not rss_url:
             rss_url = await self._probe_rss_paths(base_url)
@@ -84,7 +84,7 @@ class RSSDiscoveryStrategy(DiscoveryStrategy):
             logger.debug("Failed to fetch HTML", url=url, error=str(e))
             return None
 
-    def _find_rss_in_html(self, html: str, base_url: str) -> str | None:
+    async def _find_rss_in_html(self, html: str, base_url: str) -> str | None:
         soup = BeautifulSoup(html, "lxml")
 
         for link in soup.find_all("link", rel="alternate"):
@@ -94,7 +94,7 @@ class RSSDiscoveryStrategy(DiscoveryStrategy):
                 if href:
                     feed_url = urljoin(base_url, str(href))
                     try:
-                        validate_url_for_ssrf(feed_url)
+                        await async_validate_url_for_ssrf(feed_url)
                         return feed_url
                     except SSRFError:
                         logger.warning("Skipping RSS URL blocked by SSRF protection", url=feed_url)
@@ -105,7 +105,7 @@ class RSSDiscoveryStrategy(DiscoveryStrategy):
             if href:
                 feed_url = urljoin(base_url, str(href))
                 try:
-                    validate_url_for_ssrf(feed_url)
+                    await async_validate_url_for_ssrf(feed_url)
                     return feed_url
                 except SSRFError:
                     logger.warning("Skipping RSS URL blocked by SSRF protection", url=feed_url)

--- a/src/intelstream/adapters/strategies/sitemap_discovery.py
+++ b/src/intelstream/adapters/strategies/sitemap_discovery.py
@@ -16,7 +16,7 @@ from intelstream.adapters.strategies.base import (
 )
 from intelstream.config import get_settings
 from intelstream.utils.safe_http import SafeHTTPError, safe_request
-from intelstream.utils.url_validation import SSRFError, validate_url_for_ssrf
+from intelstream.utils.url_validation import SSRFError, async_validate_url_for_ssrf
 
 logger = structlog.get_logger()
 
@@ -132,7 +132,7 @@ class SitemapDiscoveryStrategy(DiscoveryStrategy):
                 if line.lower().startswith("sitemap:"):
                     sitemap_url = line.split(":", 1)[1].strip()
                     try:
-                        validate_url_for_ssrf(sitemap_url)
+                        await async_validate_url_for_ssrf(sitemap_url)
                     except SSRFError:
                         logger.warning(
                             "Skipping sitemap URL blocked by SSRF protection",
@@ -242,7 +242,7 @@ class SitemapDiscoveryStrategy(DiscoveryStrategy):
             loc = sitemap.find("sm:loc", SITEMAP_NS)
             if loc is not None and loc.text:
                 try:
-                    validate_url_for_ssrf(loc.text)
+                    await async_validate_url_for_ssrf(loc.text)
                 except SSRFError:
                     logger.warning("Skipping sub-sitemap blocked by SSRF protection", url=loc.text)
                     continue
@@ -258,7 +258,7 @@ class SitemapDiscoveryStrategy(DiscoveryStrategy):
             loc = sitemap.find("loc")
             if loc is not None and loc.text:
                 try:
-                    validate_url_for_ssrf(loc.text)
+                    await async_validate_url_for_ssrf(loc.text)
                 except SSRFError:
                     logger.warning("Skipping sub-sitemap blocked by SSRF protection", url=loc.text)
                     continue

--- a/src/intelstream/adapters/youtube.py
+++ b/src/intelstream/adapters/youtube.py
@@ -28,7 +28,10 @@ class YouTubeAdapter(BaseAdapter):
     def __init__(self, api_key: str, http_client: httpx.AsyncClient | None = None) -> None:
         self._api_key = api_key
         self._client = http_client
-        self._youtube: Any = build("youtube", "v3", developerKey=api_key)
+        self._youtube: Any | None = None
+        self._youtube_lock = asyncio.Lock()
+        self._channel_id_cache: dict[str, str] = {}
+        self._uploads_playlist_cache: dict[str, str] = {}
 
     @property
     def source_type(self) -> str:
@@ -37,6 +40,24 @@ class YouTubeAdapter(BaseAdapter):
     async def get_feed_url(self, identifier: str) -> str:
         channel_id = await self._resolve_channel_id(identifier)
         return f"https://www.youtube.com/channel/{channel_id}"
+
+    async def close(self) -> None:
+        youtube = self._youtube
+        self._youtube = None
+        if youtube is not None:
+            await asyncio.to_thread(youtube.close)
+
+    async def _get_youtube(self) -> Any:
+        if self._youtube is None:
+            async with self._youtube_lock:
+                if self._youtube is None:
+                    self._youtube = await asyncio.to_thread(
+                        build,
+                        "youtube",
+                        "v3",
+                        developerKey=self._api_key,
+                    )
+        return self._youtube
 
     async def fetch_latest(
         self,
@@ -88,17 +109,21 @@ class YouTubeAdapter(BaseAdapter):
 
     async def _resolve_channel_id(self, identifier: str) -> str:
         identifier = identifier.strip()
+        cached = self._channel_id_cache.get(identifier)
+        if cached is not None:
+            return cached
 
         if CHANNEL_ID_PATTERN.match(identifier):
-            return identifier
+            channel_id = identifier
+        elif identifier.startswith(("https://", "http://")):
+            channel_id = await self._extract_channel_id_from_url(identifier)
+        elif HANDLE_PATTERN.match(identifier) or not identifier.startswith("UC"):
+            channel_id = await self._get_channel_id_by_handle_or_username(identifier)
+        else:
+            channel_id = identifier
 
-        if identifier.startswith("https://") or identifier.startswith("http://"):
-            return await self._extract_channel_id_from_url(identifier)
-
-        if HANDLE_PATTERN.match(identifier) or not identifier.startswith("UC"):
-            return await self._get_channel_id_by_handle_or_username(identifier)
-
-        return identifier
+        self._channel_id_cache[identifier] = channel_id
+        return channel_id
 
     async def _extract_channel_id_from_url(self, url: str) -> str:
         if "/channel/" in url:
@@ -121,22 +146,21 @@ class YouTubeAdapter(BaseAdapter):
 
     async def _get_channel_id_by_handle_or_username(self, identifier: str) -> str:
         identifier = identifier.lstrip("@")
+        youtube = await self._get_youtube()
 
-        request = self._youtube.channels().list(part="id", forHandle=identifier)
+        request = youtube.channels().list(part="id", forHandle=identifier)
         response: dict[str, Any] = await asyncio.to_thread(request.execute)
 
         if response.get("items"):
             return str(response["items"][0]["id"])
 
-        request = self._youtube.channels().list(part="id", forUsername=identifier)
+        request = youtube.channels().list(part="id", forUsername=identifier)
         response = await asyncio.to_thread(request.execute)
 
         if response.get("items"):
             return str(response["items"][0]["id"])
 
-        request = self._youtube.search().list(
-            part="snippet", q=identifier, type="channel", maxResults=1
-        )
+        request = youtube.search().list(part="snippet", q=identifier, type="channel", maxResults=1)
         response = await asyncio.to_thread(request.execute)
 
         if response.get("items"):
@@ -145,18 +169,26 @@ class YouTubeAdapter(BaseAdapter):
         raise ValueError(f"Could not find YouTube channel: {identifier}")
 
     async def _get_uploads_playlist_id(self, channel_id: str) -> str:
-        request = self._youtube.channels().list(part="contentDetails", id=channel_id)
+        cached = self._uploads_playlist_cache.get(channel_id)
+        if cached is not None:
+            return cached
+
+        youtube = await self._get_youtube()
+        request = youtube.channels().list(part="contentDetails", id=channel_id)
         response: dict[str, Any] = await asyncio.to_thread(request.execute)
 
         if not response.get("items"):
             raise ValueError(f"Channel not found: {channel_id}")
 
-        return str(response["items"][0]["contentDetails"]["relatedPlaylists"]["uploads"])
+        playlist_id = str(response["items"][0]["contentDetails"]["relatedPlaylists"]["uploads"])
+        self._uploads_playlist_cache[channel_id] = playlist_id
+        return playlist_id
 
     async def _get_playlist_videos(
         self, playlist_id: str, max_results: int
     ) -> list[dict[str, Any]]:
-        request = self._youtube.playlistItems().list(
+        youtube = await self._get_youtube()
+        request = youtube.playlistItems().list(
             part="snippet,contentDetails",
             playlistId=playlist_id,
             maxResults=max_results,

--- a/src/intelstream/bot.py
+++ b/src/intelstream/bot.py
@@ -17,6 +17,31 @@ if TYPE_CHECKING:
 
 logger = structlog.get_logger(__name__)
 
+MAX_EMBED_FIELD_VALUE_LENGTH = 1024
+MAX_STATUS_SOURCES = 8
+
+
+def _bounded_status_lines(
+    lines: list[str],
+    *,
+    max_items: int = MAX_STATUS_SOURCES,
+    max_length: int = MAX_EMBED_FIELD_VALUE_LENGTH,
+) -> str:
+    displayed = lines[:max_items]
+    while displayed:
+        omitted = len(lines) - len(displayed)
+        rendered = list(displayed)
+        if omitted:
+            rendered.append(f"*... and {omitted} more*")
+        value = "\n".join(rendered)
+        if len(value) <= max_length:
+            return value
+        displayed.pop()
+
+    if lines:
+        return f"*... and {len(lines)} more*"[:max_length]
+    return ""
+
 
 class RestrictedCommandTree(app_commands.CommandTree):
     def __init__(self, bot: "IntelStreamBot", *args: Any, **kwargs: Any) -> None:
@@ -27,7 +52,15 @@ class RestrictedCommandTree(app_commands.CommandTree):
             return False
         bot = self.client
         allowed_channel_id = bot.settings.discord_channel_id
-        if allowed_channel_id is not None and interaction.channel_id != allowed_channel_id:
+        channel = interaction.channel
+        is_allowed_thread = (
+            isinstance(channel, discord.Thread) and channel.parent_id == allowed_channel_id
+        )
+        if (
+            allowed_channel_id is not None
+            and interaction.channel_id != allowed_channel_id
+            and not is_allowed_thread
+        ):
             await interaction.response.send_message(
                 f"Commands can only be used in <#{allowed_channel_id}>",
                 ephemeral=True,
@@ -107,11 +140,12 @@ class IntelStreamBot(commands.Bot):
             intents=intents,
             help_command=None,
             tree_cls=RestrictedCommandTree,
+            allowed_mentions=discord.AllowedMentions.none(),
         )
 
         self.settings = settings
         self.repository = repository
-        self.start_time: datetime | None = None
+        self.start_time: datetime | None = datetime.now(UTC)
         self._owner: discord.User | None = None
         self.embedding_service: EmbeddingService | None = None
         self.vector_store: VectorStore | None = None
@@ -191,33 +225,35 @@ class IntelStreamBot(commands.Bot):
             await self.add_cog(Lore(self, self.embedding_service, self.vector_store))
             logger.info("Search services initialized")
         except Exception as e:
-            logger.error("Failed to initialize search services", error=str(e))
+            logger.exception("Failed to initialize search services", error=str(e))
             self.embedding_service = None
             self.vector_store = None
 
     async def on_ready(self) -> None:
-        self.start_time = datetime.now(UTC)
+        if self.start_time is None:
+            self.start_time = datetime.now(UTC)
         logger.info(
             "Logged in",
             user=str(self.user),
             user_id=self.user.id if self.user else None,
         )
 
-        try:
-            self._owner = await self.fetch_user(self.settings.discord_owner_id)
-            logger.info("Owner set", owner=str(self._owner))
-        except discord.NotFound:
-            logger.warning(
-                "Could not find owner",
-                owner_id=self.settings.discord_owner_id,
-            )
+        if self._owner is None:
+            try:
+                self._owner = await self.fetch_user(self.settings.discord_owner_id)
+                logger.info("Owner set", owner=str(self._owner))
+            except discord.NotFound:
+                logger.warning(
+                    "Could not find owner",
+                    owner_id=self.settings.discord_owner_id,
+                )
 
         lore_cog = self.cogs.get("Lore")
         if lore_cog is not None and hasattr(lore_cog, "auto_start_ingestion"):
             try:
                 await lore_cog.auto_start_ingestion()
             except Exception as e:
-                logger.error("Failed to auto-start lore ingestion", error=str(e))
+                logger.exception("Failed to auto-start lore ingestion", error=str(e))
 
     async def on_error(self, event_method: str, *_args: Any, **_kwargs: Any) -> None:
         logger.exception("Error in event handler", event_method=event_method)
@@ -256,7 +292,7 @@ class IntelStreamBot(commands.Bot):
                 except TimeoutError:
                     logger.error("Cog unload timed out", cog=cog_name)
                 except Exception as e:
-                    logger.error("Error unloading cog", cog=cog_name, error=str(e))
+                    logger.exception("Error unloading cog", cog=cog_name, error=str(e))
 
         try:
             await asyncio.wait_for(unload_all_cogs(), timeout=30.0)
@@ -269,14 +305,14 @@ class IntelStreamBot(commands.Bot):
             except TimeoutError:
                 logger.error("Vector store close timed out")
             except Exception as e:
-                logger.error("Error closing vector store", error=str(e))
+                logger.exception("Error closing vector store", error=str(e))
 
         try:
             await asyncio.wait_for(self.repository.close(), timeout=5.0)
         except TimeoutError:
             logger.error("Repository close timed out")
         except Exception as e:
-            logger.error("Error closing repository", error=str(e))
+            logger.exception("Error closing repository", error=str(e))
         finally:
             await super().close()
 
@@ -325,6 +361,8 @@ class CoreCommands(commands.Cog):
 
     @app_commands.command(name="status", description="Show bot status and information")
     async def status(self, interaction: discord.Interaction) -> None:
+        await interaction.response.defer()
+
         logger.debug(
             "status command invoked",
             user_id=interaction.user.id,
@@ -333,23 +371,35 @@ class CoreCommands(commands.Cog):
 
         guild_id = str(interaction.guild_id) if interaction.guild_id else None
 
-        sources = await self.bot.repository.get_all_sources(active_only=False)
+        if guild_id:
+            (
+                all_sources,
+                content_stats,
+                last_posted,
+                forwarding_rules,
+                default_config,
+            ) = await asyncio.gather(
+                self.bot.repository.get_all_sources(active_only=False, guild_id=guild_id),
+                self.bot.repository.get_content_stats(guild_id),
+                self.bot.repository.get_last_posted_content(guild_id),
+                self.bot.repository.get_forwarding_rules_for_guild(guild_id),
+                self.bot.repository.get_discord_config(guild_id),
+            )
+            sources = [source for source in all_sources if source.guild_id == guild_id]
+        else:
+            content_stats, last_posted = await asyncio.gather(
+                self.bot.repository.get_content_stats(None),
+                self.bot.repository.get_last_posted_content(None),
+            )
+            sources = []
+            forwarding_rules = []
+            default_config = None
+
         active_sources = [s for s in sources if s.is_active]
         failing_sources = [
             s for s in sources if s.consecutive_failures and s.consecutive_failures > 0
         ]
-
-        content_stats = await self.bot.repository.get_content_stats(guild_id)
-        last_posted = await self.bot.repository.get_last_posted_content(guild_id)
-
-        forwarding_rules = []
-        if guild_id:
-            forwarding_rules = await self.bot.repository.get_forwarding_rules_for_guild(guild_id)
         active_rules = [r for r in forwarding_rules if r.is_active]
-
-        default_config = None
-        if guild_id:
-            default_config = await self.bot.repository.get_discord_config(guild_id)
 
         embed = discord.Embed(
             title="IntelStream Status",
@@ -382,8 +432,8 @@ class CoreCommands(commands.Cog):
         embed.add_field(name="Sources", value=source_summary, inline=True)
 
         if sources:
-            source_list = []
-            for source in sources[:8]:
+            source_list: list[str] = []
+            for source in sources:
                 icon = self._get_source_status_icon(source)
                 channel_mention = f"<#{source.channel_id}>" if source.channel_id else "No channel"
 
@@ -395,12 +445,9 @@ class CoreCommands(commands.Cog):
                     f"`{icon}` **{source.name}** ({source.type.value}) -> {channel_mention}{failure_note}"
                 )
 
-            if len(sources) > 8:
-                source_list.append(f"*... and {len(sources) - 8} more*")
-
             embed.add_field(
                 name="Configured Sources",
-                value="\n".join(source_list),
+                value=_bounded_status_lines(source_list),
                 inline=False,
             )
 
@@ -431,7 +478,7 @@ class CoreCommands(commands.Cog):
 
         embed.set_footer(text="IntelStream")
 
-        await interaction.response.send_message(embed=embed)
+        await interaction.followup.send(embed=embed)
 
     @app_commands.command(name="ping", description="Check if the bot is responsive")
     async def ping(self, interaction: discord.Interaction) -> None:
@@ -453,6 +500,6 @@ async def create_bot(settings: Settings) -> IntelStreamBot:
 async def run_bot(settings: Settings) -> None:
     bot = await create_bot(settings)
     try:
-        await bot.start(settings.discord_bot_token)
+        await bot.start(settings.discord_token)
     finally:
         await bot.close()

--- a/src/intelstream/config.py
+++ b/src/intelstream/config.py
@@ -4,8 +4,10 @@ from functools import lru_cache
 from pathlib import Path
 from typing import TYPE_CHECKING, Literal
 
-from pydantic import Field, field_validator, model_validator
+from pydantic import Field, SecretStr, field_validator, model_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
+from sqlalchemy.engine import make_url
+from sqlalchemy.exc import ArgumentError
 
 if TYPE_CHECKING:
     from intelstream.database.models import SourceType
@@ -19,14 +21,15 @@ class Settings(BaseSettings):
         extra="ignore",
     )
 
-    discord_bot_token: str = Field(min_length=1, description="Discord bot token")
-    discord_guild_id: int = Field(description="Discord guild (server) ID")
+    discord_bot_token: SecretStr = Field(description="Discord bot token")
+    discord_guild_id: int = Field(gt=0, description="Discord guild (server) ID")
     discord_channel_id: int | None = Field(
         default=None,
+        gt=0,
         description="Default Discord channel ID for posting summaries (legacy, now per-source)",
     )
     discord_owner_id: int = Field(
-        description="Discord user ID of the bot owner for DM notifications"
+        gt=0, description="Discord user ID of the bot owner for DM notifications"
     )
 
     llm_provider: Literal["anthropic", "openai", "gemini", "kimi"] = Field(
@@ -34,19 +37,23 @@ class Settings(BaseSettings):
         description="LLM provider for summarization: anthropic, openai, gemini, or kimi",
     )
 
-    anthropic_api_key: str | None = Field(default=None, description="Anthropic API key for Claude")
-    openai_api_key: str | None = Field(default=None, description="OpenAI API key")
-    gemini_api_key: str | None = Field(default=None, description="Google Gemini API key")
-    kimi_api_key: str | None = Field(default=None, description="Kimi (Moonshot AI) API key")
+    anthropic_api_key: SecretStr | None = Field(
+        default=None, description="Anthropic API key for Claude"
+    )
+    openai_api_key: SecretStr | None = Field(default=None, description="OpenAI API key")
+    gemini_api_key: SecretStr | None = Field(default=None, description="Google Gemini API key")
+    kimi_api_key: SecretStr | None = Field(default=None, description="Kimi (Moonshot AI) API key")
 
-    youtube_api_key: str | None = Field(default=None, description="YouTube Data API key (optional)")
+    youtube_api_key: SecretStr | None = Field(
+        default=None, description="YouTube Data API key (optional)"
+    )
 
-    twitter_bearer_token: str | None = Field(
+    twitter_bearer_token: SecretStr | None = Field(
         default=None,
         description="X API v2 Bearer Token for Twitter monitoring (optional)",
     )
 
-    github_token: str | None = Field(
+    github_token: SecretStr | None = Field(
         default=None, description="GitHub Personal Access Token (optional)"
     )
 
@@ -309,7 +316,12 @@ class Settings(BaseSettings):
                 f"Set the corresponding environment variable "
                 f"(e.g., ANTHROPIC_API_KEY, OPENAI_API_KEY, GEMINI_API_KEY, KIMI_API_KEY)."
             )
-        return key
+        return key.get_secret_value()
+
+    @property
+    def discord_token(self) -> str:
+        """Return the Discord token for the client connection seam."""
+        return self.discord_bot_token.get_secret_value()
 
     _PROVIDER_MODEL_DEFAULTS: dict[str, tuple[str, str]] = {
         "anthropic": ("claude-haiku-4-5-20251001", "claude-sonnet-4-6"),
@@ -345,29 +357,82 @@ class Settings(BaseSettings):
             )
         return self
 
+    @field_validator(
+        "discord_bot_token",
+        "anthropic_api_key",
+        "openai_api_key",
+        "gemini_api_key",
+        "kimi_api_key",
+        "youtube_api_key",
+        "twitter_bearer_token",
+        "github_token",
+        mode="before",
+    )
+    @classmethod
+    def strip_and_validate_credentials(cls, value: object) -> object:
+        """Normalize configured credentials and reject blank values."""
+        if value is None:
+            return None
+        raw_value = value.get_secret_value() if isinstance(value, SecretStr) else str(value)
+        normalized = raw_value.strip()
+        if not normalized:
+            raise ValueError("Credential values cannot be empty or whitespace-only")
+        return normalized
+
+    @model_validator(mode="after")
+    def validate_article_chunk_overlap(self) -> Settings:
+        if self.article_chunk_overlap_chars >= self.article_chunk_size_chars:
+            raise ValueError(
+                "ARTICLE_CHUNK_OVERLAP_CHARS must be smaller than ARTICLE_CHUNK_SIZE_CHARS"
+            )
+        return self
+
     @field_validator("database_url")
     @classmethod
     def validate_database_url(cls, v: str) -> str:
-        if v.startswith("sqlite"):
-            db_path = v.split("///")[-1]
-            if db_path == "":
-                raise ValueError("SQLite database path cannot be empty")
+        try:
+            url = make_url(v)
+        except ArgumentError as e:
+            raise ValueError("Invalid database URL") from e
+        if url.get_backend_name() != "sqlite":
+            raise ValueError(f"Only SQLite databases are supported, got {url.get_backend_name()!r}")
+        if url.drivername != "sqlite+aiosqlite":
+            raise ValueError("SQLite database URLs must use the sqlite+aiosqlite async driver")
+        if not url.database:
+            raise ValueError("SQLite database path cannot be empty")
         return v
+
+    def startup_log_context(self) -> dict[str, object]:
+        """Return operational startup fields that are safe to write to logs."""
+        return {
+            "guild_id": self.discord_guild_id,
+            "legacy_channel_restriction": self.discord_channel_id is not None,
+            "llm_provider": self.llm_provider,
+            "summary_model": self.summary_model,
+            "summary_model_interactive": self.summary_model_interactive,
+            "content_poll_interval_minutes": self.content_poll_interval_minutes,
+            "search_enabled": self.search_enabled,
+            "embedding_model": self.embedding_model if self.search_enabled else None,
+            "youtube_enabled": self.youtube_api_key is not None,
+            "twitter_enabled": self.twitter_bearer_token is not None,
+            "github_enabled": self.github_token is not None,
+            "database_backend": make_url(self.database_url).get_backend_name(),
+        }
 
     def __repr__(self) -> str:
         return (
             f"Settings("
-            f"discord_bot_token='*****', "
+            f"discord_bot_token={self.discord_bot_token!r}, "
             f"discord_guild_id={self.discord_guild_id}, "
             f"discord_owner_id={self.discord_owner_id}, "
             f"llm_provider={self.llm_provider!r}, "
-            f"anthropic_api_key={'*****' if self.anthropic_api_key else None}, "
-            f"openai_api_key={'*****' if self.openai_api_key else None}, "
-            f"gemini_api_key={'*****' if self.gemini_api_key else None}, "
-            f"kimi_api_key={'*****' if self.kimi_api_key else None}, "
-            f"youtube_api_key={'*****' if self.youtube_api_key else None}, "
-            f"twitter_bearer_token={'*****' if self.twitter_bearer_token else None}, "
-            f"github_token={'*****' if self.github_token else None}, "
+            f"anthropic_api_key={self.anthropic_api_key!r}, "
+            f"openai_api_key={self.openai_api_key!r}, "
+            f"gemini_api_key={self.gemini_api_key!r}, "
+            f"kimi_api_key={self.kimi_api_key!r}, "
+            f"youtube_api_key={self.youtube_api_key!r}, "
+            f"twitter_bearer_token={self.twitter_bearer_token!r}, "
+            f"github_token={self.github_token!r}, "
             f"database_url={self.database_url!r}, "
             f"log_level={self.log_level!r}"
             f")"
@@ -379,16 +444,26 @@ def get_settings() -> Settings:
     return Settings()
 
 
+def reveal_secret(value: SecretStr | str | None) -> str | None:
+    """Explicitly unwrap an optional credential at an external client seam."""
+    if value is None:
+        return None
+    raw_value = value.get_secret_value() if isinstance(value, SecretStr) else value
+    normalized = raw_value.strip()
+    return normalized or None
+
+
 def get_database_directory(database_url: str) -> Path | None:
     """Extract the parent directory path from a SQLite database URL.
 
     Returns None for non-SQLite databases or :memory: databases.
     """
-    if not database_url.startswith("sqlite"):
+    try:
+        url = make_url(database_url)
+    except ArgumentError:
         return None
-
-    db_path = database_url.split("///")[-1]
-    if db_path == ":memory:" or not db_path:
+    if url.get_backend_name() != "sqlite":
         return None
-
-    return Path(db_path).parent
+    if url.database in (None, "", ":memory:"):
+        return None
+    return Path(url.database).parent

--- a/src/intelstream/database/models.py
+++ b/src/intelstream/database/models.py
@@ -2,7 +2,18 @@ import enum
 from datetime import UTC, datetime
 from uuid import uuid4
 
-from sqlalchemy import Boolean, DateTime, Enum, ForeignKey, Integer, String, Text, UniqueConstraint
+from sqlalchemy import (
+    Boolean,
+    DateTime,
+    Enum,
+    ForeignKey,
+    Index,
+    Integer,
+    String,
+    Text,
+    UniqueConstraint,
+    text,
+)
 from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column, relationship
 
 
@@ -63,6 +74,20 @@ class Source(Base):
 
 class ContentItem(Base):
     __tablename__ = "content_items"
+    __table_args__ = (
+        Index("ix_content_items_source_published", "source_id", "published_at"),
+        Index(
+            "ix_content_items_unsummarized_created",
+            "created_at",
+            sqlite_where=text("summary IS NULL"),
+        ),
+        Index(
+            "ix_content_items_unposted_published",
+            "published_at",
+            "id",
+            sqlite_where=text("posted_to_discord = 0 AND summary IS NOT NULL"),
+        ),
+    )
 
     id: Mapped[str] = mapped_column(String(36), primary_key=True, default=lambda: str(uuid4()))
     source_id: Mapped[str] = mapped_column(String(36), ForeignKey("sources.id"), nullable=False)

--- a/src/intelstream/database/repository.py
+++ b/src/intelstream/database/repository.py
@@ -1,8 +1,9 @@
 from datetime import UTC, datetime, timedelta
 
 import structlog
-from sqlalchemy import and_, delete, exists, func, insert, or_, select, text
-from sqlalchemy.exc import IntegrityError, OperationalError
+from sqlalchemy import and_, delete, exists, func, insert, or_, select, text, update
+from sqlalchemy.engine import make_url
+from sqlalchemy.exc import ArgumentError, IntegrityError, OperationalError
 from sqlalchemy.ext.asyncio import (
     AsyncConnection,
     AsyncSession,
@@ -45,15 +46,31 @@ SOURCES_MIGRATIONS: list[tuple[str, str]] = [
     ("skip_summary", "BOOLEAN DEFAULT 0"),
 ]
 
+CONTENT_ITEM_INDEX_MIGRATIONS: tuple[str, ...] = (
+    "CREATE INDEX IF NOT EXISTS ix_content_items_source_published "
+    "ON content_items (source_id, published_at)",
+    "CREATE INDEX IF NOT EXISTS ix_content_items_unsummarized_created "
+    "ON content_items (created_at) WHERE summary IS NULL",
+    "CREATE INDEX IF NOT EXISTS ix_content_items_unposted_published "
+    "ON content_items (published_at, id) "
+    "WHERE posted_to_discord = 0 AND summary IS NOT NULL",
+)
+
 MIN_POLL_INTERVAL_MINUTES = 1
-MAX_POLL_INTERVAL_MINUTES = 60
+MAX_POLL_INTERVAL_MINUTES = 1440
+SQLITE_IN_BATCH_SIZE = 900
 
 
 class Repository:
     def __init__(self, database_url: str) -> None:
-        if not database_url.startswith("sqlite"):
-            db_type = database_url.split("://")[0] if "://" in database_url else database_url
-            raise ValueError(f"Only SQLite databases are supported. Got: {db_type}")
+        try:
+            url = make_url(database_url)
+        except ArgumentError as e:
+            raise ValueError("Invalid database URL") from e
+        if url.get_backend_name() != "sqlite":
+            raise ValueError(f"Only SQLite databases are supported. Got: {url.get_backend_name()}")
+        if url.drivername != "sqlite+aiosqlite":
+            raise ValueError("SQLite database URLs must use the sqlite+aiosqlite async driver")
         self._engine = create_async_engine(
             database_url,
             echo=False,
@@ -68,6 +85,7 @@ class Repository:
         async with self._engine.begin() as conn:
             await conn.run_sync(Base.metadata.create_all)
             await self._migrate_sources_table(conn)
+            await self._migrate_content_item_indexes(conn)
         logger.info("Database initialization complete")
 
     async def _migrate_sources_table(self, conn: AsyncConnection) -> None:
@@ -80,6 +98,10 @@ class Repository:
                 await conn.execute(
                     text(f"ALTER TABLE sources ADD COLUMN {column_name} {column_type}")
                 )
+
+    async def _migrate_content_item_indexes(self, conn: AsyncConnection) -> None:
+        for statement in CONTENT_ITEM_INDEX_MIGRATIONS:
+            await conn.execute(text(statement))
 
     async def migrate_sources_to_channel(self, guild_id: str, channel_id: str) -> int:
         """Assign existing sources without a channel to the specified guild and channel."""
@@ -175,7 +197,10 @@ class Repository:
             return result.scalar_one_or_none()
 
     async def get_all_sources(
-        self, active_only: bool = True, channel_id: str | None = None
+        self,
+        active_only: bool = True,
+        channel_id: str | None = None,
+        guild_id: str | None = None,
     ) -> list[Source]:
         async with self.session() as session:
             query = select(Source)
@@ -183,8 +208,33 @@ class Repository:
                 query = query.where(Source.is_active == True)  # noqa: E712
             if channel_id is not None:
                 query = query.where(Source.channel_id == channel_id)
+            if guild_id is not None:
+                query = query.where(Source.guild_id == guild_id)
             result = await session.execute(query)
             return list(result.scalars().all())
+
+    async def sync_source_poll_intervals(self, intervals: dict[SourceType, int]) -> int:
+        """Persist configured per-type intervals without rewriting unchanged rows."""
+        updated = 0
+        async with self.session() as session:
+            for source_type, interval in intervals.items():
+                if not MIN_POLL_INTERVAL_MINUTES <= interval <= MAX_POLL_INTERVAL_MINUTES:
+                    raise ValueError(
+                        "poll_interval_minutes must be between "
+                        f"{MIN_POLL_INTERVAL_MINUTES} and {MAX_POLL_INTERVAL_MINUTES}, "
+                        f"got {interval}"
+                    )
+                result = await session.execute(
+                    update(Source)
+                    .where(
+                        Source.type == source_type,
+                        Source.poll_interval_minutes != interval,
+                    )
+                    .values(poll_interval_minutes=interval)
+                )
+                updated += int(getattr(result, "rowcount", 0) or 0)
+            await session.commit()
+        return updated
 
     async def update_source_last_polled(self, source_id: str) -> bool:
         async with self.session() as session:
@@ -408,6 +458,21 @@ class Repository:
             )
             return result.scalar_one()
 
+    async def get_existing_external_ids(self, external_ids: set[str]) -> set[str]:
+        if not external_ids:
+            return set()
+
+        identifiers = list(external_ids)
+        existing: set[str] = set()
+        async with self.session() as session:
+            for start in range(0, len(identifiers), SQLITE_IN_BATCH_SIZE):
+                batch = identifiers[start : start + SQLITE_IN_BATCH_SIZE]
+                result = await session.execute(
+                    select(ContentItem.external_id).where(ContentItem.external_id.in_(batch))
+                )
+                existing.update(result.scalars().all())
+        return existing
+
     async def get_unposted_content_items(
         self,
         limit: int = 10,
@@ -477,24 +542,19 @@ class Repository:
         self, source_id: str, exclude_item_id: str | None = None
     ) -> int:
         async with self.session() as session:
-            query = (
-                select(ContentItem)
+            statement = (
+                update(ContentItem)
                 .where(ContentItem.source_id == source_id)
                 .where(ContentItem.posted_to_discord == False)  # noqa: E712
                 .where(ContentItem.summary.is_(None))
+                .values(posted_to_discord=True, discord_message_id="backfilled")
             )
             if exclude_item_id:
-                query = query.where(ContentItem.id != exclude_item_id)
+                statement = statement.where(ContentItem.id != exclude_item_id)
 
-            result = await session.execute(query)
-            items = list(result.scalars().all())
-
-            for item in items:
-                item.posted_to_discord = True
-                item.discord_message_id = "backfilled"
-
+            result = await session.execute(statement)
             await session.commit()
-            return len(items)
+            return int(getattr(result, "rowcount", 0) or 0)
 
     async def update_content_item_summary(self, content_id: str, summary: str) -> bool:
         async with self.session() as session:

--- a/src/intelstream/database/vector_store.py
+++ b/src/intelstream/database/vector_store.py
@@ -6,13 +6,11 @@ import os
 import shutil
 from dataclasses import dataclass
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, cast
+from typing import TYPE_CHECKING, Any
 
 import structlog
 
 if TYPE_CHECKING:
-    from collections.abc import Callable
-
     import zvec
 
 logger = structlog.get_logger(__name__)
@@ -24,6 +22,7 @@ _ARTICLE_CHUNK_INDEX_FIELD = "chunk_index"
 _ARTICLE_TEXT_FIELD = "text"
 _ARTICLE_SEARCH_TEXT_FIELD = "search_text"
 _UPSERT_BATCH_SIZE = 256
+_DELETE_BATCH_SIZE = 256
 
 
 def _batched[T](items: list[T], batch_size: int) -> list[list[T]]:
@@ -442,10 +441,9 @@ class VectorStore:
         collection = await self._article_collection(create=False)
         if collection is None:
             return []
-        vector_query = cast("Callable[..., Any]", zvec.VectorQuery)
         results: Any = await asyncio.to_thread(
             collection.query,
-            vector_query(_VECTOR_FIELD_NAME, vector=query_embedding),
+            zvec.Query(_VECTOR_FIELD_NAME, vector=query_embedding),
             topk=topk,
             output_fields=[
                 _ARTICLE_CONTENT_ITEM_ID_FIELD,
@@ -470,11 +468,13 @@ class VectorStore:
         return chunk_results
 
     async def delete_article_chunks(self, chunk_ids: list[str]) -> None:
+        if not chunk_ids:
+            return
         collection = await self._article_collection(create=False)
         if collection is None:
             return
-        for chunk_id in chunk_ids:
-            await asyncio.to_thread(collection.delete, chunk_id)
+        for batch in _batched(chunk_ids, _DELETE_BATCH_SIZE):
+            await asyncio.to_thread(collection.delete, batch)
 
     async def article_chunk_doc_count(self) -> int:
         collection = await self._article_collection(create=False)
@@ -564,20 +564,21 @@ class VectorStore:
         collection = await self._message_chunk_collection(guild_id, create=False)
         if collection is None:
             return []
-        vector_query = cast("Callable[..., Any]", zvec.VectorQuery)
         results: Any = await asyncio.to_thread(
             collection.query,
-            vector_query(_VECTOR_FIELD_NAME, vector=query_embedding),
+            zvec.Query(_VECTOR_FIELD_NAME, vector=query_embedding),
             topk=topk,
         )
         return [ChunkSearchResult(chunk_id=r.id, score=r.score) for r in results]
 
     async def delete_message_chunks_by_ids(self, guild_id: str, chunk_ids: list[str]) -> None:
+        if not chunk_ids:
+            return
         collection = await self._message_chunk_collection(guild_id, create=False)
         if collection is None:
             return
-        for chunk_id in chunk_ids:
-            await asyncio.to_thread(collection.delete, chunk_id)
+        for batch in _batched(chunk_ids, _DELETE_BATCH_SIZE):
+            await asyncio.to_thread(collection.delete, batch)
 
     async def message_chunk_doc_count(self, guild_id: str) -> int:
         collection = await self._message_chunk_collection(guild_id, create=False)

--- a/src/intelstream/discord/cogs/channel_summary.py
+++ b/src/intelstream/discord/cogs/channel_summary.py
@@ -42,10 +42,10 @@ class ChannelSummary(commands.Cog):
 
     @app_commands.command(
         name="summary",
-        description="Summarize recent messages in a channel",
+        description="Summarize recent non-bot messages from a text channel",
     )
     @app_commands.describe(
-        count="Number of messages to summarize (default: 200, max: 500)",
+        count="Recent messages to scan (default: 200, max: 500)",
         channel="Channel to summarize (defaults to current channel)",
     )
     @app_commands.checks.cooldown(rate=1, per=60.0, key=lambda i: i.channel_id)
@@ -55,9 +55,13 @@ class ChannelSummary(commands.Cog):
         count: app_commands.Range[int, 10, MAX_MESSAGE_COUNT] = DEFAULT_MESSAGE_COUNT,
         channel: discord.TextChannel | None = None,
     ) -> None:
-        await interaction.response.defer()
-
         target_channel = channel or interaction.channel
+        is_cross_channel = (
+            isinstance(target_channel, discord.TextChannel)
+            and target_channel.id != interaction.channel_id
+        )
+        await interaction.response.defer(ephemeral=is_cross_channel)
+
         if not isinstance(target_channel, discord.TextChannel):
             await interaction.followup.send(
                 "This command can only be used in text channels.", ephemeral=True
@@ -107,7 +111,7 @@ class ChannelSummary(commands.Cog):
                 message_count=len(messages),
             )
         except Exception as e:
-            logger.error("Failed to generate channel summary", error=str(e))
+            logger.exception("Failed to generate channel summary", error=str(e))
             await interaction.followup.send(
                 "Failed to generate summary. Please try again later.", ephemeral=True
             )
@@ -124,6 +128,7 @@ class ChannelSummary(commands.Cog):
 
         await interaction.followup.send(
             full_text,
+            ephemeral=is_cross_channel,
             allowed_mentions=discord.AllowedMentions.none(),
         )
 

--- a/src/intelstream/discord/cogs/config_management.py
+++ b/src/intelstream/discord/cogs/config_management.py
@@ -17,13 +17,16 @@ class ConfigManagement(commands.Cog):
 
     config_group = app_commands.Group(
         name="config",
-        description="Configure bot settings",
+        description="Configure fallback bot settings",
         default_permissions=discord.Permissions(manage_guild=True),
     )
 
-    @config_group.command(name="channel", description="Set the channel for content posts")
+    @config_group.command(
+        name="channel",
+        description="Set the fallback channel for sources without one",
+    )
     @app_commands.checks.has_permissions(manage_guild=True)
-    @app_commands.describe(channel="The channel where content summaries will be posted")
+    @app_commands.describe(channel="Fallback channel for sources without a channel")
     async def config_channel(
         self,
         interaction: discord.Interaction,
@@ -123,8 +126,9 @@ class ConfigManagement(commands.Cog):
                 inline=False,
             )
 
-        sources = await self.bot.repository.get_all_sources(active_only=False)
-        guild_sources = [s for s in sources if s.guild_id == str(interaction.guild.id)]
+        guild_sources = await self.bot.repository.get_all_sources(
+            active_only=False, guild_id=str(interaction.guild.id)
+        )
         active_count = sum(1 for s in guild_sources if s.is_active)
 
         embed.add_field(

--- a/src/intelstream/discord/cogs/content_posting.py
+++ b/src/intelstream/discord/cogs/content_posting.py
@@ -88,7 +88,7 @@ class ContentPosting(commands.Cog):
         except TimeoutError:
             logger.error("Pipeline close timed out during cog unload")
         except Exception as e:
-            logger.error("Error closing pipeline during cog unload", error=str(e))
+            logger.exception("Error closing pipeline during cog unload", error=str(e))
 
         if self._summarizer:
             await self._summarizer.close()
@@ -124,7 +124,7 @@ class ContentPosting(commands.Cog):
                     posted = await self._poster.post_unposted_items(guild.id)
                     total_posted += posted
                 except Exception as e:
-                    logger.error(
+                    logger.exception(
                         "Error posting to guild",
                         guild_id=guild.id,
                         error=str(e),

--- a/src/intelstream/discord/cogs/github.py
+++ b/src/intelstream/discord/cogs/github.py
@@ -6,6 +6,7 @@ import structlog
 from discord import app_commands
 from discord.ext import commands
 
+from intelstream.config import reveal_secret
 from intelstream.services.github_service import GitHubAPIError, GitHubService
 
 if TYPE_CHECKING:
@@ -17,6 +18,16 @@ GITHUB_URL_PATTERN = re.compile(
     r"^(?:https?://)?(?:www\.)?github\.com/([^/]+)/([^/]+?)(?:\.git)?/?$"
 )
 OWNER_REPO_PATTERN = re.compile(r"^([^/]+)/([^/]+)$")
+MAX_EMBED_FIELDS = 25
+MAX_EMBED_FIELD_NAME_LENGTH = 256
+MAX_EMBED_TOTAL_TEXT_LENGTH = 6000
+MAX_EMBED_FOOTER_RESERVE = 100
+
+
+def _truncate_embed_field_name(value: str) -> str:
+    if len(value) <= MAX_EMBED_FIELD_NAME_LENGTH:
+        return value
+    return value[: MAX_EMBED_FIELD_NAME_LENGTH - 3] + "..."
 
 
 def parse_github_url(url: str) -> tuple[str, str] | None:
@@ -65,10 +76,11 @@ class GitHubCommands(commands.Cog):
         self._github_service: GitHubService | None = None
 
     def _get_github_service(self) -> GitHubService | None:
-        if not self.bot.settings.github_token:
+        token = reveal_secret(self.bot.settings.github_token)
+        if token is None:
             return None
         if self._github_service is None:
-            self._github_service = GitHubService(token=self.bot.settings.github_token)
+            self._github_service = GitHubService(token=token)
         return self._github_service
 
     async def cog_unload(self) -> None:
@@ -243,7 +255,9 @@ class GitHubCommands(commands.Cog):
             color=discord.Color.blue(),
         )
 
-        for repo in repos:
+        displayed_repos = []
+        embed_text_length = len(embed.title or "")
+        for repo in repos[:MAX_EMBED_FIELDS]:
             status = "Active" if repo.is_active else "Paused"
             if repo.consecutive_failures > 0:
                 status = f"Failing ({repo.consecutive_failures} errors)"
@@ -262,11 +276,23 @@ class GitHubCommands(commands.Cog):
                 else "Never"
             )
 
-            embed.add_field(
-                name=f"{'[ON]' if repo.is_active else '[OFF]'} {repo.owner}/{repo.repo}",
-                value=f"**Status:** {status}\n**Tracking:** {', '.join(tracking)}\n**Last Poll:** {last_poll}",
-                inline=True,
+            field_name = _truncate_embed_field_name(
+                f"{'[ON]' if repo.is_active else '[OFF]'} {repo.owner}/{repo.repo}"
             )
+            field_value = (
+                f"**Status:** {status}\n**Tracking:** {', '.join(tracking)}\n"
+                f"**Last Poll:** {last_poll}"
+            )
+            if (
+                embed_text_length + len(field_name) + len(field_value)
+                > MAX_EMBED_TOTAL_TEXT_LENGTH - MAX_EMBED_FOOTER_RESERVE
+            ):
+                break
+            embed.add_field(name=field_name, value=field_value, inline=True)
+            displayed_repos.append(repo)
+            embed_text_length += len(field_name) + len(field_value)
+
+        embed.set_footer(text=f"Showing {len(displayed_repos)} of {len(repos)} repositories")
 
         await interaction.followup.send(embed=embed)
 
@@ -360,7 +386,10 @@ class GitHubCommands(commands.Cog):
     ) -> list[app_commands.Choice[str]]:
         return await self._github_repo_autocomplete(interaction, current)
 
-    @github_group.command(name="toggle", description="Enable or disable GitHub repo monitoring")
+    @github_group.command(
+        name="toggle",
+        description="Pause or resume GitHub repository monitoring",
+    )
     @app_commands.default_permissions(manage_guild=True)
     @app_commands.checks.has_permissions(manage_guild=True)
     @app_commands.describe(repo="Repository name (owner/repo format)")

--- a/src/intelstream/discord/cogs/github_polling.py
+++ b/src/intelstream/discord/cogs/github_polling.py
@@ -5,6 +5,7 @@ import httpx
 import structlog
 from discord.ext import commands, tasks
 
+from intelstream.config import reveal_secret
 from intelstream.database.models import GitHubRepo
 from intelstream.services.github_poster import GitHubPoster
 from intelstream.services.github_service import GitHubAPIError, GitHubEvent, GitHubService
@@ -29,13 +30,14 @@ class GitHubPolling(commands.Cog):
         self._base_interval: int = 5
 
     async def cog_load(self) -> None:
-        if not self.bot.settings.github_token:
+        token = reveal_secret(self.bot.settings.github_token)
+        if token is None:
             logger.info("GitHub token not configured, polling disabled")
             return
 
         self._http_client = httpx.AsyncClient(timeout=30.0)
         self._service = GitHubService(
-            token=self.bot.settings.github_token,
+            token=token,
             http_client=self._http_client,
         )
         self._poster = GitHubPoster()
@@ -93,7 +95,7 @@ class GitHubPolling(commands.Cog):
                     repos_polled += 1
                     total_events += events_posted
                 except Exception as e:
-                    logger.error(
+                    logger.exception(
                         "Error processing GitHub repo",
                         owner=repo.owner,
                         repo=repo.repo,

--- a/src/intelstream/discord/cogs/message_forwarding.py
+++ b/src/intelstream/discord/cogs/message_forwarding.py
@@ -13,6 +13,8 @@ if TYPE_CHECKING:
 
 logger = structlog.get_logger()
 
+MAX_FORWARD_LIST_LENGTH = 1900
+
 
 class MessageForwarding(commands.Cog):
     forward_group = app_commands.Group(
@@ -95,7 +97,7 @@ class MessageForwarding(commands.Cog):
         source="Source channel or thread to forward FROM",
         destination="Destination channel or thread to forward TO",
     )
-    @app_commands.default_permissions(administrator=True)
+    @app_commands.default_permissions(manage_guild=True)
     @app_commands.checks.has_permissions(manage_guild=True)
     async def forward_add(
         self,
@@ -164,7 +166,7 @@ class MessageForwarding(commands.Cog):
         )
 
     @forward_group.command(name="list", description="List all forwarding rules")
-    @app_commands.default_permissions(administrator=True)
+    @app_commands.default_permissions(manage_guild=True)
     async def forward_list(self, interaction: discord.Interaction) -> None:
         await interaction.response.defer(ephemeral=True)
 
@@ -187,6 +189,7 @@ class MessageForwarding(commands.Cog):
             return
 
         lines = ["**Forwarding Rules:**", ""]
+        shown = 0
         for i, rule in enumerate(rules, 1):
             source = self.bot.get_channel(int(rule.source_channel_id))
             dest = self.bot.get_channel(int(rule.destination_channel_id))
@@ -209,9 +212,25 @@ class MessageForwarding(commands.Cog):
             )
             status = "active" if rule.is_active else "paused"
 
-            lines.append(
+            line = (
                 f"{i}. {source_name} -> {dest_name} ({status}, {rule.messages_forwarded} forwarded)"
             )
+            if len("\n".join([*lines, line])) > MAX_FORWARD_LIST_LENGTH:
+                break
+            lines.append(line)
+            shown += 1
+
+        if shown < len(rules):
+            omitted = len(rules) - shown
+            note = f"*... {omitted} more forwarding rule{'s' if omitted != 1 else ''} not shown.*"
+            while shown > 0 and len("\n".join([*lines, note])) > MAX_FORWARD_LIST_LENGTH:
+                lines.pop()
+                shown -= 1
+                omitted += 1
+                note = (
+                    f"*... {omitted} more forwarding rule{'s' if omitted != 1 else ''} not shown.*"
+                )
+            lines.append(note)
 
         await interaction.followup.send("\n".join(lines), ephemeral=True)
 
@@ -220,7 +239,7 @@ class MessageForwarding(commands.Cog):
         source="Source channel to stop forwarding from",
         destination="Destination channel/thread to stop forwarding to",
     )
-    @app_commands.default_permissions(administrator=True)
+    @app_commands.default_permissions(manage_guild=True)
     @app_commands.checks.has_permissions(manage_guild=True)
     async def forward_remove(
         self,
@@ -265,7 +284,7 @@ class MessageForwarding(commands.Cog):
         source="Source channel to pause forwarding from",
         destination="Destination channel/thread to pause forwarding to",
     )
-    @app_commands.default_permissions(administrator=True)
+    @app_commands.default_permissions(manage_guild=True)
     @app_commands.checks.has_permissions(manage_guild=True)
     async def forward_pause(
         self,
@@ -311,7 +330,7 @@ class MessageForwarding(commands.Cog):
         source="Source channel to resume forwarding from",
         destination="Destination channel/thread to resume forwarding to",
     )
-    @app_commands.default_permissions(administrator=True)
+    @app_commands.default_permissions(manage_guild=True)
     @app_commands.checks.has_permissions(manage_guild=True)
     async def forward_resume(
         self,

--- a/src/intelstream/discord/cogs/source_management.py
+++ b/src/intelstream/discord/cogs/source_management.py
@@ -1,3 +1,4 @@
+import asyncio
 import json
 import re
 from typing import TYPE_CHECKING
@@ -10,6 +11,7 @@ from discord import app_commands
 from discord.ext import commands
 
 from intelstream.adapters.smart_blog import SmartBlogAdapter
+from intelstream.config import reveal_secret
 from intelstream.database.exceptions import (
     DatabaseConnectionError,
     DuplicateSourceError,
@@ -17,7 +19,8 @@ from intelstream.database.exceptions import (
 )
 from intelstream.database.models import PauseReason, SourceType
 from intelstream.services.page_analyzer import PageAnalysisError, PageAnalyzer
-from intelstream.utils.url_validation import is_safe_url
+from intelstream.utils.log_safety import safe_url_for_log
+from intelstream.utils.url_validation import async_is_safe_url
 
 if TYPE_CHECKING:
     from intelstream.bot import IntelStreamBot
@@ -27,6 +30,23 @@ logger = structlog.get_logger()
 
 _TWITTER_USERNAME_RE = re.compile(r"^[A-Za-z0-9_]{1,15}$")
 _ARXIV_CATEGORY_RE = re.compile(r"^[A-Za-z0-9.-]+$")
+MAX_EMBED_FIELDS = 25
+MAX_EMBED_FIELD_NAME_LENGTH = 256
+MAX_EMBED_FIELD_VALUE_LENGTH = 1024
+MAX_EMBED_TOTAL_TEXT_LENGTH = 6000
+MAX_EMBED_FOOTER_RESERVE = 100
+
+
+def _truncate_embed_field_name(value: str) -> str:
+    if len(value) <= MAX_EMBED_FIELD_NAME_LENGTH:
+        return value
+    return value[: MAX_EMBED_FIELD_NAME_LENGTH - 3] + "..."
+
+
+def _truncate_embed_field_value(value: str) -> str:
+    if len(value) <= MAX_EMBED_FIELD_VALUE_LENGTH:
+        return value
+    return value[: MAX_EMBED_FIELD_VALUE_LENGTH - 3] + "..."
 
 
 def _is_valid_twitter_username(username: str) -> bool:
@@ -96,7 +116,8 @@ def parse_source_identifier(source_type: SourceType, url: str) -> tuple[str, str
         return identifier, feed_url
 
     elif source_type == SourceType.YOUTUBE:
-        if "youtube.com" in parsed.netloc:
+        host = (parsed.hostname or "").lower().rstrip(".")
+        if host == "youtube.com" or host.endswith(".youtube.com"):
             path = parsed.path
             if path.startswith("/@"):
                 identifier = path[2:]
@@ -187,9 +208,10 @@ class SourceManagement(commands.Cog):
 
     def _get_anthropic_client(self) -> anthropic.AsyncAnthropic:
         if self._anthropic_client is None:
-            self._anthropic_client = anthropic.AsyncAnthropic(
-                api_key=self.bot.settings.anthropic_api_key
-            )
+            api_key = reveal_secret(self.bot.settings.anthropic_api_key)
+            if api_key is None:
+                raise RuntimeError("Anthropic API key is not configured")
+            self._anthropic_client = anthropic.AsyncAnthropic(api_key=api_key)
             self._owns_anthropic_client = True
         return self._anthropic_client
 
@@ -257,7 +279,7 @@ class SourceManagement(commands.Cog):
             guild_id=str(interaction.guild_id) if interaction.guild_id else None,
             source_type=source_type.value,
             name=name,
-            url=url,
+            url=safe_url_for_log(url),
         )
 
         try:
@@ -309,9 +331,27 @@ class SourceManagement(commands.Cog):
             return
 
         validation_url = feed_url if stype == SourceType.ARXIV and feed_url else url
-        safe, error_msg = is_safe_url(validation_url)
+        safe, error_msg = await async_is_safe_url(validation_url)
         if not safe:
             await interaction.followup.send(f"URL not allowed: {error_msg}", ephemeral=True)
+            return
+
+        existing, existing_name = await asyncio.gather(
+            self.bot.repository.get_source_by_identifier(identifier),
+            self.bot.repository.get_source_by_name(name),
+        )
+        if existing:
+            await interaction.followup.send(
+                f"A source with identifier `{identifier}` already exists: **{existing.name}**",
+                ephemeral=True,
+            )
+            return
+
+        if existing_name:
+            await interaction.followup.send(
+                f"A source with name **{name}** already exists.",
+                ephemeral=True,
+            )
             return
 
         discovery_strategy: str | None = None
@@ -335,7 +375,7 @@ class SourceManagement(commands.Cog):
             discovered_url_pattern = result.url_pattern
             logger.info(
                 "Blog analysis complete",
-                url=url,
+                url=safe_url_for_log(url),
                 strategy=result.strategy,
                 post_count=result.post_count,
             )
@@ -359,22 +399,6 @@ class SourceManagement(commands.Cog):
                 )
                 return
 
-        existing = await self.bot.repository.get_source_by_identifier(identifier)
-        if existing:
-            await interaction.followup.send(
-                f"A source with identifier `{identifier}` already exists: **{existing.name}**",
-                ephemeral=True,
-            )
-            return
-
-        existing_name = await self.bot.repository.get_source_by_name(name)
-        if existing_name:
-            await interaction.followup.send(
-                f"A source with name **{name}** already exists.",
-                ephemeral=True,
-            )
-            return
-
         final_feed_url = discovered_feed_url if discovered_feed_url else feed_url
 
         try:
@@ -383,7 +407,7 @@ class SourceManagement(commands.Cog):
                 name=name,
                 identifier=identifier,
                 feed_url=final_feed_url,
-                poll_interval_minutes=self.bot.settings.default_poll_interval_minutes,
+                poll_interval_minutes=self.bot.settings.get_poll_interval(stype),
                 extraction_profile=extraction_profile_json,
                 discovery_strategy=discovery_strategy,
                 url_pattern=discovered_url_pattern,
@@ -411,12 +435,18 @@ class SourceManagement(commands.Cog):
             title="Source Added",
             color=discord.Color.green(),
         )
-        embed.add_field(name="Name", value=name, inline=True)
+        embed.add_field(name="Name", value=_truncate_embed_field_value(name), inline=True)
         embed.add_field(name="Type", value=source_type.name, inline=True)
         embed.add_field(name="Channel", value=f"<#{target_channel_id}>", inline=True)
-        embed.add_field(name="Identifier", value=identifier, inline=False)
+        embed.add_field(
+            name="Identifier", value=_truncate_embed_field_value(identifier), inline=False
+        )
         if final_feed_url:
-            embed.add_field(name="Feed URL", value=final_feed_url, inline=False)
+            embed.add_field(
+                name="Feed URL",
+                value=_truncate_embed_field_value(final_feed_url),
+                inline=False,
+            )
         if not summarize:
             embed.add_field(name="Summarize", value="Off", inline=True)
         if discovery_strategy:
@@ -449,7 +479,9 @@ class SourceManagement(commands.Cog):
             color=discord.Color.blue(),
         )
 
-        for source in sources:
+        displayed_sources = []
+        embed_text_length = len(embed.title or "")
+        for source in sources[:MAX_EMBED_FIELDS]:
             if source.is_active:
                 status = "Active"
             elif source.pause_reason == PauseReason.USER_PAUSED.value:
@@ -463,15 +495,29 @@ class SourceManagement(commands.Cog):
                 if source.last_polled_at
                 else "Never"
             )
-            embed.add_field(
-                name=f"{'[ON]' if source.is_active else '[OFF]'} {source.name}",
-                value=f"**Type:** {source.type.value}\n**Status:** {status}\n**Last Poll:** {last_poll}",
-                inline=True,
+            field_name = _truncate_embed_field_name(
+                f"{'[ON]' if source.is_active else '[OFF]'} {source.name}"
             )
+            field_value = (
+                f"**Type:** {source.type.value}\n**Status:** {status}\n**Last Poll:** {last_poll}"
+            )
+            if (
+                embed_text_length + len(field_name) + len(field_value)
+                > MAX_EMBED_TOTAL_TEXT_LENGTH - MAX_EMBED_FOOTER_RESERVE
+            ):
+                break
+            embed.add_field(name=field_name, value=field_value, inline=True)
+            displayed_sources.append(source)
+            embed_text_length += len(field_name) + len(field_value)
+
+        embed.set_footer(text=f"Showing {len(displayed_sources)} of {len(sources)} sources")
 
         await interaction.followup.send(embed=embed)
 
-    @source_group.command(name="remove", description="Remove a content source")
+    @source_group.command(
+        name="remove",
+        description="Archive a content source and stop polling it",
+    )
     @app_commands.default_permissions(manage_guild=True)
     @app_commands.checks.has_permissions(manage_guild=True)
     @app_commands.describe(name="Name of the source to remove")
@@ -607,7 +653,10 @@ class SourceManagement(commands.Cog):
     ) -> list[app_commands.Choice[str]]:
         return await self._source_name_autocomplete(interaction, current)
 
-    @source_group.command(name="toggle", description="Enable or disable a content source")
+    @source_group.command(
+        name="toggle",
+        description="Pause or resume polling for a content source",
+    )
     @app_commands.default_permissions(manage_guild=True)
     @app_commands.checks.has_permissions(manage_guild=True)
     @app_commands.describe(name="Name of the source to toggle")

--- a/src/intelstream/discord/cogs/suck_boobs.py
+++ b/src/intelstream/discord/cogs/suck_boobs.py
@@ -55,17 +55,25 @@ class SuckBoobs(commands.Cog):
             target_id=target.id,
             guild_id=interaction.guild_id,
         )
+        target_mention = discord.AllowedMentions(
+            everyone=False,
+            roles=False,
+            users=[target],
+            replied_user=False,
+        )
 
         # 1/20 chance (5%)
         if random.randint(1, 20) == 1:  # nosec B311
             await interaction.response.send_message(
                 f"{interaction.user.display_name} lost all self-control! Instead of the boob, they bypassed it entirely "
                 f"and started violently gobbling on <@{target.id}>'s dick like it's their last meal on Earth. "
-                f"Have some shame, you starving animal!"
+                f"Have some shame, you starving animal!",
+                allowed_mentions=target_mention,
             )
         else:
             await interaction.response.send_message(
-                f"🍼 {interaction.user.display_name} sucks <@{target.id}>'s boobs 🥛😳"
+                f"🍼 {interaction.user.display_name} sucks <@{target.id}>'s boobs 🥛😳",
+                allowed_mentions=target_mention,
             )
 
     @app_commands.command(name="suck_boobs_score", description="Show the suck_boobs leaderboard")

--- a/src/intelstream/discord/cogs/summarize.py
+++ b/src/intelstream/discord/cogs/summarize.py
@@ -2,7 +2,7 @@ import asyncio
 import contextlib
 import re
 from datetime import UTC, datetime
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 from urllib.parse import urlparse
 
 import discord
@@ -19,10 +19,12 @@ from youtube_transcript_api._errors import (
 )
 
 from intelstream.adapters.substack import SubstackAdapter
+from intelstream.config import reveal_secret
 from intelstream.services.llm_client import create_llm_client
 from intelstream.services.summarizer import SummarizationService
 from intelstream.services.web_fetcher import WebContent, WebFetcher, WebFetchError
-from intelstream.utils.url_validation import is_safe_url
+from intelstream.utils.log_safety import safe_url_for_log
+from intelstream.utils.url_validation import async_is_safe_url
 
 if TYPE_CHECKING:
     from intelstream.bot import IntelStreamBot
@@ -52,11 +54,19 @@ MAX_EMBED_TITLE = 256
 YOUTUBE_TRANSCRIPT_TIMEOUT_SECONDS = 30.0
 
 
+def _hostname_matches(hostname: str, domain: str) -> bool:
+    normalized = hostname.lower().rstrip(".")
+    return normalized == domain or normalized.endswith(f".{domain}")
+
+
 class Summarize(commands.Cog):
     def __init__(self, bot: "IntelStreamBot") -> None:
         self.bot = bot
         self._http_client: httpx.AsyncClient | None = None
         self._summarizer: SummarizationService | None = None
+        self._youtube: Any | None = None
+        self._youtube_lock = asyncio.Lock()
+        self._youtube_request_lock = asyncio.Lock()
 
     async def cog_load(self) -> None:
         self._http_client = httpx.AsyncClient(
@@ -81,27 +91,40 @@ class Summarize(commands.Cog):
             await self._summarizer.close()
         if self._http_client:
             await self._http_client.aclose()
+        if self._youtube is not None:
+            close = getattr(self._youtube, "close", None)
+            if callable(close):
+                await asyncio.to_thread(close)
+            self._youtube = None
         logger.info("Summarize cog unloaded")
+
+    async def _get_youtube_client(self, api_key: str) -> Any:
+        if self._youtube is not None:
+            return self._youtube
+        async with self._youtube_lock:
+            if self._youtube is None:
+                self._youtube = await asyncio.to_thread(
+                    build,
+                    "youtube",
+                    "v3",
+                    developerKey=api_key,
+                )
+        return self._youtube
 
     def detect_url_type(self, url: str) -> str:
         parsed = urlparse(url)
-        domain = parsed.netloc.lower()
+        hostname = parsed.hostname or ""
 
-        if "youtube.com" in domain or "youtu.be" in domain:
+        if _hostname_matches(hostname, "youtube.com") or _hostname_matches(hostname, "youtu.be"):
             return "youtube"
 
-        if "substack.com" in domain:
+        if _hostname_matches(hostname, "substack.com"):
             return "substack"
 
-        if "twitter.com" in domain or "x.com" in domain:
+        if _hostname_matches(hostname, "twitter.com") or _hostname_matches(hostname, "x.com"):
             return "twitter"
 
         return "web"
-
-    def _is_substack_url(self, url: str) -> bool:
-        parsed = urlparse(url)
-        domain = parsed.netloc.lower()
-        return "substack.com" in domain
 
     def _extract_youtube_video_id(self, url: str) -> str | None:
         for pattern in YOUTUBE_VIDEO_PATTERNS:
@@ -155,14 +178,15 @@ class Summarize(commands.Cog):
         if not video_id:
             raise WebFetchError("Could not extract video ID from URL")
 
-        api_key = self.bot.settings.youtube_api_key
+        api_key = reveal_secret(self.bot.settings.youtube_api_key)
         if not api_key:
             raise WebFetchError("YouTube API key not configured")
 
-        youtube = build("youtube", "v3", developerKey=api_key)
+        youtube = await self._get_youtube_client(api_key)
 
-        request = youtube.videos().list(part="snippet", id=video_id)
-        response = await asyncio.to_thread(request.execute)
+        async with self._youtube_request_lock:
+            request = youtube.videos().list(part="snippet", id=video_id)
+            response = await asyncio.to_thread(request.execute)
 
         if not response.get("items"):
             raise WebFetchError("Video not found")
@@ -274,9 +298,9 @@ class Summarize(commands.Cog):
 
     @app_commands.command(
         name="summarize",
-        description="Get an AI summary of any URL (YouTube, Substack, or web page)",
+        description="Summarize a public YouTube, Substack, or web page",
     )
-    @app_commands.describe(url="URL to summarize (YouTube video, Substack article, or any webpage)")
+    @app_commands.describe(url="Public HTTP(S) URL for a supported video, article, or web page")
     @app_commands.checks.cooldown(rate=10, per=300.0)
     async def summarize(self, interaction: discord.Interaction, url: str) -> None:
         await interaction.response.defer()
@@ -285,7 +309,7 @@ class Summarize(commands.Cog):
             "summarize command invoked",
             user_id=interaction.user.id,
             guild_id=str(interaction.guild_id) if interaction.guild_id else None,
-            url=url,
+            url=safe_url_for_log(url),
         )
 
         parsed = urlparse(url)
@@ -293,11 +317,11 @@ class Summarize(commands.Cog):
             await interaction.followup.send("Please provide a valid URL.", ephemeral=True)
             return
 
-        if not parsed.scheme.startswith("http"):
+        if parsed.scheme.lower() not in {"http", "https"}:
             await interaction.followup.send("Please provide an HTTP or HTTPS URL.", ephemeral=True)
             return
 
-        safe, error_msg = is_safe_url(url)
+        safe, error_msg = await async_is_safe_url(url)
         if not safe:
             await interaction.followup.send(f"URL not allowed: {error_msg}", ephemeral=True)
             return
@@ -323,7 +347,7 @@ class Summarize(commands.Cog):
             await interaction.followup.send(str(e), ephemeral=True)
             return
         except Exception as e:
-            logger.error("Failed to fetch content", url=url, error=str(e))
+            logger.exception("Failed to fetch content", url=safe_url_for_log(url), error=str(e))
             await interaction.followup.send(
                 "Could not fetch content from that URL. The page may be behind a paywall or require login.",
                 ephemeral=True,
@@ -357,7 +381,7 @@ class Summarize(commands.Cog):
             )
 
         except Exception as e:
-            logger.error("Failed to generate summary", url=url, error=str(e))
+            logger.exception("Failed to generate summary", url=safe_url_for_log(url), error=str(e))
             await interaction.followup.send(
                 "Failed to generate summary. Please try again.", ephemeral=True
             )
@@ -377,7 +401,7 @@ class Summarize(commands.Cog):
 
         logger.info(
             "Summarized content",
-            url=url,
+            url=safe_url_for_log(url),
             source_type=source_type,
             user_id=interaction.user.id,
         )

--- a/src/intelstream/main.py
+++ b/src/intelstream/main.py
@@ -6,17 +6,20 @@ import structlog
 
 from intelstream.bot import run_bot
 from intelstream.config import get_settings
+from intelstream.utils.log_safety import sanitize_log_urls
 
 
 def configure_logging(log_level: str) -> None:
+    stdout_is_tty = getattr(sys.stdout, "isatty", lambda: False)()
     structlog.configure(
         processors=[
             structlog.contextvars.merge_contextvars,
+            sanitize_log_urls,
             structlog.processors.add_log_level,
             structlog.processors.StackInfoRenderer(),
             structlog.dev.set_exc_info,
-            structlog.processors.TimeStamper(fmt="iso"),
-            structlog.dev.ConsoleRenderer(),
+            structlog.processors.TimeStamper(fmt="iso", utc=True),
+            structlog.dev.ConsoleRenderer(colors=stdout_is_tty),
         ],
         wrapper_class=structlog.make_filtering_bound_logger(getattr(logging, log_level.upper())),
         context_class=dict,
@@ -41,7 +44,7 @@ def main() -> None:
     configure_logging(settings.log_level)
 
     logger = structlog.get_logger()
-    logger.info("Starting IntelStream bot")
+    logger.info("Starting IntelStream bot", **settings.startup_log_context())
 
     try:
         asyncio.run(run_bot(settings))

--- a/src/intelstream/services/content_extractor.py
+++ b/src/intelstream/services/content_extractor.py
@@ -1,3 +1,4 @@
+import asyncio
 import contextlib
 import re
 from dataclasses import dataclass
@@ -9,8 +10,8 @@ import trafilatura
 from bs4 import BeautifulSoup, Tag
 
 from intelstream.config import get_settings
+from intelstream.utils.log_safety import safe_url_for_log
 from intelstream.utils.safe_http import SafeHTTPError, safe_request
-from intelstream.utils.url_validation import SSRFError, validate_url_for_ssrf
 
 logger = structlog.get_logger()
 
@@ -61,16 +62,12 @@ class ContentExtractor:
         self._client = http_client
 
     async def extract(self, url: str) -> ExtractedContent:
-        try:
-            validate_url_for_ssrf(url)
-        except SSRFError:
-            logger.warning("Skipping URL blocked by SSRF protection", url=url)
-            return ExtractedContent(text="")
-
         html = await self._fetch_html(url)
         if not html:
             return ExtractedContent(text="")
+        return await asyncio.to_thread(self._extract_html, html, url)
 
+    def _extract_html(self, html: str, url: str) -> ExtractedContent:
         result = trafilatura.extract(
             html,
             include_comments=False,
@@ -146,7 +143,7 @@ class ContentExtractor:
                 published_at=self._extract_date(soup),
             )
 
-        logger.warning("Content extraction failed validation", url=url)
+        logger.warning("Content extraction failed validation", url=safe_url_for_log(url))
         return ExtractedContent(
             text="",
             title=self._extract_title(soup),
@@ -190,7 +187,7 @@ class ContentExtractor:
             response.raise_for_status()
             return response.text
         except (httpx.HTTPError, SafeHTTPError) as e:
-            logger.warning("Failed to fetch content", url=url, error=str(e))
+            logger.warning("Failed to fetch content", url=safe_url_for_log(url), error=str(e))
             return None
 
     def _extract_title(self, soup: BeautifulSoup) -> str | None:

--- a/src/intelstream/services/content_poster.py
+++ b/src/intelstream/services/content_poster.py
@@ -256,7 +256,7 @@ class ContentPoster:
                         error=str(e),
                     )
                 except Exception as e:
-                    logger.error(
+                    logger.exception(
                         "Unexpected error posting content item",
                         item_id=item.id,
                         title=item.title,

--- a/src/intelstream/services/pipeline.py
+++ b/src/intelstream/services/pipeline.py
@@ -16,7 +16,7 @@ from intelstream.adapters.smart_blog import SmartBlogAdapter
 from intelstream.adapters.substack import SubstackAdapter
 from intelstream.adapters.twitter import TwitterAdapter
 from intelstream.adapters.youtube import YouTubeAdapter
-from intelstream.config import Settings
+from intelstream.config import Settings, reveal_secret
 from intelstream.database.exceptions import DuplicateContentError
 from intelstream.database.models import ArticleChunkMeta, ContentItem, Source, SourceType
 from intelstream.database.repository import Repository
@@ -55,13 +55,27 @@ class ContentPipeline:
         )
 
     async def initialize(self) -> None:
+        configured_intervals = {
+            source_type: self._settings.get_poll_interval(source_type) for source_type in SourceType
+        }
+        updated_sources = await self._repository.sync_source_poll_intervals(configured_intervals)
         self._http_client = httpx.AsyncClient(timeout=self._settings.http_timeout_seconds)
         self._adapters = self._create_adapters()
-        logger.debug("Content pipeline initialized")
+        logger.debug(
+            "Content pipeline initialized",
+            source_intervals_updated=updated_sources,
+        )
 
     async def close(self) -> None:
+        for adapter in self._adapters.values():
+            try:
+                await adapter.close()
+            except Exception:
+                logger.exception("Failed to close content adapter", adapter=adapter.source_type)
+        self._adapters.clear()
         if self._http_client:
             await self._http_client.aclose()
+            self._http_client = None
         for client in self._owned_anthropic_clients:
             await client.close()
         self._owned_anthropic_clients.clear()
@@ -74,20 +88,23 @@ class ContentPipeline:
             SourceType.ARXIV: ArxivAdapter(http_client=self._http_client),
         }
 
-        if self._settings.youtube_api_key:
+        youtube_api_key = reveal_secret(self._settings.youtube_api_key)
+        if youtube_api_key:
             adapters[SourceType.YOUTUBE] = YouTubeAdapter(
-                api_key=self._settings.youtube_api_key,
+                api_key=youtube_api_key,
                 http_client=self._http_client,
             )
 
-        if self._settings.twitter_bearer_token:
+        twitter_bearer_token = reveal_secret(self._settings.twitter_bearer_token)
+        if twitter_bearer_token:
             adapters[SourceType.TWITTER] = TwitterAdapter(
-                bearer_token=self._settings.twitter_bearer_token,
+                bearer_token=twitter_bearer_token,
                 http_client=self._http_client,
             )
 
-        if self._settings.anthropic_api_key and self._settings.anthropic_api_key.strip():
-            anthropic_client = anthropic.AsyncAnthropic(api_key=self._settings.anthropic_api_key)
+        anthropic_api_key = reveal_secret(self._settings.anthropic_api_key)
+        if anthropic_api_key:
+            anthropic_client = anthropic.AsyncAnthropic(api_key=anthropic_api_key)
             self._owned_anthropic_clients.append(anthropic_client)
             adapters[SourceType.BLOG] = SmartBlogAdapter(
                 anthropic_client=anthropic_client,
@@ -111,15 +128,16 @@ class ContentPipeline:
         sources_skipped = 0
         sources_failed = 0
         fetch_delay = self._settings.fetch_delay_seconds
+        now = datetime.now(UTC)
+        due_sources: list[Source] = []
 
-        for i, source in enumerate(sources):
+        for source in sources:
             if source.last_polled_at is not None:
-                interval = self._settings.get_poll_interval(source.type)
                 last_polled = source.last_polled_at
                 if last_polled.tzinfo is None:
                     last_polled = last_polled.replace(tzinfo=UTC)
-                next_poll_at = last_polled + timedelta(minutes=interval)
-                if datetime.now(UTC) < next_poll_at:
+                next_poll_at = last_polled + timedelta(minutes=source.poll_interval_minutes)
+                if now < next_poll_at:
                     logger.debug(
                         "Skipping source, not due yet",
                         source_name=source.name,
@@ -128,7 +146,9 @@ class ContentPipeline:
                     )
                     sources_skipped += 1
                     continue
+            due_sources.append(source)
 
+        for i, source in enumerate(due_sources):
             fetch_succeeded = False
             try:
                 new_items = await self._fetch_source(source)
@@ -213,7 +233,7 @@ class ContentPipeline:
             if fetch_succeeded:
                 await self._repository.reset_failure_count(source.id)
 
-            if fetch_delay > 0 and i < len(sources) - 1:
+            if fetch_delay > 0 and i < len(due_sources) - 1:
                 await asyncio.sleep(fetch_delay)
 
         await self._repository.cleanup_extraction_cache()
@@ -268,14 +288,21 @@ class ContentPipeline:
         is_first_poll = source.last_polled_at is None
 
         new_count = 0
+        existing_ids = (
+            await self._repository.get_existing_external_ids({item.external_id for item in items})
+            if items
+            else set()
+        )
+        seen_ids = set(existing_ids)
         for item in items:
-            if not await self._repository.content_item_exists(item.external_id):
-                try:
-                    await self._store_content_item(source, item)
-                    new_count += 1
-                except DuplicateContentError:
-                    logger.debug("Content item already exists", external_id=item.external_id)
-                    continue
+            if item.external_id in seen_ids:
+                continue
+            try:
+                await self._store_content_item(source, item)
+                new_count += 1
+            except DuplicateContentError:
+                logger.debug("Content item already exists", external_id=item.external_id)
+            seen_ids.add(item.external_id)
 
         if is_first_poll and new_count > 0:
             most_recent = await self._repository.get_most_recent_item_for_source(source.id)
@@ -337,7 +364,7 @@ class ContentPipeline:
             {item.source_id for item in items}
         )
 
-        for item in items:
+        for item_index, item in enumerate(items):
             source = sources_by_id.get(item.source_id)
             source_name = source.name if source else "unknown"
             source_type = source.type.value if source else "unknown"
@@ -393,7 +420,7 @@ class ContentPipeline:
                     error=str(e),
                 )
             except Exception as e:
-                logger.error(
+                logger.exception(
                     "Unexpected error during summarization",
                     item_id=item.id,
                     title=item.title,
@@ -401,7 +428,8 @@ class ContentPipeline:
                     error=str(e),
                 )
 
-            await asyncio.sleep(self._settings.summarization_delay_seconds)
+            if item_index < len(items) - 1 and self._settings.summarization_delay_seconds > 0:
+                await asyncio.sleep(self._settings.summarization_delay_seconds)
 
         elapsed = round(time.monotonic() - summarize_start, 2)
         logger.info(
@@ -467,7 +495,7 @@ class ContentPipeline:
             await self._repository.add_article_chunk_metas_batch(metas)
             await vector_store.upsert_article_chunks_batch(vector_items)
         except Exception as e:
-            logger.warning("Failed to embed item", item_id=item_id, error=str(e))
+            logger.exception("Failed to embed item", item_id=item_id, error=str(e))
 
     async def _handle_first_posting_backfill(self, items: list[ContentItem]) -> None:
         processed_sources: set[str] = set()

--- a/src/intelstream/services/web_fetcher.py
+++ b/src/intelstream/services/web_fetcher.py
@@ -1,3 +1,4 @@
+import asyncio
 from dataclasses import dataclass
 from datetime import datetime
 
@@ -5,6 +6,7 @@ import httpx
 import structlog
 from bs4 import BeautifulSoup, Tag
 
+from intelstream.utils.log_safety import safe_url_for_log
 from intelstream.utils.safe_http import DEFAULT_MAX_REDIRECTS, SafeHTTPError, safe_request
 
 logger = structlog.get_logger()
@@ -59,13 +61,17 @@ class WebFetcher:
             if len(html) > MAX_CONTENT_LENGTH:
                 html = html[:MAX_CONTENT_LENGTH]
 
-            return self._parse_html(url, html)
+            return await asyncio.to_thread(self._parse_html, url, html)
 
         except httpx.HTTPStatusError as e:
-            logger.warning("HTTP error fetching URL", url=url, status=e.response.status_code)
+            logger.warning(
+                "HTTP error fetching URL",
+                url=safe_url_for_log(url),
+                status=e.response.status_code,
+            )
             raise WebFetchError(f"Failed to fetch URL: HTTP {e.response.status_code}") from e
         except httpx.RequestError as e:
-            logger.warning("Request error fetching URL", url=url, error=str(e))
+            logger.warning("Request error fetching URL", url=safe_url_for_log(url), error=str(e))
             raise WebFetchError(f"Failed to fetch URL: {e}") from e
         except SafeHTTPError as e:
             raise WebFetchError(str(e)) from e

--- a/src/intelstream/utils/log_safety.py
+++ b/src/intelstream/utils/log_safety.py
@@ -1,0 +1,41 @@
+import re
+from collections.abc import MutableMapping
+from typing import Any
+from urllib.parse import urlsplit, urlunsplit
+
+MAX_LOG_URL_LENGTH = 500
+_CONTROL_CHARACTERS = re.compile(r"[\x00-\x1f\x7f-\x9f]")
+
+
+def safe_url_for_log(url: str) -> str:
+    """Remove credentials, query parameters, fragments, and control characters from a URL."""
+    cleaned = _CONTROL_CHARACTERS.sub("", url).strip()
+    try:
+        parsed = urlsplit(cleaned)
+        hostname = parsed.hostname
+        if parsed.scheme and hostname:
+            host = f"[{hostname}]" if ":" in hostname else hostname
+            if parsed.port is not None:
+                host = f"{host}:{parsed.port}"
+            cleaned = urlunsplit((parsed.scheme, host, parsed.path, "", ""))
+        else:
+            cleaned = cleaned.split("?", 1)[0].split("#", 1)[0]
+    except ValueError:
+        cleaned = "<invalid-url>"
+
+    if len(cleaned) > MAX_LOG_URL_LENGTH:
+        return cleaned[: MAX_LOG_URL_LENGTH - 3] + "..."
+    return cleaned
+
+
+def sanitize_log_urls(
+    _logger: Any,
+    _method_name: str,
+    event_dict: MutableMapping[str, Any],
+) -> MutableMapping[str, Any]:
+    """Structlog processor that redacts every URL-shaped event field centrally."""
+    for key, value in event_dict.items():
+        normalized_key = key.lower()
+        if isinstance(value, str) and (normalized_key == "url" or normalized_key.endswith("_url")):
+            event_dict[key] = safe_url_for_log(value)
+    return event_dict

--- a/src/intelstream/utils/safe_http.py
+++ b/src/intelstream/utils/safe_http.py
@@ -5,7 +5,7 @@ from urllib.parse import urljoin
 
 import httpx
 
-from intelstream.utils.url_validation import SSRFError, validate_url_for_ssrf
+from intelstream.utils.url_validation import SSRFError, async_validate_url_for_ssrf
 
 DEFAULT_MAX_RESPONSE_BYTES = 2 * 1024 * 1024
 DEFAULT_MAX_REDIRECTS = 10
@@ -31,7 +31,7 @@ async def safe_request(
         raise ValueError("max_redirects cannot be negative")
 
     if validate_ssrf:
-        _validate_url(url)
+        await _validate_url(url)
 
     current_url = url
     redirects_followed = 0
@@ -44,7 +44,7 @@ async def safe_request(
 
                 redirect_url = _redirect_url(response)
                 if validate_ssrf:
-                    _validate_url(redirect_url, redirect=True)
+                    await _validate_url(redirect_url, redirect=True)
                 current_url = redirect_url
                 redirects_followed += 1
                 continue
@@ -75,9 +75,9 @@ async def _stream_response(
         yield response
 
 
-def _validate_url(url: str, *, redirect: bool = False) -> None:
+async def _validate_url(url: str, *, redirect: bool = False) -> None:
     try:
-        validate_url_for_ssrf(url)
+        await async_validate_url_for_ssrf(url)
     except SSRFError as exc:
         prefix = "Redirect" if redirect else "URL"
         raise SafeHTTPError(f"{prefix} blocked by SSRF protection: {exc}") from exc
@@ -104,7 +104,7 @@ async def _read_limited(response: httpx.Response, max_response_bytes: int) -> by
 
     content = bytearray()
     async for chunk in response.aiter_bytes():
-        content.extend(chunk)
-        if len(content) > max_response_bytes:
+        if len(content) + len(chunk) > max_response_bytes:
             raise SafeHTTPError(f"Response exceeds {max_response_bytes} byte limit")
+        content.extend(chunk)
     return bytes(content)

--- a/src/intelstream/utils/url_validation.py
+++ b/src/intelstream/utils/url_validation.py
@@ -1,6 +1,9 @@
+import asyncio
 import ipaddress
 import re
 import socket
+from collections.abc import Iterable
+from typing import Any
 from urllib.parse import urlparse
 
 
@@ -75,21 +78,7 @@ def _is_private_ip(ip_str: str) -> bool:
     return False
 
 
-def validate_url_for_ssrf(url: str) -> None:
-    """
-    Validate a URL to prevent SSRF attacks.
-
-    WARNING: This validation has inherent limitations:
-    - TOCTOU (time-of-check-time-of-use): DNS resolution may change between
-      validation and the actual HTTP request. An attacker could use DNS rebinding
-      to bypass this check.
-    - Callers must revalidate every redirect target. The shared safe HTTP
-      helper does this for all externally supplied and discovered URLs.
-
-    Raises:
-        SSRFError: If the URL points to a blocked host or internal IP, or if
-            the hostname cannot be resolved.
-    """
+def _validate_url_without_dns(url: str) -> str:
     parsed = urlparse(url)
 
     if parsed.scheme not in ("http", "https"):
@@ -110,12 +99,51 @@ def validate_url_for_ssrf(url: str) -> None:
     if _is_private_ip(hostname_lower):
         raise SSRFError("URLs pointing to private IP addresses are not allowed")
 
+    return hostname
+
+
+def _validate_resolved_addresses(resolved_ips: Iterable[tuple[Any, ...]]) -> None:
+    for resolved in resolved_ips:
+        sockaddr = resolved[-1]
+        ip_str = str(sockaddr[0])
+        if _is_private_ip(ip_str):
+            raise SSRFError(f"URL resolves to a private IP address ({ip_str})")
+
+
+def validate_url_for_ssrf(url: str) -> None:
+    """
+    Validate a URL to prevent SSRF attacks.
+
+    WARNING: This validation has inherent limitations:
+    - TOCTOU (time-of-check-time-of-use): DNS resolution may change between
+      validation and the actual HTTP request. An attacker could use DNS rebinding
+      to bypass this check.
+    - Callers must revalidate every redirect target. The shared safe HTTP
+      helper does this for all externally supplied and discovered URLs.
+
+    Raises:
+        SSRFError: If the URL points to a blocked host or internal IP, or if
+            the hostname cannot be resolved.
+    """
+    hostname = _validate_url_without_dns(url)
     try:
         resolved_ips = socket.getaddrinfo(hostname, None, socket.AF_UNSPEC, socket.SOCK_STREAM)
-        for _, _, _, _, sockaddr in resolved_ips:
-            ip_str = str(sockaddr[0])
-            if _is_private_ip(ip_str):
-                raise SSRFError(f"URL resolves to a private IP address ({ip_str})")
+        _validate_resolved_addresses(resolved_ips)
+    except socket.gaierror as e:
+        raise SSRFError("Could not resolve hostname") from e
+
+
+async def async_validate_url_for_ssrf(url: str) -> None:
+    """Validate a URL without blocking the event loop during DNS resolution."""
+    hostname = _validate_url_without_dns(url)
+    try:
+        resolved_ips = await asyncio.get_running_loop().getaddrinfo(
+            hostname,
+            None,
+            family=socket.AF_UNSPEC,
+            type=socket.SOCK_STREAM,
+        )
+        _validate_resolved_addresses(resolved_ips)
     except socket.gaierror as e:
         raise SSRFError("Could not resolve hostname") from e
 
@@ -132,6 +160,15 @@ def is_safe_url(url: str) -> tuple[bool, str]:
     """
     try:
         validate_url_for_ssrf(url)
+        return True, ""
+    except SSRFError as e:
+        return False, str(e)
+
+
+async def async_is_safe_url(url: str) -> tuple[bool, str]:
+    """Async variant of is_safe_url for Discord and HTTP request paths."""
+    try:
+        await async_validate_url_for_ssrf(url)
         return True, ""
     except SSRFError as e:
         return False, str(e)

--- a/tests/test_adapters/test_base_contracts.py
+++ b/tests/test_adapters/test_base_contracts.py
@@ -42,6 +42,7 @@ async def test_base_adapter_super_methods_are_noops() -> None:
     assert adapter.source_type is None
     assert await adapter.fetch_latest("identifier", feed_url="feed", skip_content=True) is None
     assert await adapter.get_feed_url("identifier") is None
+    assert await adapter.close() is None
 
 
 def test_content_data_defaults() -> None:

--- a/tests/test_adapters/test_strategies/test_rss_discovery.py
+++ b/tests/test_adapters/test_strategies/test_rss_discovery.py
@@ -225,7 +225,7 @@ class TestRSSDiscoveryStrategy:
         assert result is None
         client.get.assert_awaited_once()
 
-    def test_find_rss_in_html_skips_ssrf_blocked_links(self, rss_strategy):
+    async def test_find_rss_in_html_skips_ssrf_blocked_links(self, rss_strategy):
         html = """
         <html><head>
           <link rel="alternate" type="application/rss+xml" href="http://127.0.0.1/rss">
@@ -234,14 +234,14 @@ class TestRSSDiscoveryStrategy:
         """
 
         with patch(
-            "intelstream.adapters.strategies.rss_discovery.validate_url_for_ssrf",
+            "intelstream.adapters.strategies.rss_discovery.async_validate_url_for_ssrf",
             side_effect=[SSRFError("blocked"), None],
         ):
-            result = rss_strategy._find_rss_in_html(html, "https://example.com")
+            result = await rss_strategy._find_rss_in_html(html, "https://example.com")
 
         assert result == "https://example.com/safe-feed.xml"
 
-    def test_find_rss_in_html_skips_irrelevant_missing_and_blocked_links(self, rss_strategy):
+    async def test_find_rss_in_html_skips_irrelevant_missing_and_blocked_links(self, rss_strategy):
         html = """
         <html><head>
           <link rel="alternate" type="text/html" href="/not-a-feed">
@@ -253,10 +253,10 @@ class TestRSSDiscoveryStrategy:
         """
 
         with patch(
-            "intelstream.adapters.strategies.rss_discovery.validate_url_for_ssrf",
+            "intelstream.adapters.strategies.rss_discovery.async_validate_url_for_ssrf",
             side_effect=[SSRFError("blocked"), None],
         ):
-            result = rss_strategy._find_rss_in_html(html, "https://example.com")
+            result = await rss_strategy._find_rss_in_html(html, "https://example.com")
 
         assert result == "https://example.com/safe-feed.xml"
 

--- a/tests/test_adapters/test_strategies/test_sitemap_discovery.py
+++ b/tests/test_adapters/test_strategies/test_sitemap_discovery.py
@@ -87,7 +87,7 @@ class TestSitemapDiscoveryStrategy:
             return_value=httpx.Response(200, text=sitemap)
         )
 
-        with patch("intelstream.adapters.strategies.sitemap_discovery.validate_url_for_ssrf"):
+        with patch("intelstream.adapters.strategies.sitemap_discovery.async_validate_url_for_ssrf"):
             result = await sitemap_strategy.discover("https://example.com/research")
 
         assert result is not None
@@ -139,7 +139,7 @@ class TestSitemapDiscoveryStrategy:
             return_value=httpx.Response(200, text=posts_sitemap)
         )
 
-        with patch("intelstream.adapters.strategies.sitemap_discovery.validate_url_for_ssrf"):
+        with patch("intelstream.adapters.strategies.sitemap_discovery.async_validate_url_for_ssrf"):
             result = await sitemap_strategy.discover("https://example.com/articles")
 
         assert result is not None
@@ -410,7 +410,7 @@ class TestSitemapDiscoveryStrategy:
         strategy = SitemapDiscoveryStrategy(http_client=client)
 
         with patch(
-            "intelstream.adapters.strategies.sitemap_discovery.validate_url_for_ssrf",
+            "intelstream.adapters.strategies.sitemap_discovery.async_validate_url_for_ssrf",
             side_effect=SSRFError("blocked"),
         ):
             assert await strategy._check_robots_txt("https://example.com") is None
@@ -539,7 +539,7 @@ class TestSitemapDiscoveryStrategy:
         )
 
         with patch(
-            "intelstream.adapters.strategies.sitemap_discovery.validate_url_for_ssrf",
+            "intelstream.adapters.strategies.sitemap_discovery.async_validate_url_for_ssrf",
             side_effect=[SSRFError("blocked"), None],
         ):
             result = await strategy._parse_sitemap_index(root)
@@ -560,7 +560,7 @@ class TestSitemapDiscoveryStrategy:
         )
 
         with patch(
-            "intelstream.adapters.strategies.sitemap_discovery.validate_url_for_ssrf",
+            "intelstream.adapters.strategies.sitemap_discovery.async_validate_url_for_ssrf",
             side_effect=[SSRFError("blocked"), None],
         ):
             result = await strategy._parse_sitemap_index(root)
@@ -581,7 +581,7 @@ class TestSitemapDiscoveryStrategy:
             return_value=[{"url": "https://example.com/blog/post", "lastmod": None}]
         )
 
-        with patch("intelstream.adapters.strategies.sitemap_discovery.validate_url_for_ssrf"):
+        with patch("intelstream.adapters.strategies.sitemap_discovery.async_validate_url_for_ssrf"):
             result = await strategy._parse_sitemap_index(root)
 
         assert result == [{"url": "https://example.com/blog/post", "lastmod": None}]
@@ -604,7 +604,7 @@ class TestSitemapDiscoveryStrategy:
         )
 
         with (
-            patch("intelstream.adapters.strategies.sitemap_discovery.validate_url_for_ssrf"),
+            patch("intelstream.adapters.strategies.sitemap_discovery.async_validate_url_for_ssrf"),
             patch.object(sitemap_discovery, "MAX_SUB_SITEMAPS", 2),
         ):
             result = await strategy._parse_sitemap_index(root)
@@ -632,7 +632,7 @@ class TestSitemapDiscoveryStrategy:
         )
 
         with (
-            patch("intelstream.adapters.strategies.sitemap_discovery.validate_url_for_ssrf"),
+            patch("intelstream.adapters.strategies.sitemap_discovery.async_validate_url_for_ssrf"),
             patch.object(sitemap_discovery, "MAX_SITEMAP_URLS", 2),
         ):
             result = await strategy._parse_sitemap_index(root)
@@ -671,7 +671,7 @@ class TestSitemapDiscoveryStrategy:
             return_value=[{"url": "https://example.com/blog/post", "lastmod": None}]
         )
 
-        with patch("intelstream.adapters.strategies.sitemap_discovery.validate_url_for_ssrf"):
+        with patch("intelstream.adapters.strategies.sitemap_discovery.async_validate_url_for_ssrf"):
             result = await strategy._parse_sitemap_index(root)
 
         assert result == [{"url": "https://example.com/blog/post", "lastmod": None}]
@@ -694,7 +694,7 @@ class TestSitemapDiscoveryStrategy:
         )
 
         with (
-            patch("intelstream.adapters.strategies.sitemap_discovery.validate_url_for_ssrf"),
+            patch("intelstream.adapters.strategies.sitemap_discovery.async_validate_url_for_ssrf"),
             patch.object(sitemap_discovery, "MAX_SITEMAP_URLS", 2),
         ):
             result = await strategy._parse_sitemap_index(root)

--- a/tests/test_adapters/test_youtube.py
+++ b/tests/test_adapters/test_youtube.py
@@ -14,7 +14,7 @@ class TestYouTubeAdapter:
     def setup_method(self) -> None:
         self.mock_youtube = MagicMock()
         self.patcher = patch("intelstream.adapters.youtube.build", return_value=self.mock_youtube)
-        self.patcher.start()
+        self.mock_build = self.patcher.start()
 
     def teardown_method(self) -> None:
         self.patcher.stop()
@@ -22,6 +22,36 @@ class TestYouTubeAdapter:
     async def test_source_type(self) -> None:
         adapter = YouTubeAdapter(api_key="test-key")
         assert adapter.source_type == "youtube"
+        self.mock_build.assert_not_called()
+
+    async def test_google_client_is_lazy_reused_and_closed(self) -> None:
+        adapter = YouTubeAdapter(api_key="test-key")
+
+        first = await adapter._get_youtube()
+        second = await adapter._get_youtube()
+        await adapter.close()
+
+        assert first is self.mock_youtube
+        assert second is self.mock_youtube
+        self.mock_build.assert_called_once_with("youtube", "v3", developerKey="test-key")
+        self.mock_youtube.close.assert_called_once_with()
+
+    async def test_resolved_channel_and_playlist_ids_are_cached(self) -> None:
+        self.mock_youtube.channels().list().execute.side_effect = [
+            {"items": [{"id": "UCtest123456789012345"}]},
+            {"items": [{"contentDetails": {"relatedPlaylists": {"uploads": "UUuploads"}}}]},
+        ]
+        self.mock_youtube.channels().list.reset_mock()
+        adapter = YouTubeAdapter(api_key="test-key")
+
+        first_channel = await adapter._resolve_channel_id("@testchannel")
+        second_channel = await adapter._resolve_channel_id("@testchannel")
+        first_playlist = await adapter._get_uploads_playlist_id(first_channel)
+        second_playlist = await adapter._get_uploads_playlist_id(first_channel)
+
+        assert first_channel == second_channel == "UCtest123456789012345"
+        assert first_playlist == second_playlist == "UUuploads"
+        assert self.mock_youtube.channels().list.call_count == 2
 
     async def test_get_feed_url_returns_channel_url(self) -> None:
         self.mock_youtube.channels().list().execute.return_value = {

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -4,7 +4,7 @@ from pathlib import Path
 import pytest
 from pydantic import ValidationError
 
-from intelstream.config import Settings, get_database_directory
+from intelstream.config import Settings, get_database_directory, reveal_secret
 from intelstream.database.models import SourceType
 
 
@@ -19,11 +19,12 @@ class TestSettings:
 
         settings = Settings(_env_file=None)
 
-        assert settings.discord_bot_token == "test_token"
+        assert settings.discord_bot_token.get_secret_value() == "test_token"
         assert settings.discord_guild_id == 123456789
         assert settings.discord_channel_id == 987654321
         assert settings.discord_owner_id == 111222333
-        assert settings.anthropic_api_key == "sk-ant-test"
+        assert settings.anthropic_api_key is not None
+        assert settings.anthropic_api_key.get_secret_value() == "sk-ant-test"
         assert settings.youtube_api_key is None
         assert settings.default_poll_interval_minutes == 5
         assert settings.log_level == "INFO"
@@ -38,7 +39,8 @@ class TestSettings:
 
         settings = Settings(_env_file=None)
 
-        assert settings.youtube_api_key == "yt-api-key"
+        assert settings.youtube_api_key is not None
+        assert settings.youtube_api_key.get_secret_value() == "yt-api-key"
 
     def test_settings_accepts_lowercase_env_and_optional_legacy_channel(
         self, monkeypatch: pytest.MonkeyPatch
@@ -61,7 +63,7 @@ class TestSettings:
 
         settings = Settings(_env_file=None)
 
-        assert settings.discord_bot_token == "test_token"
+        assert settings.discord_bot_token.get_secret_value() == "test_token"
         assert settings.discord_guild_id == 123456789
         assert settings.discord_channel_id is None
         assert settings.discord_owner_id == 111222333
@@ -136,6 +138,17 @@ class TestSettings:
         assert "discord_owner_id=111222333" in repr_str
         assert "llm_provider=" in repr_str
 
+        settings_str = str(settings)
+        serialized = settings.model_dump(mode="json")
+        for secret in (
+            "secret-discord-token-12345",
+            "sk-ant-secret-key-67890",
+            "sk-openai-secret",
+            "yt-secret-api-key",
+        ):
+            assert secret not in settings_str
+            assert secret not in repr(serialized)
+
     def test_repr_handles_none_keys(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setenv("DISCORD_BOT_TOKEN", "test_token")
         monkeypatch.setenv("DISCORD_GUILD_ID", "123456789")
@@ -167,7 +180,7 @@ class TestSettings:
         monkeypatch.setenv("DISCORD_OWNER_ID", "111222333")
         monkeypatch.setenv("ANTHROPIC_API_KEY", "")
 
-        with pytest.raises(ValidationError, match="No API key configured"):
+        with pytest.raises(ValidationError, match="cannot be empty or whitespace-only"):
             Settings(_env_file=None)
 
     def test_llm_api_key_returns_correct_provider_key(
@@ -181,6 +194,19 @@ class TestSettings:
 
         settings = Settings(_env_file=None)
         assert settings.llm_api_key == "sk-openai-test"
+
+    def test_explicit_secret_accessors_return_raw_values(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("DISCORD_BOT_TOKEN", "discord-token")
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "anthropic-token")
+
+        settings = Settings(_env_file=None)
+
+        assert settings.discord_token == "discord-token"
+        assert reveal_secret(settings.anthropic_api_key) == "anthropic-token"
+        assert reveal_secret("  legacy-test-token  ") == "legacy-test-token"
+        assert reveal_secret(None) is None
 
     def test_llm_api_key_raises_if_configured_key_is_later_cleared(
         self, monkeypatch: pytest.MonkeyPatch
@@ -255,16 +281,106 @@ class TestSettings:
         with pytest.raises(ValidationError, match="SQLite database path cannot be empty"):
             Settings(_env_file=None)
 
-    def test_non_sqlite_database_url_accepted(self, monkeypatch: pytest.MonkeyPatch) -> None:
+    def test_non_sqlite_database_url_rejected(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setenv("DISCORD_BOT_TOKEN", "test_token")
         monkeypatch.setenv("DISCORD_GUILD_ID", "123456789")
         monkeypatch.setenv("DISCORD_OWNER_ID", "111222333")
         monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-test")
         monkeypatch.setenv("DATABASE_URL", "postgresql+asyncpg://user:pass@localhost/db")
 
+        with pytest.raises(ValidationError, match="Only SQLite databases are supported"):
+            Settings(_env_file=None)
+
+    @pytest.mark.parametrize(
+        "database_url",
+        ["sqlite:///./data/intelstream.db", "sqlite+pysqlite:///./data/intelstream.db"],
+    )
+    def test_synchronous_sqlite_driver_rejected(
+        self, monkeypatch: pytest.MonkeyPatch, database_url: str
+    ) -> None:
+        monkeypatch.setenv("DISCORD_BOT_TOKEN", "test_token")
+        monkeypatch.setenv("DISCORD_GUILD_ID", "123456789")
+        monkeypatch.setenv("DISCORD_OWNER_ID", "111222333")
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-test")
+        monkeypatch.setenv("DATABASE_URL", database_url)
+
+        with pytest.raises(ValidationError, match=r"sqlite\+aiosqlite async driver"):
+            Settings(_env_file=None)
+
+    @pytest.mark.parametrize(
+        ("env_name", "env_value"),
+        [
+            ("DISCORD_BOT_TOKEN", "   "),
+            ("ANTHROPIC_API_KEY", "\t"),
+            ("YOUTUBE_API_KEY", "\n"),
+        ],
+    )
+    def test_whitespace_credentials_are_rejected(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        env_name: str,
+        env_value: str,
+    ) -> None:
+        monkeypatch.setenv(env_name, env_value)
+
+        with pytest.raises(ValidationError, match="cannot be empty or whitespace-only"):
+            Settings(_env_file=None)
+
+    def test_credentials_are_trimmed(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("DISCORD_BOT_TOKEN", "  discord-token  ")
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "  anthropic-key  ")
+
         settings = Settings(_env_file=None)
 
-        assert settings.database_url == "postgresql+asyncpg://user:pass@localhost/db"
+        assert settings.discord_bot_token.get_secret_value() == "discord-token"
+        assert settings.llm_api_key == "anthropic-key"
+
+    @pytest.mark.parametrize(
+        "env_name",
+        ["DISCORD_GUILD_ID", "DISCORD_CHANNEL_ID", "DISCORD_OWNER_ID"],
+    )
+    @pytest.mark.parametrize("env_value", ["0", "-1"])
+    def test_discord_ids_must_be_positive(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        env_name: str,
+        env_value: str,
+    ) -> None:
+        monkeypatch.setenv(env_name, env_value)
+
+        with pytest.raises(ValidationError):
+            Settings(_env_file=None)
+
+    def test_article_chunk_overlap_must_be_smaller_than_chunk_size(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("ARTICLE_CHUNK_SIZE_CHARS", "500")
+        monkeypatch.setenv("ARTICLE_CHUNK_OVERLAP_CHARS", "500")
+
+        with pytest.raises(ValidationError, match="must be smaller"):
+            Settings(_env_file=None)
+
+    def test_startup_log_context_contains_no_credentials(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        secrets = {
+            "DISCORD_BOT_TOKEN": "discord-startup-secret",
+            "ANTHROPIC_API_KEY": "anthropic-startup-secret",
+            "YOUTUBE_API_KEY": "youtube-startup-secret",
+            "TWITTER_BEARER_TOKEN": "twitter-startup-secret",
+            "GITHUB_TOKEN": "github-startup-secret",
+        }
+        for name, value in secrets.items():
+            monkeypatch.setenv(name, value)
+
+        context = Settings(_env_file=None).startup_log_context()
+        rendered = repr(context)
+
+        assert context["database_backend"] == "sqlite"
+        assert context["youtube_enabled"] is True
+        assert context["twitter_enabled"] is True
+        assert context["github_enabled"] is True
+        assert not any(secret in rendered for secret in secrets.values())
 
     def test_summarization_delay_minimum(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setenv("DISCORD_BOT_TOKEN", "test_token")
@@ -432,3 +548,62 @@ class TestGetDatabaseDirectory:
     def test_returns_current_dir_for_db_in_root(self) -> None:
         result = get_database_directory("sqlite+aiosqlite:///mydb.db")
         assert result == Path()
+
+    def test_handles_sqlite_query_parameters(self) -> None:
+        result = get_database_directory(
+            "sqlite+aiosqlite:////home/user/data/intelstream.db?mode=rwc&uri=true"
+        )
+        assert result == Path("/home/user/data")
+
+    def test_returns_none_for_malformed_url(self) -> None:
+        assert get_database_directory("://not-a-database-url") is None
+
+
+class TestEnvironmentExample:
+    def test_example_documents_every_setting_and_loads_after_required_values_are_set(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        example_path = Path(__file__).parents[1] / ".env.example"
+        example = example_path.read_text()
+
+        documented_names = {
+            line.lstrip("# ").split("=", 1)[0]
+            for line in example.splitlines()
+            if "=" in line and line.lstrip("# ").split("=", 1)[0].isupper()
+        }
+        expected_names = {field_name.upper() for field_name in Settings.model_fields}
+        assert documented_names == expected_names
+
+        configured = (
+            example.replace(
+                "DISCORD_BOT_TOKEN=replace_with_discord_bot_token",
+                "DISCORD_BOT_TOKEN=test-discord-token",
+            )
+            .replace(
+                "DISCORD_GUILD_ID=replace_with_discord_server_id",
+                "DISCORD_GUILD_ID=123456789",
+            )
+            .replace(
+                "DISCORD_OWNER_ID=replace_with_discord_user_id",
+                "DISCORD_OWNER_ID=987654321",
+            )
+            .replace(
+                "ANTHROPIC_API_KEY=replace_with_anthropic_api_key",
+                "ANTHROPIC_API_KEY=test-anthropic-key",
+            )
+        )
+        env_path = tmp_path / ".env"
+        env_path.write_text(configured)
+
+        for field_name in Settings.model_fields:
+            monkeypatch.delenv(field_name.upper(), raising=False)
+
+        settings = Settings(_env_file=env_path)
+
+        assert settings.discord_bot_token.get_secret_value() == "test-discord-token"
+        assert settings.discord_channel_id is None
+        assert settings.youtube_api_key is None
+        assert settings.twitter_bearer_token is None
+        assert settings.github_token is None

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -153,6 +153,10 @@ class TestRepositoryInitialization:
         with pytest.raises(ValueError, match="Only SQLite databases are supported"):
             Repository("mysql+aiomysql://localhost/test")
 
+    def test_rejects_synchronous_sqlite_driver(self) -> None:
+        with pytest.raises(ValueError, match=r"sqlite\+aiosqlite async driver"):
+            Repository("sqlite:///test.db")
+
     async def test_accepts_sqlite_database_url(self) -> None:
         repo = Repository("sqlite+aiosqlite:///:memory:")
         assert repo is not None
@@ -206,7 +210,7 @@ class TestSourceOperations:
                 source_type=SourceType.SUBSTACK,
                 name="Test",
                 identifier="test-high",
-                poll_interval_minutes=61,
+                poll_interval_minutes=1441,
             )
 
     async def test_add_duplicate_source_raises_error(self, repository: Repository) -> None:
@@ -238,9 +242,9 @@ class TestSourceOperations:
             source_type=SourceType.SUBSTACK,
             name="Max Interval",
             identifier="test-max",
-            poll_interval_minutes=60,
+            poll_interval_minutes=1440,
         )
-        assert source_max.poll_interval_minutes == 60
+        assert source_max.poll_interval_minutes == 1440
 
     async def test_get_source_by_identifier(self, repository: Repository) -> None:
         await repository.add_source(
@@ -300,6 +304,52 @@ class TestSourceOperations:
 
         all_sources = await repository.get_all_sources()
         assert len(all_sources) == 3
+
+    async def test_get_all_sources_filtered_by_guild(self, repository: Repository) -> None:
+        await repository.add_source(
+            source_type=SourceType.RSS,
+            name="Guild A Source",
+            identifier="guild-a-source",
+            guild_id="guild-a",
+        )
+        await repository.add_source(
+            source_type=SourceType.RSS,
+            name="Guild B Source",
+            identifier="guild-b-source",
+            guild_id="guild-b",
+        )
+
+        sources = await repository.get_all_sources(guild_id="guild-a")
+
+        assert [source.name for source in sources] == ["Guild A Source"]
+
+    async def test_sync_source_poll_intervals_updates_only_changed_types(
+        self, repository: Repository
+    ) -> None:
+        rss = await repository.add_source(
+            source_type=SourceType.RSS,
+            name="RSS Source",
+            identifier="rss-source",
+            poll_interval_minutes=10,
+        )
+        youtube = await repository.add_source(
+            source_type=SourceType.YOUTUBE,
+            name="YouTube Source",
+            identifier="youtube-source",
+            poll_interval_minutes=15,
+        )
+
+        updated = await repository.sync_source_poll_intervals(
+            {SourceType.RSS: 30, SourceType.YOUTUBE: 15}
+        )
+
+        assert updated == 1
+        refreshed_rss = await repository.get_source_by_id(rss.id)
+        refreshed_youtube = await repository.get_source_by_id(youtube.id)
+        assert refreshed_rss is not None
+        assert refreshed_rss.poll_interval_minutes == 30
+        assert refreshed_youtube is not None
+        assert refreshed_youtube.poll_interval_minutes == 15
 
     async def test_get_sources_for_guild_returns_active_sources_only(
         self, repository: Repository
@@ -526,6 +576,29 @@ class TestContentItemOperations:
 
         assert await repository.content_item_exists("video123") is True
         assert await repository.content_item_exists("nonexistent") is False
+
+    async def test_get_existing_external_ids_returns_only_matches(
+        self, repository: Repository
+    ) -> None:
+        source = await repository.add_source(
+            source_type=SourceType.RSS,
+            name="Bulk Existing IDs",
+            identifier="bulk-existing-ids",
+        )
+        for external_id in ("post-1", "post-2"):
+            await repository.add_content_item(
+                source_id=source.id,
+                external_id=external_id,
+                title=external_id,
+                original_url=f"https://example.com/{external_id}",
+                author="Author",
+                published_at=datetime.now(UTC),
+            )
+
+        requested_ids = {f"missing-{index}" for index in range(1_000)}
+        requested_ids.update({"post-1", "post-2"})
+        assert await repository.get_existing_external_ids(requested_ids) == {"post-1", "post-2"}
+        assert await repository.get_existing_external_ids(set()) == set()
 
     async def test_add_duplicate_content_raises_error(self, repository: Repository) -> None:
         source = await repository.add_source(
@@ -1233,6 +1306,42 @@ class TestDiscordConfigOperations:
 
 
 class TestMigrations:
+    async def test_migrate_adds_content_item_workload_indexes(self, tmp_path) -> None:
+        db_path = tmp_path / "legacy-content.db"
+        db_url = f"sqlite+aiosqlite:///{db_path}"
+        engine = create_async_engine(db_url, echo=False)
+        async with engine.begin() as conn:
+            await conn.execute(
+                text("""
+                CREATE TABLE content_items (
+                    id VARCHAR(36) PRIMARY KEY,
+                    source_id VARCHAR(36) NOT NULL,
+                    external_id VARCHAR(512) NOT NULL UNIQUE,
+                    published_at DATETIME NOT NULL,
+                    summary TEXT,
+                    posted_to_discord BOOLEAN DEFAULT 0,
+                    created_at DATETIME
+                )
+            """)
+            )
+        await engine.dispose()
+
+        repo = Repository(db_url)
+        await repo.initialize()
+        await repo.initialize()
+
+        async with repo._engine.begin() as conn:
+            result = await conn.execute(text("PRAGMA index_list(content_items)"))
+            indexes = {row[1] for row in result.fetchall()}
+
+        assert {
+            "ix_content_items_source_published",
+            "ix_content_items_unsummarized_created",
+            "ix_content_items_unposted_published",
+        } <= indexes
+
+        await repo.close()
+
     async def test_migrate_adds_missing_columns_to_sources(self, tmp_path) -> None:
         db_path = tmp_path / "test.db"
         db_url = f"sqlite+aiosqlite:///{db_path}"

--- a/tests/test_discord/test_bot.py
+++ b/tests/test_discord/test_bot.py
@@ -33,7 +33,10 @@ def make_command_interaction(guild_id: int | None = 123456789) -> MagicMock:
     interaction.user.id = 12345
     interaction.guild_id = guild_id
     interaction.response = MagicMock()
+    interaction.response.defer = AsyncMock()
     interaction.response.send_message = AsyncMock()
+    interaction.followup = MagicMock()
+    interaction.followup.send = AsyncMock()
     return interaction
 
 
@@ -51,6 +54,7 @@ class TestIntelStreamBot:
         bot = await create_bot(mock_settings)
 
         assert bot.intents.message_content is True
+        assert bot.allowed_mentions.to_dict() == discord.AllowedMentions.none().to_dict()
 
         await bot.repository.close()
 
@@ -319,10 +323,13 @@ class TestIntelStreamBot:
         bot.start_time = None
 
         await IntelStreamBot.on_ready(bot)
+        first_start_time = bot.start_time
+        await IntelStreamBot.on_ready(bot)
 
-        assert bot.start_time is not None
+        assert bot.start_time is first_start_time
         assert bot._owner is owner
-        lore_cog.auto_start_ingestion.assert_awaited_once()
+        assert lore_cog.auto_start_ingestion.await_count == 2
+        bot.fetch_user.assert_awaited_once_with(mock_settings.discord_owner_id)
 
     async def test_on_ready_handles_missing_owner_and_lore_start_failure(
         self, mock_settings: Settings
@@ -360,6 +367,26 @@ class TestIntelStreamBot:
 
         assert bot.start_time is not None
         assert bot._owner is owner
+
+    async def test_on_ready_retries_lore_start_after_transient_failure(
+        self, mock_settings: Settings
+    ) -> None:
+        bot = MagicMock()
+        bot.user = None
+        bot.settings = mock_settings
+        bot.fetch_user = AsyncMock(return_value=MagicMock(spec=discord.User))
+        lore_cog = MagicMock()
+        lore_cog.auto_start_ingestion = AsyncMock(
+            side_effect=[RuntimeError("temporary failure"), None]
+        )
+        bot.cogs = {"Lore": lore_cog}
+        bot._owner = MagicMock(spec=discord.User)
+        bot.start_time = None
+
+        await IntelStreamBot.on_ready(bot)
+        await IntelStreamBot.on_ready(bot)
+
+        assert lore_cog.auto_start_ingestion.await_count == 2
 
     async def test_on_error_notifies_owner(self) -> None:
         bot = MagicMock()
@@ -443,7 +470,7 @@ class TestIntelStreamBot:
         with patch("intelstream.bot.create_bot", AsyncMock(return_value=bot)):
             await run_bot(mock_settings)
 
-        bot.start.assert_awaited_once_with(mock_settings.discord_bot_token)
+        bot.start.assert_awaited_once_with(mock_settings.discord_token)
         bot.close.assert_awaited_once()
 
     async def test_run_bot_closes_bot_when_start_fails(self, mock_settings: Settings) -> None:
@@ -493,6 +520,23 @@ class TestRestrictedCommandTreeInteractionCheck:
 
         assert allowed is True
         interaction.response.send_message.assert_not_called()
+
+        await bot.repository.close()
+
+    async def test_allows_commands_in_thread_under_allowed_channel(
+        self, mock_settings: Settings
+    ) -> None:
+        bot = await create_bot(mock_settings)
+        interaction = MagicMock(spec=discord.Interaction)
+        interaction.channel_id = mock_settings.discord_channel_id + 1
+        interaction.channel = MagicMock(spec=discord.Thread)
+        interaction.channel.parent_id = mock_settings.discord_channel_id
+        interaction.response.send_message = AsyncMock()
+
+        allowed = await bot.tree.interaction_check(interaction)
+
+        assert allowed is True
+        interaction.response.send_message.assert_not_awaited()
 
         await bot.repository.close()
 
@@ -696,11 +740,13 @@ class TestCoreCommandsCommands:
         is_active: bool = True,
         failures: int = 0,
         channel_id: str | None = "222",
+        guild_id: str = "123456789",
     ) -> MagicMock:
         source = MagicMock()
         source.name = f"Source {index}"
         source.type = SourceType.RSS
         source.channel_id = channel_id
+        source.guild_id = guild_id
         source.is_active = is_active
         source.consecutive_failures = failures
         source.pause_reason = PauseReason.NONE.value
@@ -740,7 +786,8 @@ class TestCoreCommandsCommands:
 
         await core.status.callback(core, interaction)
 
-        embed = interaction.response.send_message.await_args.kwargs["embed"]
+        interaction.response.defer.assert_awaited_once_with()
+        embed = interaction.followup.send.await_args.kwargs["embed"]
         assert embed.title == "IntelStream Status"
         field_names = [field.name for field in embed.fields]
         assert "System" in field_names
@@ -777,7 +824,8 @@ class TestCoreCommandsCommands:
 
         await core.status.callback(core, interaction)
 
-        embed = interaction.response.send_message.await_args.kwargs["embed"]
+        interaction.response.defer.assert_awaited_once_with()
+        embed = interaction.followup.send.await_args.kwargs["embed"]
         assert embed.title == "IntelStream Status"
         assert all(field.name != "Configured Sources" for field in embed.fields)
         repository.get_forwarding_rules_for_guild.assert_not_called()
@@ -802,7 +850,7 @@ class TestCoreCommandsCommands:
 
         await core.status.callback(core, interaction)
 
-        embed = interaction.response.send_message.await_args.kwargs["embed"]
+        embed = interaction.followup.send.await_args.kwargs["embed"]
         configured = next(
             field.value for field in embed.fields if field.name == "Configured Sources"
         )
@@ -811,6 +859,63 @@ class TestCoreCommandsCommands:
         )
         assert "*... and" not in configured
         assert "*... and" not in forwarding
+
+    async def test_status_filters_sources_to_interaction_guild(self) -> None:
+        bot = MagicMock()
+        bot.latency = 0
+        bot.start_time = datetime.now(UTC)
+        bot.settings.content_poll_interval_minutes = 5
+        repository = AsyncMock()
+        repository.get_all_sources = AsyncMock(
+            return_value=[self._make_source(1), self._make_source(2, guild_id="other-guild")]
+        )
+        repository.get_content_stats = AsyncMock(
+            return_value={"total_fetched": 1, "total_posted": 1}
+        )
+        repository.get_last_posted_content = AsyncMock(return_value=None)
+        repository.get_forwarding_rules_for_guild = AsyncMock(return_value=[])
+        repository.get_discord_config = AsyncMock(return_value=None)
+        bot.repository = repository
+        core = CoreCommands(bot)
+        interaction = make_command_interaction()
+
+        await core.status.callback(core, interaction)
+
+        embed = interaction.followup.send.await_args.kwargs["embed"]
+        configured = next(
+            field.value for field in embed.fields if field.name == "Configured Sources"
+        )
+        assert "Source 1" in configured
+        assert "Source 2" not in configured
+
+    async def test_status_bounds_long_source_field(self) -> None:
+        bot = MagicMock()
+        bot.latency = 0
+        bot.start_time = datetime.now(UTC)
+        bot.settings.content_poll_interval_minutes = 5
+        repository = AsyncMock()
+        sources = [self._make_source(i) for i in range(8)]
+        for source in sources:
+            source.name = "x" * 255
+        repository.get_all_sources = AsyncMock(return_value=sources)
+        repository.get_content_stats = AsyncMock(
+            return_value={"total_fetched": 1, "total_posted": 1}
+        )
+        repository.get_last_posted_content = AsyncMock(return_value=None)
+        repository.get_forwarding_rules_for_guild = AsyncMock(return_value=[])
+        repository.get_discord_config = AsyncMock(return_value=None)
+        bot.repository = repository
+        core = CoreCommands(bot)
+        interaction = make_command_interaction()
+
+        await core.status.callback(core, interaction)
+
+        embed = interaction.followup.send.await_args.kwargs["embed"]
+        configured = next(
+            field.value for field in embed.fields if field.name == "Configured Sources"
+        )
+        assert len(configured) <= 1024
+        assert "more" in configured
 
     async def test_ping_sends_latency(self) -> None:
         bot = MagicMock(spec=IntelStreamBot)

--- a/tests/test_discord/test_channel_summary.py
+++ b/tests/test_discord/test_channel_summary.py
@@ -174,8 +174,10 @@ class TestSummaryCommand:
         await cog.summary.callback(cog, mock_interaction, count=200, channel=target_channel)
 
         target_channel.history.assert_called_once()
+        mock_interaction.response.defer.assert_awaited_once_with(ephemeral=True)
         sent_text = mock_interaction.followup.send.call_args.args[0]
         assert "<#88888>" in sent_text
+        assert mock_interaction.followup.send.call_args.kwargs["ephemeral"] is True
 
     async def test_summary_handles_summarization_failure(self, cog, mock_interaction):
         messages = [_make_message(f"msg {i}", f"user{i}") for i in range(10)]
@@ -383,6 +385,14 @@ class TestSummaryError:
 
         with pytest.raises(app_commands.AppCommandError, match="boom"):
             await cog.summary_error(mock_interaction, error)
+
+
+def test_summary_command_description_explains_scan_behavior(cog):
+    assert cog.summary.description == "Summarize recent non-bot messages from a text channel"
+    count_parameter = next(
+        parameter for parameter in cog.summary.parameters if parameter.name == "count"
+    )
+    assert count_parameter.description == "Recent messages to scan (default: 200, max: 500)"
 
 
 async def test_setup_adds_channel_summary_cog(mock_bot):

--- a/tests/test_discord/test_config_management.py
+++ b/tests/test_discord/test_config_management.py
@@ -327,6 +327,14 @@ class TestConfigManagementErrors:
             await config_management.config_channel_error(interaction, error)
 
 
+def test_config_descriptions_explain_fallback_behavior(config_management):
+    assert config_management.config_group.description == "Configure fallback bot settings"
+    assert (
+        config_management.config_channel.description
+        == "Set the fallback channel for sources without one"
+    )
+
+
 class TestSetup:
     async def test_setup_adds_config_management_cog(self, mock_bot):
         mock_bot.add_cog = AsyncMock()

--- a/tests/test_discord/test_github.py
+++ b/tests/test_discord/test_github.py
@@ -433,6 +433,36 @@ class TestGitHubList:
         assert "Failing (3 errors)" in values
         assert "Never" in values
 
+    async def test_list_caps_embed_fields_and_reports_total(self, github_commands, mock_bot):
+        channel = make_channel(channel_id=321, name="dev")
+        interaction = make_interaction(channel=channel)
+        repos = []
+        for index in range(30):
+            repo = MagicMock()
+            repo.owner = "o" * 255
+            repo.repo = f"repo-{index}-" + ("r" * 255)
+            repo.is_active = True
+            repo.consecutive_failures = 0
+            repo.track_commits = True
+            repo.track_prs = False
+            repo.track_issues = False
+            repo.last_polled_at = None
+            repos.append(repo)
+        mock_bot.repository.get_github_repos_for_channel = AsyncMock(return_value=repos)
+
+        await github_commands.github_list.callback(github_commands, interaction)
+
+        embed = interaction.followup.send.call_args.kwargs["embed"]
+        assert 0 < len(embed.fields) < 25
+        assert all(len(field.name) <= 256 for field in embed.fields)
+        total_text = (
+            len(embed.title or "")
+            + len(embed.footer.text or "")
+            + sum(len(field.name) + len(field.value) for field in embed.fields)
+        )
+        assert total_text <= 6000
+        assert embed.footer.text == f"Showing {len(embed.fields)} of 30 repositories"
+
 
 class TestGitHubRemoveConfirmation:
     def _make_confirmed_view(self) -> MagicMock:
@@ -668,6 +698,12 @@ class TestGitHubToggle:
 
         assert choices == [choice]
         github_commands._github_repo_autocomplete.assert_awaited_once_with(interaction, "org")
+
+
+def test_github_toggle_description_matches_pause_behavior(github_commands):
+    assert (
+        github_commands.github_toggle.description == "Pause or resume GitHub repository monitoring"
+    )
 
 
 class TestGitHubErrorHandlers:

--- a/tests/test_discord/test_message_forwarding.py
+++ b/tests/test_discord/test_message_forwarding.py
@@ -328,6 +328,25 @@ class TestForwardList:
         assert "Unknown (111)" in message
         assert "Unknown (222)" in message
 
+    async def test_forward_list_bounds_long_output_and_reports_omissions(self, cog, mock_bot):
+        interaction = make_interaction()
+        rules = []
+        for index in range(100):
+            rule = MagicMock()
+            rule.source_channel_id = str(10_000_000_000_000_000 + index)
+            rule.destination_channel_id = str(20_000_000_000_000_000 + index)
+            rule.is_active = True
+            rule.messages_forwarded = index
+            rules.append(rule)
+        mock_bot.repository.get_forwarding_rules_for_guild = AsyncMock(return_value=rules)
+        mock_bot.get_channel = MagicMock(return_value=None)
+
+        await cog.forward_list.callback(cog, interaction)
+
+        message = interaction.followup.send.call_args.args[0]
+        assert len(message) < 2000
+        assert "more forwarding rules" in message
+
 
 class TestForwardRemove:
     async def test_forward_remove_success(self, cog, mock_bot):
@@ -708,6 +727,19 @@ class TestCacheRefresh:
         await cog._refresh_cache()
 
         assert cog._rules_cache["111"] == [rule_1, rule_2]
+
+
+def test_forward_commands_default_to_manage_guild_permission(cog):
+    for command in (
+        cog.forward_add,
+        cog.forward_list,
+        cog.forward_remove,
+        cog.forward_pause,
+        cog.forward_resume,
+    ):
+        assert command.default_permissions is not None
+        assert command.default_permissions.manage_guild is True
+        assert command.default_permissions.administrator is False
 
 
 class TestForwardingErrors:

--- a/tests/test_discord/test_source_management.py
+++ b/tests/test_discord/test_source_management.py
@@ -26,8 +26,11 @@ from intelstream.services.page_analyzer import PageAnalysisError
 def mock_bot():
     bot = MagicMock()
     bot.repository = MagicMock()
+    bot.repository.get_source_by_identifier = AsyncMock(return_value=None)
+    bot.repository.get_source_by_name = AsyncMock(return_value=None)
     bot.settings = MagicMock()
     bot.settings.default_poll_interval_minutes = 5
+    bot.settings.get_poll_interval = MagicMock(return_value=5)
     bot.settings.youtube_api_key = "test-api-key"
     bot.settings.twitter_bearer_token = "test-twitter-token"
     return bot
@@ -324,6 +327,8 @@ class TestSourceManagementAdd:
         call_kwargs = mock_bot.repository.add_source.call_args.kwargs
         assert call_kwargs["guild_id"] == "456"
         assert call_kwargs["channel_id"] == "789"
+        assert call_kwargs["poll_interval_minutes"] == 5
+        mock_bot.settings.get_poll_interval.assert_called_once_with(SourceType.SUBSTACK)
         interaction.followup.send.assert_called_once()
         call_kwargs = interaction.followup.send.call_args.kwargs
         assert "embed" in call_kwargs
@@ -391,9 +396,41 @@ class TestSourceManagementAdd:
         )
 
         mock_bot.repository.add_source.assert_not_called()
+        mock_bot.repository.get_source_by_identifier.assert_awaited_once_with("test")
+        mock_bot.repository.get_source_by_name.assert_awaited_once_with("Test Newsletter")
         interaction.followup.send.assert_called_once()
         call_args = interaction.followup.send.call_args
         assert "already exists" in call_args[0][0]
+
+    async def test_add_duplicate_blog_skips_expensive_analysis(self, source_management, mock_bot):
+        mock_bot.settings.anthropic_api_key = "anthropic-key"
+        interaction = make_interaction()
+        source_type_choice = MagicMock(value="blog", name="Blog")
+        existing_source = MagicMock(name="Existing Blog")
+        mock_bot.repository.get_source_by_identifier = AsyncMock(return_value=existing_source)
+        adapter = MagicMock()
+        adapter.analyze_site = AsyncMock()
+
+        with (
+            patch(
+                "intelstream.discord.cogs.source_management.async_is_safe_url",
+                return_value=(True, ""),
+            ),
+            patch(
+                "intelstream.discord.cogs.source_management.SmartBlogAdapter",
+                return_value=adapter,
+            ),
+        ):
+            await source_management.source_add.callback(
+                source_management,
+                interaction,
+                source_type=source_type_choice,
+                name="Existing Blog",
+                url="https://blog.example.com",
+            )
+
+        adapter.analyze_site.assert_not_awaited()
+        mock_bot.repository.add_source.assert_not_called()
 
     async def test_add_source_duplicate_name(self, source_management, mock_bot):
         interaction = MagicMock(spec=discord.Interaction)
@@ -701,7 +738,7 @@ class TestSourceManagementAdd:
         source_type_choice.name = "RSS"
 
         with patch(
-            "intelstream.discord.cogs.source_management.is_safe_url",
+            "intelstream.discord.cogs.source_management.async_is_safe_url",
             return_value=(False, "private address"),
         ):
             await source_management.source_add.callback(
@@ -841,7 +878,7 @@ class TestSourceManagementAdd:
         with (
             patch.object(source_management, "_get_anthropic_client", return_value=MagicMock()),
             patch(
-                "intelstream.discord.cogs.source_management.is_safe_url",
+                "intelstream.discord.cogs.source_management.async_is_safe_url",
                 return_value=(True, None),
             ),
             patch(
@@ -878,7 +915,7 @@ class TestSourceManagementAdd:
         with (
             patch.object(source_management, "_get_anthropic_client", return_value=MagicMock()),
             patch(
-                "intelstream.discord.cogs.source_management.is_safe_url",
+                "intelstream.discord.cogs.source_management.async_is_safe_url",
                 return_value=(True, None),
             ),
             patch(
@@ -976,6 +1013,34 @@ class TestSourceManagementList:
         assert "Disabled: 4 consecutive failures" in embed.fields[0].value
         assert "2026-01-02 03:04 UTC" in embed.fields[0].value
         assert "**Status:** Paused" in embed.fields[1].value
+
+    async def test_list_sources_caps_embed_fields_and_reports_total(
+        self, source_management, mock_bot
+    ):
+        interaction = make_interaction()
+        sources = []
+        for index in range(30):
+            source = MagicMock()
+            source.name = f"Source {index} " + ("x" * 255)
+            source.type = SourceType.RSS
+            source.is_active = True
+            source.pause_reason = PauseReason.NONE.value
+            source.last_polled_at = None
+            sources.append(source)
+        mock_bot.repository.get_all_sources = AsyncMock(return_value=sources)
+
+        await source_management.source_list.callback(source_management, interaction)
+
+        embed = interaction.followup.send.call_args.kwargs["embed"]
+        assert 0 < len(embed.fields) < 25
+        assert all(len(field.name) <= 256 for field in embed.fields)
+        total_text = (
+            len(embed.title or "")
+            + len(embed.footer.text or "")
+            + sum(len(field.name) + len(field.value) for field in embed.fields)
+        )
+        assert total_text <= 6000
+        assert embed.footer.text == f"Showing {len(embed.fields)} of 30 sources"
 
 
 class TestSourceManagementRemove:
@@ -1615,6 +1680,17 @@ class TestSourceManagementLifecycle:
 
         mock_bot.add_cog.assert_awaited_once()
         assert isinstance(mock_bot.add_cog.call_args.args[0], SourceManagement)
+
+
+def test_source_management_descriptions_match_archive_and_pause_behavior(source_management):
+    assert (
+        source_management.source_remove.description
+        == "Archive a content source and stop polling it"
+    )
+    assert (
+        source_management.source_toggle.description
+        == "Pause or resume polling for a content source"
+    )
 
 
 class TestSourceManagementErrors:

--- a/tests/test_discord/test_suck_boobs.py
+++ b/tests/test_discord/test_suck_boobs.py
@@ -92,6 +92,10 @@ class TestCommand:
         message = interaction.response.send_message.await_args.args[0]
         assert "Caller" in message
         assert "<@2>" in message
+        allowed_mentions = interaction.response.send_message.await_args.kwargs["allowed_mentions"]
+        assert allowed_mentions.users == [target]
+        assert allowed_mentions.everyone is False
+        assert allowed_mentions.roles is False
 
     async def test_rare_response_still_records_usage(self):
         bot = MagicMock()
@@ -107,6 +111,9 @@ class TestCommand:
 
         bot.repository.record_suck_boobs_usage.assert_awaited_once()
         assert "<@2>" in interaction.response.send_message.await_args.args[0]
+        assert interaction.response.send_message.await_args.kwargs["allowed_mentions"].users == [
+            target
+        ]
 
 
 class TestScoreCommand:

--- a/tests/test_discord/test_summarize.py
+++ b/tests/test_discord/test_summarize.py
@@ -7,6 +7,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import discord
 import httpx
 import pytest
+from googleapiclient.discovery import build
 from youtube_transcript_api._errors import (
     NoTranscriptFound,
     TranscriptsDisabled,
@@ -38,6 +39,16 @@ def summarize_cog(mock_bot):
     cog._summarizer.summarize = AsyncMock(return_value="This is a test summary.")
     cog._http_client = MagicMock()
     return cog
+
+
+def make_youtube_resource(response):
+    request = MagicMock()
+    request.execute.return_value = response
+    videos = MagicMock()
+    videos.list.return_value = request
+    resource = MagicMock()
+    resource.videos.return_value = videos
+    return resource
 
 
 @pytest.fixture
@@ -73,9 +84,31 @@ class TestDetectUrlType:
         assert summarize_cog.detect_url_type("https://nytimes.com/2024/article") == "web"
         assert summarize_cog.detect_url_type("https://blog.example.org/post") == "web"
 
-    def test_is_substack_url(self, summarize_cog):
-        assert summarize_cog._is_substack_url("https://example.substack.com/p/post") is True
-        assert summarize_cog._is_substack_url("https://example.com/p/post") is False
+    @pytest.mark.parametrize(
+        "url",
+        [
+            "https://youtube.com.evil.example/watch?v=abc123",
+            "https://substack.com.evil.example/p/article",
+            "https://twitter.com.evil.example/user/status/123",
+            "https://x.com.evil.example/user/status/123",
+        ],
+    )
+    def test_detect_lookalike_domains_as_generic_web(self, summarize_cog, url):
+        assert summarize_cog.detect_url_type(url) == "web"
+
+    def test_detect_supported_subdomains_and_trailing_dot(self, summarize_cog):
+        assert (
+            summarize_cog.detect_url_type("https://music.youtube.com/watch?v=abc123") == "youtube"
+        )
+        assert (
+            summarize_cog.detect_url_type("https://example.substack.com./p/article") == "substack"
+        )
+
+
+def test_summarize_description_limits_scope_to_public_supported_pages(summarize_cog):
+    assert (
+        summarize_cog.summarize.description == "Summarize a public YouTube, Substack, or web page"
+    )
 
 
 class TestExtractYoutubeVideoId:
@@ -241,11 +274,12 @@ class TestFetchYoutubeContent:
             await summarize_cog._fetch_youtube_content("https://youtube.com/watch?v=dQw4w9WgXcQ")
 
     async def test_fetch_youtube_reports_missing_video(self, summarize_cog):
+        youtube = make_youtube_resource({"items": []})
         with (
-            patch("intelstream.discord.cogs.summarize.build"),
-            patch(
-                "intelstream.discord.cogs.summarize.asyncio.to_thread",
-                AsyncMock(return_value={"items": []}),
+            patch.object(
+                summarize_cog,
+                "_get_youtube_client",
+                AsyncMock(return_value=youtube),
             ),
             pytest.raises(WebFetchError, match="Video not found"),
         ):
@@ -269,11 +303,12 @@ class TestFetchYoutubeContent:
             ]
         }
 
+        youtube = make_youtube_resource(response)
         with (
-            patch("intelstream.discord.cogs.summarize.build") as build,
-            patch(
-                "intelstream.discord.cogs.summarize.asyncio.to_thread",
-                AsyncMock(return_value=response),
+            patch.object(
+                summarize_cog,
+                "_get_youtube_client",
+                AsyncMock(return_value=youtube),
             ),
             patch.object(summarize_cog, "_fetch_youtube_transcript", AsyncMock(return_value=None)),
         ):
@@ -281,8 +316,9 @@ class TestFetchYoutubeContent:
                 "https://youtube.com/watch?v=dQw4w9WgXcQ"
             )
 
-        build.assert_called_once_with("youtube", "v3", developerKey="test-youtube-key")
+        youtube.videos.return_value.list.assert_called_once_with(part="snippet", id="dQw4w9WgXcQ")
         assert content.title == "Video Title"
+        assert content.url == "https://youtube.com/watch?v=dQw4w9WgXcQ"
         assert content.author == "Channel"
         assert content.content == "Description fallback"
         assert content.thumbnail_url == "https://example.com/high.jpg"
@@ -301,11 +337,12 @@ class TestFetchYoutubeContent:
             ]
         }
 
+        youtube = make_youtube_resource(response)
         with (
-            patch("intelstream.discord.cogs.summarize.build"),
-            patch(
-                "intelstream.discord.cogs.summarize.asyncio.to_thread",
-                AsyncMock(return_value=response),
+            patch.object(
+                summarize_cog,
+                "_get_youtube_client",
+                AsyncMock(return_value=youtube),
             ),
             patch.object(
                 summarize_cog,
@@ -318,6 +355,48 @@ class TestFetchYoutubeContent:
             )
 
         assert content.content == "Transcript text"
+
+    async def test_fetch_youtube_serializes_cached_client_requests(self, summarize_cog):
+        response = {
+            "items": [
+                {
+                    "snippet": {
+                        "title": "Video",
+                        "description": "Description",
+                        "thumbnails": {},
+                    }
+                }
+            ]
+        }
+        summarize_cog._youtube = make_youtube_resource(response)
+        active_requests = 0
+        max_active_requests = 0
+
+        async def execute_off_thread(_function, *_args, **_kwargs):
+            nonlocal active_requests, max_active_requests
+            active_requests += 1
+            max_active_requests = max(max_active_requests, active_requests)
+            await asyncio.sleep(0)
+            active_requests -= 1
+            return response
+
+        with (
+            patch(
+                "intelstream.discord.cogs.summarize.asyncio.to_thread",
+                side_effect=execute_off_thread,
+            ),
+            patch.object(
+                summarize_cog,
+                "_fetch_youtube_transcript",
+                AsyncMock(return_value="Transcript"),
+            ),
+        ):
+            await asyncio.gather(
+                summarize_cog._fetch_youtube_content("https://youtube.com/watch?v=dQw4w9WgXcQ"),
+                summarize_cog._fetch_youtube_content("https://youtube.com/watch?v=dQw4w9WgXcQ"),
+            )
+
+        assert max_active_requests == 1
 
 
 class TestFetchYoutubeTranscript:
@@ -571,7 +650,7 @@ class TestSummarizeCommand:
 
     async def test_rejects_unsafe_url(self, summarize_cog, mock_interaction):
         with patch(
-            "intelstream.discord.cogs.summarize.is_safe_url",
+            "intelstream.discord.cogs.summarize.async_is_safe_url",
             return_value=(False, "private network target"),
         ):
             await summarize_cog.summarize.callback(
@@ -873,6 +952,36 @@ class TestSummarizeCommand:
 
 
 class TestCogLifecycle:
+    async def test_youtube_client_is_built_off_thread_and_cached(self, mock_bot):
+        cog = Summarize(mock_bot)
+        resource = MagicMock()
+
+        with patch(
+            "intelstream.discord.cogs.summarize.asyncio.to_thread",
+            AsyncMock(return_value=resource),
+        ) as to_thread:
+            first = await cog._get_youtube_client("youtube-key")
+            second = await cog._get_youtube_client("youtube-key")
+
+        assert first is resource
+        assert second is resource
+        to_thread.assert_awaited_once_with(
+            build,
+            "youtube",
+            "v3",
+            developerKey="youtube-key",
+        )
+
+    async def test_cog_unload_closes_youtube_client(self, mock_bot):
+        cog = Summarize(mock_bot)
+        resource = MagicMock()
+        cog._youtube = resource
+
+        await cog.cog_unload()
+
+        resource.close.assert_called_once_with()
+        assert cog._youtube is None
+
     async def test_cog_load_initializes_http_client(self, mock_bot):
         cog = Summarize(mock_bot)
         assert cog._http_client is None

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -7,6 +7,13 @@ import pytest
 from intelstream import main as main_module
 
 
+def make_settings() -> SimpleNamespace:
+    return SimpleNamespace(
+        log_level="INFO",
+        startup_log_context=lambda: {"guild_id": 123, "search_enabled": True},
+    )
+
+
 class TestConfigureLogging:
     def test_debug_level_enables_debug_for_third_party_loggers(self) -> None:
         main_module.configure_logging("DEBUG")
@@ -26,10 +33,41 @@ class TestConfigureLogging:
         with pytest.raises(AttributeError):
             main_module.configure_logging("not-a-level")
 
+    @pytest.mark.parametrize(("is_tty", "expected_colors"), [(True, True), (False, False)])
+    def test_console_colors_follow_stdout_tty(
+        self,
+        is_tty: bool,
+        expected_colors: bool,
+    ) -> None:
+        with (
+            patch.object(main_module.sys.stdout, "isatty", return_value=is_tty),
+            patch("intelstream.main.structlog.dev.ConsoleRenderer") as renderer,
+            patch("intelstream.main.structlog.configure"),
+        ):
+            main_module.configure_logging("INFO")
+
+        renderer.assert_called_once_with(colors=expected_colors)
+
+    def test_timestamp_processor_is_explicitly_utc(self) -> None:
+        with (
+            patch("intelstream.main.structlog.processors.TimeStamper") as time_stamper,
+            patch("intelstream.main.structlog.configure"),
+        ):
+            main_module.configure_logging("INFO")
+
+        time_stamper.assert_called_once_with(fmt="iso", utc=True)
+
+    def test_logging_pipeline_redacts_url_fields(self) -> None:
+        with patch("intelstream.main.structlog.configure") as configure:
+            main_module.configure_logging("INFO")
+
+        processors = configure.call_args.kwargs["processors"]
+        assert main_module.sanitize_log_urls in processors
+
 
 class TestMainEntrypoint:
     def test_main_runs_bot_with_settings(self) -> None:
-        settings = SimpleNamespace(log_level="INFO")
+        settings = make_settings()
 
         with (
             patch("intelstream.main.get_settings", return_value=settings),
@@ -47,7 +85,7 @@ class TestMainEntrypoint:
         asyncio_run.assert_called_once_with("run-bot-result")
 
     def test_main_handles_keyboard_interrupt_without_exiting(self) -> None:
-        settings = SimpleNamespace(log_level="INFO")
+        settings = make_settings()
 
         with (
             patch("intelstream.main.get_settings", return_value=settings),
@@ -64,7 +102,7 @@ class TestMainEntrypoint:
         sys_exit.assert_not_called()
 
     def test_main_exits_on_unhandled_exception(self) -> None:
-        settings = SimpleNamespace(log_level="INFO")
+        settings = make_settings()
 
         with (
             patch("intelstream.main.get_settings", return_value=settings),
@@ -81,7 +119,7 @@ class TestMainEntrypoint:
         sys_exit.assert_called_once_with(1)
 
     def test_module_execution_invokes_main(self) -> None:
-        settings = SimpleNamespace(log_level="INFO")
+        settings = make_settings()
         main_path = main_module.__file__
 
         with (
@@ -92,3 +130,25 @@ class TestMainEntrypoint:
             runpy.run_path(main_path, run_name="__main__")
 
         asyncio_run.assert_called_once_with("run-bot-result")
+
+    def test_main_logs_safe_startup_context(self) -> None:
+        settings = make_settings()
+        logger = MagicMock()
+
+        with (
+            patch("intelstream.main.get_settings", return_value=settings),
+            patch("intelstream.main.configure_logging"),
+            patch("intelstream.main.structlog.get_logger", return_value=logger),
+            patch(
+                "intelstream.main.run_bot",
+                new=MagicMock(return_value="run-bot-result"),
+            ),
+            patch("intelstream.main.asyncio.run"),
+        ):
+            main_module.main()
+
+        logger.info.assert_called_once_with(
+            "Starting IntelStream bot",
+            guild_id=123,
+            search_enabled=True,
+        )

--- a/tests/test_services/test_content_extractor.py
+++ b/tests/test_services/test_content_extractor.py
@@ -1,3 +1,4 @@
+import threading
 from contextlib import asynccontextmanager
 from datetime import UTC, datetime
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -10,6 +11,7 @@ from bs4 import BeautifulSoup
 from intelstream.services.content_extractor import (
     MIN_CONTENT_LENGTH,
     ContentExtractor,
+    ExtractedContent,
 )
 
 
@@ -28,6 +30,22 @@ def valid_article_text() -> str:
 
 
 class TestContentExtractor:
+    async def test_extract_offloads_html_parsing(self, extractor: ContentExtractor) -> None:
+        event_loop_thread = threading.get_ident()
+        worker_threads: list[int] = []
+        extractor._fetch_html = AsyncMock(return_value="<html></html>")
+
+        def parse(_html: str, _url: str) -> ExtractedContent:
+            worker_threads.append(threading.get_ident())
+            return ExtractedContent(text="parsed")
+
+        extractor._extract_html = MagicMock(side_effect=parse)
+
+        result = await extractor.extract("https://example.com/article")
+
+        assert result.text == "parsed"
+        assert worker_threads and worker_threads[0] != event_loop_thread
+
     async def test_extract_rejects_ssrf_blocked_url(self, extractor: ContentExtractor):
         result = await extractor.extract("http://localhost/admin")
 

--- a/tests/test_services/test_pipeline.py
+++ b/tests/test_services/test_pipeline.py
@@ -1,4 +1,4 @@
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -27,7 +27,9 @@ def mock_settings():
 
 @pytest.fixture
 def mock_repository():
-    return AsyncMock(spec=Repository)
+    repository = AsyncMock(spec=Repository)
+    repository.get_existing_external_ids.return_value = set()
+    return repository
 
 
 @pytest.fixture
@@ -54,6 +56,7 @@ def sample_source():
     source.feed_url = "https://test.substack.com/feed"
     source.skip_summary = False
     source.last_polled_at = None
+    source.poll_interval_minutes = 5
     return source
 
 
@@ -93,6 +96,27 @@ class TestContentPipelineInitialization:
         assert pipeline._http_client is not None
         assert pipeline._adapters is not None
 
+        await pipeline.close()
+
+    async def test_initialize_synchronizes_configured_source_intervals(
+        self,
+        pipeline: ContentPipeline,
+        mock_settings: MagicMock,
+        mock_repository: AsyncMock,
+    ):
+        mock_settings.get_poll_interval.side_effect = lambda source_type: {
+            SourceType.RSS: 30,
+            SourceType.YOUTUBE: 60,
+        }.get(source_type, 5)
+
+        await pipeline.initialize()
+
+        mock_repository.sync_source_poll_intervals.assert_awaited_once_with(
+            {
+                source_type: mock_settings.get_poll_interval(source_type)
+                for source_type in SourceType
+            }
+        )
         await pipeline.close()
 
     async def test_initialize_creates_adapters(self, pipeline: ContentPipeline):
@@ -168,6 +192,18 @@ class TestContentPipelineInitialization:
         await pipeline.close()
 
         assert http_client.is_closed
+
+    async def test_close_releases_each_adapter_once(self, pipeline: ContentPipeline):
+        await pipeline.initialize()
+        adapters = list(pipeline._adapters.values())
+        for adapter in adapters:
+            adapter.close = AsyncMock()
+
+        await pipeline.close()
+        await pipeline.close()
+
+        for adapter in adapters:
+            adapter.close.assert_awaited_once()
 
     async def test_close_closes_owned_anthropic_client_once(
         self,
@@ -261,7 +297,7 @@ class TestFetchAllSources:
         await pipeline.initialize()
 
         mock_repository.get_all_sources.return_value = [sample_source]
-        mock_repository.content_item_exists.return_value = False
+        mock_repository.get_existing_external_ids.return_value = set()
         mock_repository.get_most_recent_item_for_source.return_value = MagicMock(
             spec=ContentItem, id="item-1", title="Test"
         )
@@ -291,7 +327,7 @@ class TestFetchAllSources:
         await pipeline.initialize()
 
         mock_repository.get_all_sources.return_value = [sample_source]
-        mock_repository.content_item_exists.return_value = True
+        mock_repository.get_existing_external_ids.return_value = {sample_content_data.external_id}
 
         with patch.object(
             pipeline._adapters[SourceType.SUBSTACK],
@@ -372,7 +408,7 @@ class TestFetchAllSources:
         ]
 
         mock_repository.get_all_sources.return_value = [sample_source]
-        mock_repository.content_item_exists.return_value = False
+        mock_repository.get_existing_external_ids.return_value = set()
         mock_repository.get_most_recent_item_for_source.return_value = most_recent
         mock_repository.mark_items_as_backfilled.return_value = 4
 
@@ -386,6 +422,10 @@ class TestFetchAllSources:
 
         assert result == 5
         assert mock_repository.add_content_item.call_count == 5
+        mock_repository.get_existing_external_ids.assert_awaited_once_with(
+            {item.external_id for item in items}
+        )
+        mock_repository.content_item_exists.assert_not_awaited()
         mock_repository.get_most_recent_item_for_source.assert_called_once_with(sample_source.id)
         mock_repository.mark_items_as_backfilled.assert_called_once_with(
             source_id=sample_source.id,
@@ -411,7 +451,7 @@ class TestFetchAllSources:
         most_recent.title = "Test Article"
 
         mock_repository.get_all_sources.return_value = [sample_source]
-        mock_repository.content_item_exists.return_value = False
+        mock_repository.get_existing_external_ids.return_value = set()
         mock_repository.get_most_recent_item_for_source.return_value = most_recent
         mock_repository.mark_items_as_backfilled.return_value = 0
 
@@ -454,7 +494,7 @@ class TestFetchAllSources:
         ]
 
         mock_repository.get_all_sources.return_value = [sample_source]
-        mock_repository.content_item_exists.return_value = False
+        mock_repository.get_existing_external_ids.return_value = set()
 
         with patch.object(
             pipeline._adapters[SourceType.SUBSTACK],
@@ -507,7 +547,7 @@ class TestFetchAllSources:
         source2.skip_summary = False
 
         mock_repository.get_all_sources.return_value = [source1, source2]
-        mock_repository.content_item_exists.return_value = True
+        mock_repository.get_existing_external_ids.return_value = set()
 
         with (
             patch.object(
@@ -522,6 +562,43 @@ class TestFetchAllSources:
         ):
             await pipeline.fetch_all_sources()
             mock_sleep.assert_called_once_with(0.1)
+
+        await pipeline.close()
+
+    async def test_fetch_delay_ignores_sources_filtered_as_not_due(
+        self,
+        pipeline: ContentPipeline,
+        mock_repository: AsyncMock,
+        sample_source,
+    ):
+        await pipeline.initialize()
+
+        not_due = MagicMock(spec=Source)
+        not_due.id = "source-not-due"
+        not_due.name = "Not Due"
+        not_due.type = SourceType.SUBSTACK
+        not_due.identifier = "not-due"
+        not_due.feed_url = "https://not-due.substack.com/feed"
+        not_due.skip_summary = False
+        not_due.last_polled_at = datetime.now(UTC)
+        not_due.poll_interval_minutes = 60
+        mock_repository.get_all_sources.return_value = [sample_source, not_due]
+
+        with (
+            patch.object(
+                pipeline._adapters[SourceType.SUBSTACK],
+                "fetch_latest",
+                new_callable=AsyncMock,
+                return_value=[],
+            ) as mock_fetch,
+            patch(
+                "intelstream.services.pipeline.asyncio.sleep", new_callable=AsyncMock
+            ) as mock_sleep,
+        ):
+            await pipeline.fetch_all_sources()
+
+        mock_fetch.assert_awaited_once()
+        mock_sleep.assert_not_awaited()
 
         await pipeline.close()
 
@@ -742,7 +819,7 @@ class TestFetchAllSources:
         await pipeline.initialize()
 
         mock_repository.get_all_sources.return_value = [sample_source]
-        mock_repository.content_item_exists.return_value = False
+        mock_repository.get_existing_external_ids.return_value = set()
         mock_repository.get_most_recent_item_for_source.return_value = MagicMock(
             spec=ContentItem, id="item-1", title="Test"
         )
@@ -773,7 +850,7 @@ class TestFetchAllSources:
         sample_source.skip_summary = True
 
         mock_repository.get_all_sources.return_value = [sample_source]
-        mock_repository.content_item_exists.return_value = False
+        mock_repository.get_existing_external_ids.return_value = set()
         mock_repository.get_most_recent_item_for_source.return_value = MagicMock(
             spec=ContentItem, id="item-1", title="Test"
         )
@@ -803,9 +880,10 @@ class TestFetchAllSources:
         sample_source,
     ):
         await pipeline.initialize()
+        mock_settings.get_poll_interval.reset_mock()
 
-        sample_source.last_polled_at = datetime(2099, 1, 1, 0, 0, 0, tzinfo=UTC)
-        mock_settings.get_poll_interval.return_value = 20
+        sample_source.last_polled_at = datetime.now(UTC) - timedelta(minutes=10)
+        sample_source.poll_interval_minutes = 20
         mock_repository.get_all_sources.return_value = [sample_source]
 
         with patch.object(
@@ -817,6 +895,7 @@ class TestFetchAllSources:
 
         assert result == 0
         mock_fetch.assert_not_called()
+        mock_settings.get_poll_interval.assert_not_called()
 
         await pipeline.close()
 
@@ -828,9 +907,10 @@ class TestFetchAllSources:
         sample_source,
     ):
         await pipeline.initialize()
+        mock_settings.get_poll_interval.reset_mock()
 
         sample_source.last_polled_at = datetime(2099, 1, 1, 0, 0, 0)
-        mock_settings.get_poll_interval.return_value = 20
+        sample_source.poll_interval_minutes = 20
         mock_repository.get_all_sources.return_value = [sample_source]
 
         with patch.object(
@@ -842,6 +922,7 @@ class TestFetchAllSources:
 
         assert result == 0
         mock_fetch.assert_not_called()
+        mock_settings.get_poll_interval.assert_not_called()
 
         await pipeline.close()
 
@@ -854,11 +935,12 @@ class TestFetchAllSources:
         sample_content_data,
     ):
         await pipeline.initialize()
+        mock_settings.get_poll_interval.reset_mock()
 
         sample_source.last_polled_at = datetime(2000, 1, 1, 0, 0, 0, tzinfo=UTC)
-        mock_settings.get_poll_interval.return_value = 5
+        sample_source.poll_interval_minutes = 5
         mock_repository.get_all_sources.return_value = [sample_source]
-        mock_repository.content_item_exists.return_value = False
+        mock_repository.get_existing_external_ids.return_value = set()
 
         with patch.object(
             pipeline._adapters[SourceType.SUBSTACK],
@@ -869,6 +951,7 @@ class TestFetchAllSources:
             result = await pipeline.fetch_all_sources()
 
         assert result == 1
+        mock_settings.get_poll_interval.assert_not_called()
 
         await pipeline.close()
 
@@ -881,10 +964,11 @@ class TestFetchAllSources:
         sample_content_data,
     ):
         await pipeline.initialize()
+        mock_settings.get_poll_interval.reset_mock()
 
         sample_source.last_polled_at = None
         mock_repository.get_all_sources.return_value = [sample_source]
-        mock_repository.content_item_exists.return_value = False
+        mock_repository.get_existing_external_ids.return_value = set()
         mock_repository.get_most_recent_item_for_source.return_value = MagicMock(
             spec=ContentItem, id="item-1", title="Test"
         )
@@ -951,7 +1035,7 @@ class TestFetchAllSources:
             '{"site_name":"Example","post_selector":"article",'
             '"title_selector":"h2","url_selector":"a","url_attribute":"href"}'
         )
-        mock_repository.content_item_exists.return_value = False
+        mock_repository.get_existing_external_ids.return_value = set()
 
         with patch(
             "intelstream.adapters.page.PageAdapter.fetch_latest",
@@ -977,7 +1061,7 @@ class TestFetchAllSources:
     ):
         await pipeline.initialize()
 
-        mock_repository.content_item_exists.return_value = False
+        mock_repository.get_existing_external_ids.return_value = set()
 
         with (
             patch.object(
@@ -1010,7 +1094,7 @@ class TestFetchAllSources:
         await pipeline.initialize()
 
         sample_source.last_polled_at = None
-        mock_repository.content_item_exists.return_value = False
+        mock_repository.get_existing_external_ids.return_value = set()
         mock_repository.get_most_recent_item_for_source.return_value = None
 
         with patch.object(
@@ -1043,7 +1127,10 @@ class TestSummarizePending:
         mock_repository.has_source_posted_content.return_value = True
         mock_summarizer.summarize.return_value = "This is the summary."
 
-        result = await pipeline.summarize_pending(max_items=5)
+        with patch(
+            "intelstream.services.pipeline.asyncio.sleep", new_callable=AsyncMock
+        ) as mock_sleep:
+            result = await pipeline.summarize_pending(max_items=5)
 
         assert result == 1
         mock_summarizer.summarize.assert_called_once_with(
@@ -1055,6 +1142,41 @@ class TestSummarizePending:
         mock_repository.update_content_item_summary.assert_called_once_with(
             sample_content_item.id, "This is the summary."
         )
+        mock_sleep.assert_not_awaited()
+
+        await pipeline.close()
+
+    async def test_summarize_pending_delays_only_between_items(
+        self,
+        pipeline: ContentPipeline,
+        mock_repository: AsyncMock,
+        mock_summarizer: AsyncMock,
+        sample_content_item,
+        sample_source,
+    ):
+        await pipeline.initialize()
+
+        second_item = MagicMock(spec=ContentItem)
+        second_item.id = "item-456"
+        second_item.source_id = sample_source.id
+        second_item.title = "Second Article"
+        second_item.author = "Second Author"
+        second_item.raw_content = "Second article content."
+        mock_repository.get_unsummarized_content_items.return_value = [
+            sample_content_item,
+            second_item,
+        ]
+        mock_repository.get_sources_by_ids.return_value = {sample_source.id: sample_source}
+        mock_repository.has_source_posted_content.return_value = True
+        mock_summarizer.summarize.side_effect = ["First summary", "Second summary"]
+
+        with patch(
+            "intelstream.services.pipeline.asyncio.sleep", new_callable=AsyncMock
+        ) as mock_sleep:
+            result = await pipeline.summarize_pending()
+
+        assert result == 2
+        mock_sleep.assert_awaited_once_with(0.5)
 
         await pipeline.close()
 

--- a/tests/test_utils/test_log_safety.py
+++ b/tests/test_utils/test_log_safety.py
@@ -1,0 +1,48 @@
+from intelstream.utils.log_safety import (
+    MAX_LOG_URL_LENGTH,
+    safe_url_for_log,
+    sanitize_log_urls,
+)
+
+
+def test_safe_url_for_log_removes_credentials_query_and_fragment() -> None:
+    result = safe_url_for_log("https://user:password@example.com:8443/article?token=secret#private")
+
+    assert result == "https://example.com:8443/article"
+
+
+def test_safe_url_for_log_preserves_ipv6_host_format() -> None:
+    assert safe_url_for_log("https://[2001:db8::1]:8443/path?q=1") == (
+        "https://[2001:db8::1]:8443/path"
+    )
+
+
+def test_safe_url_for_log_handles_relative_and_invalid_urls() -> None:
+    assert safe_url_for_log("/path?token=secret#fragment") == "/path"
+    assert safe_url_for_log("https://example.com:invalid/path") == "<invalid-url>"
+
+
+def test_safe_url_for_log_removes_control_characters_and_limits_length() -> None:
+    result = safe_url_for_log("https://example.com/" + "a" * 600 + "\n?token=secret")
+
+    assert "\n" not in result
+    assert "secret" not in result
+    assert len(result) == MAX_LOG_URL_LENGTH
+
+
+def test_sanitize_log_urls_redacts_all_url_fields_and_leaves_other_fields() -> None:
+    event = {
+        "event": "fetch failed",
+        "url": "https://user:pass@example.com/a?token=secret",
+        "feed_url": "https://feeds.example.com/rss?key=private",
+        "detail": "unchanged",
+    }
+
+    result = sanitize_log_urls(None, "warning", event)
+
+    assert result == {
+        "event": "fetch failed",
+        "url": "https://example.com/a",
+        "feed_url": "https://feeds.example.com/rss",
+        "detail": "unchanged",
+    }

--- a/tests/test_utils/test_safe_http.py
+++ b/tests/test_utils/test_safe_http.py
@@ -17,7 +17,7 @@ async def test_safe_request_follows_relative_redirect_and_reads_body() -> None:
         return httpx.Response(200, text="finished")
 
     async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
-        with patch("intelstream.utils.safe_http.validate_url_for_ssrf"):
+        with patch("intelstream.utils.safe_http.async_validate_url_for_ssrf"):
             response = await safe_request(client, "GET", "https://example.com/start")
 
     assert response.text == "finished"
@@ -36,7 +36,7 @@ async def test_safe_request_blocks_private_redirect_before_second_request() -> N
             raise SSRFError("private address")
 
     async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
-        with patch("intelstream.utils.safe_http.validate_url_for_ssrf", side_effect=validate):
+        with patch("intelstream.utils.safe_http.async_validate_url_for_ssrf", side_effect=validate):
             with pytest.raises(SafeHTTPError, match="Redirect blocked"):
                 await safe_request(client, "GET", "https://example.com/start")
 
@@ -53,7 +53,7 @@ async def test_safe_request_rejects_content_length_over_limit_without_reading() 
 
     async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
         with (
-            patch("intelstream.utils.safe_http.validate_url_for_ssrf"),
+            patch("intelstream.utils.safe_http.async_validate_url_for_ssrf"),
             pytest.raises(SafeHTTPError, match="10 byte limit"),
         ):
             await safe_request(
@@ -70,7 +70,7 @@ async def test_safe_request_rejects_streamed_body_over_limit() -> None:
 
     async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
         with (
-            patch("intelstream.utils.safe_http.validate_url_for_ssrf"),
+            patch("intelstream.utils.safe_http.async_validate_url_for_ssrf"),
             pytest.raises(SafeHTTPError, match="10 byte limit"),
         ):
             await safe_request(
@@ -87,7 +87,7 @@ async def test_safe_request_enforces_redirect_limit() -> None:
 
     async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as client:
         with (
-            patch("intelstream.utils.safe_http.validate_url_for_ssrf"),
+            patch("intelstream.utils.safe_http.async_validate_url_for_ssrf"),
             pytest.raises(SafeHTTPError, match="Too many redirects"),
         ):
             await safe_request(

--- a/tests/test_utils/test_url_validation.py
+++ b/tests/test_utils/test_url_validation.py
@@ -1,4 +1,5 @@
 import socket
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
@@ -7,6 +8,8 @@ from intelstream.utils.url_validation import (
     SSRFError,
     _is_obfuscated_ip,
     _is_private_ip,
+    async_is_safe_url,
+    async_validate_url_for_ssrf,
     is_safe_url,
     validate_url_for_ssrf,
 )
@@ -210,3 +213,29 @@ class TestIsSafeUrl:
 
         assert safe is False
         assert error == "Could not resolve hostname"
+
+
+class TestAsyncUrlValidation:
+    async def test_uses_async_resolver(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        loop = MagicMock()
+        loop.getaddrinfo = AsyncMock(
+            return_value=[(socket.AF_INET, socket.SOCK_STREAM, 6, "", ("93.184.216.34", 443))]
+        )
+        monkeypatch.setattr(url_validation_module.asyncio, "get_running_loop", lambda: loop)
+
+        await async_validate_url_for_ssrf("https://example.com/article")
+
+        loop.getaddrinfo.assert_awaited_once()
+
+    async def test_blocks_localhost_without_async_dns_lookup(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        loop = MagicMock()
+        loop.getaddrinfo = AsyncMock(side_effect=AssertionError("DNS should not be called"))
+        monkeypatch.setattr(url_validation_module.asyncio, "get_running_loop", lambda: loop)
+
+        safe, error = await async_is_safe_url("http://localhost/admin")
+
+        assert safe is False
+        assert "localhost" in error.lower()
+        loop.getaddrinfo.assert_not_awaited()

--- a/tests/test_vector_store.py
+++ b/tests/test_vector_store.py
@@ -484,7 +484,20 @@ class TestDelete:
 
         await store.close()
 
-    async def test_delete_message_chunks_deletes_each_id(self, tmp_path):
+    async def test_delete_article_chunks_batches_ids(self, tmp_path):
+        store = VectorStore(data_dir=str(tmp_path / "vectors"), dimensions=4, model_name="model-a")
+        store._initialized = True
+        store._articles = MagicMock()
+        chunk_ids = [f"chunk-{index}" for index in range(300)]
+
+        await store.delete_article_chunks(chunk_ids)
+
+        assert [call.args[0] for call in store._articles.delete.call_args_list] == [
+            chunk_ids[:256],
+            chunk_ids[256:],
+        ]
+
+    async def test_delete_message_chunks_batches_ids(self, tmp_path):
         store = VectorStore(data_dir=str(tmp_path / "vectors"), dimensions=4, model_name="model-a")
         store._initialized = True
         collection = MagicMock()
@@ -492,10 +505,7 @@ class TestDelete:
 
         await store.delete_message_chunks_by_ids("guild-1", ["chunk-1", "chunk-2"])
 
-        assert [call.args[0] for call in collection.delete.call_args_list] == [
-            "chunk-1",
-            "chunk-2",
-        ]
+        collection.delete.assert_called_once_with(["chunk-1", "chunk-2"])
 
 
 class TestRecreateCollections:


### PR DESCRIPTION
## Summary

This PR makes exactly 25 reliability, security, performance, configuration, logging, and Discord UX improvements to existing behavior. It intentionally adds no new bot features or commands.

The pass focused on reducing event-loop blocking, database round trips, unsafe or noisy logging, resource leaks, configuration drift, and Discord payload failures while preserving the current production behavior.

## The 25 improvements

1. Store credentials as Pydantic `SecretStr` values and unwrap them only at external client seams.
2. Trim credentials, reject blank values, and require positive Discord IDs during configuration loading.
3. Fail fast on unsupported database URLs, synchronous SQLite drivers, and invalid article chunk overlap.
4. Make `.env.example` copy-safe and complete, and document every runtime setting and startup migration.
5. Parse SQLite paths through SQLAlchemy so relative, absolute, memory, and query-parameter URLs behave consistently.
6. Emit UTC timestamps, disable ANSI colors for redirected output, and log a credential-free startup context.
7. Redact credentials, queries, fragments, and control characters from all structured URL fields; retain tracebacks for unexpected failures.
8. Move DNS-based SSRF validation off the event loop and apply it to initial URLs, redirects, slash commands, and discovered feed/post URLs.
9. Reject oversized streamed responses before extending the body buffer.
10. Move HTML extraction/parsing and Google/YouTube blocking work to worker threads.
11. Synchronize effective per-source-type poll intervals into existing source rows at pipeline startup.
12. Filter not-due sources before polling and avoid rate-limit sleeps for skipped sources.
13. Replace per-item external-ID lookups with batched SQLite-safe deduplication queries.
14. Replace row-by-row first-poll backfill updates with one SQL `UPDATE`.
15. Avoid the unnecessary summarization delay after the final item.
16. Add three restart-safe partial/composite indexes for source history, unsummarized work, and unposted work.
17. Batch zvec deletes and replace deprecated `VectorQuery` calls with `Query`.
18. Lazily build and reuse YouTube clients plus channel/playlist lookups, with serialized access to non-thread-safe Google resources.
19. Close adapters, Google resources, HTTP clients, vector stores, repositories, and owned LLM clients deterministically.
20. Make `/status` deferred, concurrent, guild-scoped, bounded, and reconnect-stable without resetting uptime or refetching the owner.
21. Keep cross-channel `/summary` output private and enforce safe default mention handling while preserving the one intentional generated user ping.
22. Bound source, GitHub, forwarding, and status output by Discord field, message, and aggregate embed limits with omission counts.
23. Reject duplicate sources before expensive analysis and use exact hostname matching for YouTube/Substack/Twitter classification.
24. Allow legacy restricted commands in child threads and align forwarding command visibility with its existing Manage Server permission checks.
25. Clarify slash-command descriptions, fallback configuration wording, archive/pause semantics, scan counts, and supported URL scope.

## Why

Several mature paths were correct functionally but expensive or fragile under larger data sets: polling performed avoidable reads and sleeps, startup/config validation did not fully match runtime requirements, blocking DNS/HTML/Google work could stall Discord interactions, and list commands could exceed Discord payload limits. Resource ownership and logs also needed clearer boundaries.

## Validation

- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run mypy src/`
- `uv run pytest tests/` — 1,610 passed
- `git diff --check`
- Batched article/message zvec deletes verified against real zvec 0.5.1 collections
- Production `.env` validated without exposing credentials

## Restart verification

A full setup/shutdown smoke test ran against a consistent backup of the live database, without touching the running instance:

- `PRAGMA quick_check`: `ok`
- 49 sources and 55,890 content items loaded
- all three new content-query indexes created
- 12 cogs initialized
- search and lore initialized from cached models in offline mode
- shutdown completed and owned resources were released

Operational note: the first restart creates the new SQLite indexes. On the production-sized backup this took about 11 seconds before bot setup continued and may briefly hold a SQLite write lock. It also synchronizes 20 existing YouTube/Twitter source interval rows to the current configured 15/25-minute cadences, preserving the behavior the pre-PR runtime already derived from environment settings.

## User impact

Existing commands and integrations remain the same. Responses are safer and less likely to time out or exceed Discord limits, polling and persistence perform less unnecessary work, configuration errors fail at startup with actionable messages, and restart behavior has been exercised against production-shaped data.