### PR TITLE
Launch Hands before database work

### DIFF
--- a/src/intelstream/discord/cogs/hands.py
+++ b/src/intelstream/discord/cogs/hands.py
@@ -82,9 +82,6 @@ class Hands(commands.Cog):
                 "Hands is temporarily unavailable.", ephemeral=True
             )
             return
-        await self.bot.repository.get_or_create_hands_rating(
-            str(interaction.guild_id), str(interaction.user.id)
-        )
         logger.info(
             "Launching Hands activity",
             guild_id=interaction.guild_id,

--- a/tests/test_discord/test_hands.py
+++ b/tests/test_discord/test_hands.py
@@ -81,8 +81,11 @@ async def test_hands_rejects_dm_wrong_guild_disabled_and_unavailable() -> None:
         mock_bot.repository.get_or_create_hands_rating.assert_not_awaited()
 
 
-async def test_hands_materializes_rating_then_launches_exactly_once() -> None:
+async def test_hands_launches_immediately_without_database_round_trip() -> None:
     mock_bot = bot()
+    mock_bot.repository.get_or_create_hands_rating.side_effect = AssertionError(
+        "launch callback must not wait on the database"
+    )
     cog = Hands(mock_bot)
     cog.server = MagicMock()
     cog.server.running = True
@@ -90,7 +93,7 @@ async def test_hands_materializes_rating_then_launches_exactly_once() -> None:
 
     await cog.hands.callback(cog, value)
 
-    mock_bot.repository.get_or_create_hands_rating.assert_awaited_once_with("123", "10")
+    mock_bot.repository.get_or_create_hands_rating.assert_not_awaited()
     value.response.launch_activity.assert_awaited_once_with()
     value.response.send_message.assert_not_awaited()
     value.response.defer.assert_not_awaited()


### PR DESCRIPTION
## Summary
- remove the rating database round trip before `/hands` sends its initial Activity callback
- rely on authenticated token/room admission to create ratings, as it already does
- add a regression proving `/hands` launches exactly once without touching the repository or deferring

## Root cause
Discord logged `10062 Unknown interaction`: `/hands` performed database I/O before `launch_activity()`, risking Discord’s approximately three-second initial-response deadline.

## Validation
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run mypy src/`
- `uv run pytest tests/` (1,871 passed)
- Bandit
- independent review: no issues found