### PR TITLE
Prevent secrets from appearing in fatal tracebacks

### DIFF
--- a/src/intelstream/main.py
+++ b/src/intelstream/main.py
@@ -19,7 +19,10 @@ def configure_logging(log_level: str) -> None:
             structlog.processors.StackInfoRenderer(),
             structlog.dev.set_exc_info,
             structlog.processors.TimeStamper(fmt="iso", utc=True),
-            structlog.dev.ConsoleRenderer(colors=stdout_is_tty),
+            structlog.dev.ConsoleRenderer(
+                colors=stdout_is_tty,
+                exception_formatter=structlog.dev.plain_traceback,
+            ),
         ],
         wrapper_class=structlog.make_filtering_bound_logger(getattr(logging, log_level.upper())),
         context_class=dict,

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,4 +1,6 @@
 import runpy
+import sys
+from io import StringIO
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
@@ -46,7 +48,25 @@ class TestConfigureLogging:
         ):
             main_module.configure_logging("INFO")
 
-        renderer.assert_called_once_with(colors=expected_colors)
+        renderer.assert_called_once_with(
+            colors=expected_colors,
+            exception_formatter=main_module.structlog.dev.plain_traceback,
+        )
+
+    def test_exception_formatter_does_not_render_local_values(self) -> None:
+        formatter = main_module.structlog.dev.plain_traceback
+        secret = "".join(("traceback", "-local", "-secret"))
+        try:
+            raise RuntimeError("safe failure")
+        except RuntimeError:
+            exc_info = sys.exc_info()
+
+        output = StringIO()
+        formatter(output, exc_info)
+
+        rendered = output.getvalue()
+        assert "RuntimeError: safe failure" in rendered
+        assert secret not in rendered
 
     def test_timestamp_processor_is_explicitly_utc(self) -> None:
         with (


### PR DESCRIPTION
## Summary
- explicitly configure structlog's console renderer to use a traceback formatter that never renders frame locals
- retain exception type, message, source locations, and stack frames for diagnosis
- add a regression proving a local credential value is absent from rendered exception output

## Root cause
Structlog 26.1.0 selects its Rich traceback formatter when Rich is installed. That formatter defaults to `show_locals=True`, so an otherwise routine startup failure could expose secrets held in nested frame locals. The affected Discord credentials were rotated before this PR was opened.

## Validation
- independent review: no issues found
- end-to-end dummy-credential traceback rendering check
- `uv run ruff check .`
- `uv run ruff format --check .`
- `uv run mypy src/`
- `uv run pytest tests/` — 1,876 passed
- Bandit — no issues
- pip-audit — no known vulnerabilities
