### PR TITLE
Make blog/page LLM extraction provider-agnostic

### DIFF
--- a/src/intelstream/adapters/smart_blog.py
+++ b/src/intelstream/adapters/smart_blog.py
@@ -1,7 +1,6 @@
 from dataclasses import dataclass
 from datetime import UTC, datetime
 
-import anthropic
 import httpx
 import structlog
 
@@ -18,6 +17,7 @@ from intelstream.config import get_settings
 from intelstream.database.models import Source
 from intelstream.database.repository import Repository
 from intelstream.services.content_extractor import ContentExtractor
+from intelstream.services.llm_client import LLMClient
 
 logger = structlog.get_logger()
 UNKNOWN_DATE = datetime(1970, 1, 1, tzinfo=UTC)
@@ -37,11 +37,10 @@ class AnalysisResult:
 class SmartBlogAdapter(BaseAdapter):
     def __init__(
         self,
-        anthropic_client: anthropic.AsyncAnthropic,
+        llm_client: LLMClient,
         repository: Repository,
         http_client: httpx.AsyncClient | None = None,
     ) -> None:
-        self._anthropic = anthropic_client
         self._repository = repository
         self._http_client = http_client
         self._content_extractor = ContentExtractor(http_client=http_client)
@@ -49,7 +48,7 @@ class SmartBlogAdapter(BaseAdapter):
             RSSDiscoveryStrategy(http_client=http_client),
             SitemapDiscoveryStrategy(http_client=http_client),
             LLMExtractionStrategy(
-                anthropic_client=anthropic_client,
+                llm_client=llm_client,
                 repository=repository,
                 http_client=http_client,
             ),

--- a/src/intelstream/adapters/strategies/llm_extraction.py
+++ b/src/intelstream/adapters/strategies/llm_extraction.py
@@ -4,7 +4,6 @@ import json
 import re
 from urllib.parse import urljoin, urlparse
 
-import anthropic
 import httpx
 import structlog
 from bs4 import BeautifulSoup
@@ -22,12 +21,12 @@ from intelstream.adapters.strategies.base import (
 )
 from intelstream.config import get_settings
 from intelstream.database.repository import Repository
+from intelstream.services.llm_client import LLMClient, LLMError, LLMRateLimitError
 from intelstream.utils.safe_http import SafeHTTPError, safe_request
 from intelstream.utils.url_validation import SSRFError, async_validate_url_for_ssrf
 
 logger = structlog.get_logger()
 
-DEFAULT_MODEL = "claude-haiku-4-5-20251001"
 LLM_EXTRACTION_TIMEOUT_SECONDS = 120
 
 EXTRACTION_PROMPT = """Analyze this HTML and extract all blog posts/articles listed on the page.
@@ -49,15 +48,13 @@ HTML:
 class LLMExtractionStrategy(DiscoveryStrategy):
     def __init__(
         self,
-        anthropic_client: anthropic.AsyncAnthropic,
+        llm_client: LLMClient,
         repository: Repository,
         http_client: httpx.AsyncClient | None = None,
-        model: str = DEFAULT_MODEL,
     ) -> None:
-        self._client = anthropic_client
+        self._client = llm_client
         self._repository = repository
         self._http_client = http_client
-        self._model = model
 
     @property
     def name(self) -> str:
@@ -181,7 +178,7 @@ class LLMExtractionStrategy(DiscoveryStrategy):
         return cleaned
 
     @retry(
-        retry=retry_if_exception_type(anthropic.RateLimitError),
+        retry=retry_if_exception_type(LLMRateLimitError),
         wait=wait_exponential(multiplier=1, min=4, max=60),
         stop=stop_after_attempt(3),
     )
@@ -194,18 +191,11 @@ class LLMExtractionStrategy(DiscoveryStrategy):
         prompt = EXTRACTION_PROMPT.format(base_url=base_url, html=cleaned_html)
 
         try:
-            message = await self._client.messages.create(
-                model=self._model,
+            response_text = await self._client.complete(
+                system="",
+                user_message=prompt,
                 max_tokens=4000,
-                messages=[{"role": "user", "content": prompt}],
             )
-
-            response_text = ""
-            for block in message.content:
-                if hasattr(block, "text"):
-                    response_text += block.text
-
-            response_text = response_text.strip()
 
             posts_data = self._extract_json_from_response(response_text)
 
@@ -226,8 +216,8 @@ class LLMExtractionStrategy(DiscoveryStrategy):
 
             return posts
 
-        except anthropic.APIError as e:
-            logger.error("Anthropic API error during extraction", url=url, error=str(e))
+        except LLMError as e:
+            logger.error("LLM API error during extraction", url=url, error=str(e))
             return []
 
     def _extract_json_from_response(self, text: str) -> list[dict[str, str]]:

--- a/src/intelstream/discord/cogs/source_management.py
+++ b/src/intelstream/discord/cogs/source_management.py
@@ -4,20 +4,19 @@ import re
 from typing import TYPE_CHECKING
 from urllib.parse import urlparse
 
-import anthropic
 import discord
 import structlog
 from discord import app_commands
 from discord.ext import commands
 
 from intelstream.adapters.smart_blog import SmartBlogAdapter
-from intelstream.config import reveal_secret
 from intelstream.database.exceptions import (
     DatabaseConnectionError,
     DuplicateSourceError,
     SourceNotFoundError,
 )
 from intelstream.database.models import PauseReason, SourceType
+from intelstream.services.llm_client import LLMClient, create_llm_client
 from intelstream.services.page_analyzer import PageAnalysisError, PageAnalyzer
 from intelstream.utils.log_safety import safe_url_for_log
 from intelstream.utils.url_validation import async_is_safe_url
@@ -203,23 +202,29 @@ class ConfirmSourceRemoveView(discord.ui.View):
 class SourceManagement(commands.Cog):
     def __init__(self, bot: "IntelStreamBot") -> None:
         self.bot = bot
-        self._anthropic_client: anthropic.AsyncAnthropic | None = None
-        self._owns_anthropic_client = False
+        self._llm_clients: dict[str, LLMClient] = {}
 
-    def _get_anthropic_client(self) -> anthropic.AsyncAnthropic:
-        if self._anthropic_client is None:
-            api_key = reveal_secret(self.bot.settings.anthropic_api_key)
-            if api_key is None:
-                raise RuntimeError("Anthropic API key is not configured")
-            self._anthropic_client = anthropic.AsyncAnthropic(api_key=api_key)
-            self._owns_anthropic_client = True
-        return self._anthropic_client
+    def _has_llm_key(self) -> bool:
+        try:
+            return bool(self.bot.settings.llm_api_key)
+        except ValueError:
+            return False
+
+    def _get_llm_client(self, model: str) -> LLMClient:
+        client = self._llm_clients.get(model)
+        if client is None:
+            client = create_llm_client(
+                provider=self.bot.settings.llm_provider,
+                api_key=self.bot.settings.llm_api_key,
+                model=model,
+            )
+            self._llm_clients[model] = client
+        return client
 
     async def cog_unload(self) -> None:
-        if self._anthropic_client is not None and self._owns_anthropic_client:
-            await self._anthropic_client.close()
-            self._anthropic_client = None
-            self._owns_anthropic_client = False
+        for client in self._llm_clients.values():
+            await client.close()
+        self._llm_clients.clear()
 
     async def _source_name_autocomplete(
         self,
@@ -297,16 +302,16 @@ class SourceManagement(commands.Cog):
             )
             return
 
-        if stype == SourceType.PAGE and not self.bot.settings.anthropic_api_key:
+        if stype == SourceType.PAGE and not self._has_llm_key():
             await interaction.followup.send(
-                "Page sources are not available. No Anthropic API key configured.",
+                "Page sources are not available. No LLM API key configured.",
                 ephemeral=True,
             )
             return
 
-        if stype == SourceType.BLOG and not self.bot.settings.anthropic_api_key:
+        if stype == SourceType.BLOG and not self._has_llm_key():
             await interaction.followup.send(
-                "Blog sources are not available. No Anthropic API key configured.",
+                "Blog sources are not available. No LLM API key configured.",
                 ephemeral=True,
             )
             return
@@ -360,7 +365,7 @@ class SourceManagement(commands.Cog):
 
         if stype == SourceType.BLOG:
             adapter = SmartBlogAdapter(
-                anthropic_client=self._get_anthropic_client(),
+                llm_client=self._get_llm_client(self.bot.settings.summary_model),
                 repository=self.bot.repository,
             )
             result = await adapter.analyze_site(url)
@@ -382,14 +387,16 @@ class SourceManagement(commands.Cog):
 
         extraction_profile_json: str | None = None
         if stype == SourceType.PAGE:
-            if not self.bot.settings.anthropic_api_key:
+            if not self._has_llm_key():
                 await interaction.followup.send(
-                    "Page sources require ANTHROPIC_API_KEY to be configured.",
+                    "Page sources require an LLM API key to be configured.",
                     ephemeral=True,
                 )
                 return
             try:
-                analyzer = PageAnalyzer(anthropic_client=self._get_anthropic_client())
+                analyzer = PageAnalyzer(
+                    llm_client=self._get_llm_client(self.bot.settings.summary_model_interactive)
+                )
                 profile = await analyzer.analyze(url)
                 extraction_profile_json = json.dumps(profile.to_dict())
             except PageAnalysisError as e:

--- a/src/intelstream/services/page_analyzer.py
+++ b/src/intelstream/services/page_analyzer.py
@@ -4,7 +4,6 @@ from dataclasses import dataclass
 from typing import Any
 from urllib.parse import urlparse
 
-import anthropic
 import httpx
 import structlog
 from bs4 import BeautifulSoup
@@ -17,11 +16,10 @@ from tenacity import (
 )
 
 from intelstream.config import get_settings
+from intelstream.services.llm_client import LLMClient, LLMError, LLMRateLimitError
 from intelstream.utils.safe_http import SafeHTTPError, safe_request
 
 logger = structlog.get_logger()
-
-DEFAULT_MODEL = "claude-sonnet-4-6"
 
 
 @dataclass
@@ -96,22 +94,11 @@ IMPORTANT:
 class PageAnalyzer:
     def __init__(
         self,
-        api_key: str | None = None,
+        llm_client: LLMClient,
         http_client: httpx.AsyncClient | None = None,
-        model: str = DEFAULT_MODEL,
-        anthropic_client: anthropic.AsyncAnthropic | None = None,
     ) -> None:
-        if anthropic_client is None and not api_key:
-            raise ValueError("api_key is required when anthropic_client is not provided")
-        self._client = anthropic_client or anthropic.AsyncAnthropic(api_key=api_key)
-        self._owns_client = anthropic_client is None
+        self._client = llm_client
         self._http_client = http_client
-        self._model = model
-
-    async def close(self) -> None:
-        if self._owns_client:
-            await self._client.close()
-            self._owns_client = False
 
     async def analyze(self, url: str) -> ExtractionProfile:
         parsed_url = urlparse(url)
@@ -192,7 +179,7 @@ class PageAnalyzer:
         return cleaned
 
     @retry(
-        retry=retry_if_exception_type(anthropic.RateLimitError),
+        retry=retry_if_exception_type(LLMRateLimitError),
         wait=wait_exponential(multiplier=1, min=4, max=60),
         stop=stop_after_attempt(3),
     )
@@ -209,19 +196,11 @@ HTML:
 Respond with ONLY a JSON object, no markdown formatting."""
 
         try:
-            message = await self._client.messages.create(
-                model=self._model,
-                max_tokens=1024,
+            response_text = await self._client.complete(
                 system=ANALYSIS_SYSTEM_PROMPT,
-                messages=[{"role": "user", "content": user_prompt}],
+                user_message=user_prompt,
+                max_tokens=1024,
             )
-
-            response_text = ""
-            for block in message.content:
-                if hasattr(block, "text"):
-                    response_text += block.text
-
-            response_text = response_text.strip()
 
             json_match = re.search(r"\{.*\}", response_text, re.DOTALL)
             if json_match:
@@ -253,8 +232,8 @@ Respond with ONLY a JSON object, no markdown formatting."""
 
             return data
 
-        except anthropic.APIError as e:
-            logger.error("Anthropic API error during page analysis", error=str(e))
+        except LLMError as e:
+            logger.error("LLM API error during page analysis", error=str(e))
             raise PageAnalysisError(f"LLM API error: {e}") from e
 
     def _validate_profile(self, html: str, profile: ExtractionProfile) -> dict[str, Any]:

--- a/src/intelstream/services/pipeline.py
+++ b/src/intelstream/services/pipeline.py
@@ -5,7 +5,6 @@ from collections.abc import Callable
 from datetime import UTC, datetime, timedelta
 from typing import TYPE_CHECKING
 
-import anthropic
 import httpx
 import structlog
 
@@ -22,6 +21,7 @@ from intelstream.database.models import ArticleChunkMeta, ContentItem, Source, S
 from intelstream.database.repository import Repository
 from intelstream.database.vector_store import ArticleChunkVector
 from intelstream.services.article_search import ArticleChunker, build_article_chunk_id
+from intelstream.services.llm_client import LLMClient, create_llm_client
 from intelstream.services.summarizer import SummarizationError, SummarizationService
 from intelstream.utils.safe_http import SafeHTTPError
 
@@ -47,7 +47,7 @@ class ContentPipeline:
         self._summarizer = summarizer
         self._get_search_services = get_search_services
         self._http_client: httpx.AsyncClient | None = None
-        self._owned_anthropic_clients: list[anthropic.AsyncAnthropic] = []
+        self._owned_llm_clients: list[LLMClient] = []
         self._adapters: dict[SourceType, BaseAdapter] = {}
         self._article_chunker = ArticleChunker(
             chunk_size_chars=getattr(self._settings, "article_chunk_size_chars", 1200),
@@ -76,9 +76,9 @@ class ContentPipeline:
         if self._http_client:
             await self._http_client.aclose()
             self._http_client = None
-        for client in self._owned_anthropic_clients:
+        for client in self._owned_llm_clients:
             await client.close()
-        self._owned_anthropic_clients.clear()
+        self._owned_llm_clients.clear()
         logger.debug("Content pipeline closed")
 
     def _create_adapters(self) -> dict[SourceType, BaseAdapter]:
@@ -102,18 +102,26 @@ class ContentPipeline:
                 http_client=self._http_client,
             )
 
-        anthropic_api_key = reveal_secret(self._settings.anthropic_api_key)
-        if anthropic_api_key:
-            anthropic_client = anthropic.AsyncAnthropic(api_key=anthropic_api_key)
-            self._owned_anthropic_clients.append(anthropic_client)
+        try:
+            llm_api_key = self._settings.llm_api_key
+        except ValueError:
+            llm_api_key = None
+
+        if llm_api_key:
+            extraction_client = create_llm_client(
+                provider=self._settings.llm_provider,
+                api_key=llm_api_key,
+                model=self._settings.summary_model,
+            )
+            self._owned_llm_clients.append(extraction_client)
             adapters[SourceType.BLOG] = SmartBlogAdapter(
-                anthropic_client=anthropic_client,
+                llm_client=extraction_client,
                 repository=self._repository,
                 http_client=self._http_client,
             )
         else:
             logger.warning(
-                "ANTHROPIC_API_KEY not set; Blog and Page source types will be unavailable"
+                "No LLM API key configured; Blog and Page source types will be unavailable"
             )
 
         return adapters

--- a/tests/test_adapters/test_smart_blog.py
+++ b/tests/test_adapters/test_smart_blog.py
@@ -27,17 +27,16 @@ def mock_repository():
 
 
 @pytest.fixture
-def mock_anthropic_client():
+def mock_llm_client():
     client = MagicMock()
-    client.messages = MagicMock()
-    client.messages.create = AsyncMock()
+    client.complete = AsyncMock()
     return client
 
 
 @pytest.fixture
-def adapter(mock_anthropic_client, mock_repository):
+def adapter(mock_llm_client, mock_repository):
     return SmartBlogAdapter(
-        anthropic_client=mock_anthropic_client,
+        llm_client=mock_llm_client,
         repository=mock_repository,
     )
 

--- a/tests/test_adapters/test_strategies/test_llm_extraction.py
+++ b/tests/test_adapters/test_strategies/test_llm_extraction.py
@@ -1,7 +1,6 @@
 import json
 from unittest.mock import AsyncMock, MagicMock, patch
 
-import anthropic
 import httpx
 import pytest
 import respx
@@ -9,6 +8,7 @@ import respx
 from intelstream.adapters.strategies.llm_extraction import LLMExtractionStrategy
 from intelstream.database.models import ExtractionCache
 from intelstream.database.repository import Repository
+from intelstream.services.llm_client import LLMError
 
 
 @pytest.fixture
@@ -20,17 +20,16 @@ def mock_repository():
 
 
 @pytest.fixture
-def mock_anthropic_client():
+def mock_llm_client():
     client = MagicMock()
-    client.messages = MagicMock()
-    client.messages.create = AsyncMock()
+    client.complete = AsyncMock()
     return client
 
 
 @pytest.fixture
-def llm_strategy(mock_anthropic_client, mock_repository):
+def llm_strategy(mock_llm_client, mock_repository):
     return LLMExtractionStrategy(
-        anthropic_client=mock_anthropic_client,
+        llm_client=mock_llm_client,
         repository=mock_repository,
     )
 
@@ -41,7 +40,7 @@ class TestLLMExtractionStrategy:
 
     @respx.mock
     async def test_discover_extracts_posts(
-        self, llm_strategy: LLMExtractionStrategy, mock_anthropic_client
+        self, llm_strategy: LLMExtractionStrategy, mock_llm_client
     ):
         html = """
         <html>
@@ -51,18 +50,12 @@ class TestLLMExtractionStrategy:
         </body>
         </html>
         """
-        llm_response = MagicMock()
-        llm_response.content = [
-            MagicMock(
-                text=json.dumps(
-                    [
-                        {"url": "https://example.com/post/1", "title": "Post 1"},
-                        {"url": "https://example.com/post/2", "title": "Post 2"},
-                    ]
-                )
-            )
-        ]
-        mock_anthropic_client.messages.create.return_value = llm_response
+        mock_llm_client.complete.return_value = json.dumps(
+            [
+                {"url": "https://example.com/post/1", "title": "Post 1"},
+                {"url": "https://example.com/post/2", "title": "Post 2"},
+            ]
+        )
 
         respx.get("https://example.com/blog").mock(return_value=httpx.Response(200, text=html))
 
@@ -75,7 +68,7 @@ class TestLLMExtractionStrategy:
 
     @respx.mock
     async def test_discover_uses_cache(
-        self, llm_strategy: LLMExtractionStrategy, mock_repository, mock_anthropic_client
+        self, llm_strategy: LLMExtractionStrategy, mock_repository, mock_llm_client
     ):
         html = "<html><body>Content</body></html>"
         expected_hash = llm_strategy._get_content_hash(html)
@@ -93,18 +86,16 @@ class TestLLMExtractionStrategy:
         assert result is not None
         assert len(result.posts) == 1
         assert result.posts[0].url == "https://example.com/cached"
-        mock_anthropic_client.messages.create.assert_not_called()
+        mock_llm_client.complete.assert_not_called()
 
     @respx.mock
     async def test_discover_caches_result(
-        self, llm_strategy: LLMExtractionStrategy, mock_repository, mock_anthropic_client
+        self, llm_strategy: LLMExtractionStrategy, mock_repository, mock_llm_client
     ):
         html = "<html><body>Content</body></html>"
-        llm_response = MagicMock()
-        llm_response.content = [
-            MagicMock(text='[{"url": "https://example.com/new", "title": "New"}]')
-        ]
-        mock_anthropic_client.messages.create.return_value = llm_response
+        mock_llm_client.complete.return_value = (
+            '[{"url": "https://example.com/new", "title": "New"}]'
+        )
 
         respx.get("https://example.com/").mock(return_value=httpx.Response(200, text=html))
 
@@ -114,16 +105,12 @@ class TestLLMExtractionStrategy:
 
     @respx.mock
     async def test_discover_handles_json_in_markdown(
-        self, llm_strategy: LLMExtractionStrategy, mock_anthropic_client
+        self, llm_strategy: LLMExtractionStrategy, mock_llm_client
     ):
         html = "<html><body>Content</body></html>"
-        llm_response = MagicMock()
-        llm_response.content = [
-            MagicMock(
-                text='```json\n[{"url": "https://example.com/wrapped", "title": "Wrapped"}]\n```'
-            )
-        ]
-        mock_anthropic_client.messages.create.return_value = llm_response
+        mock_llm_client.complete.return_value = (
+            '```json\n[{"url": "https://example.com/wrapped", "title": "Wrapped"}]\n```'
+        )
 
         respx.get("https://example.com/").mock(return_value=httpx.Response(200, text=html))
 
@@ -135,12 +122,10 @@ class TestLLMExtractionStrategy:
 
     @respx.mock
     async def test_discover_resolves_relative_urls(
-        self, llm_strategy: LLMExtractionStrategy, mock_anthropic_client
+        self, llm_strategy: LLMExtractionStrategy, mock_llm_client
     ):
         html = "<html><body>Content</body></html>"
-        llm_response = MagicMock()
-        llm_response.content = [MagicMock(text='[{"url": "/post/relative", "title": "Relative"}]')]
-        mock_anthropic_client.messages.create.return_value = llm_response
+        mock_llm_client.complete.return_value = '[{"url": "/post/relative", "title": "Relative"}]'
 
         respx.get("https://example.com/blog").mock(return_value=httpx.Response(200, text=html))
 
@@ -151,12 +136,10 @@ class TestLLMExtractionStrategy:
 
     @respx.mock
     async def test_discover_returns_none_on_empty_result(
-        self, llm_strategy: LLMExtractionStrategy, mock_anthropic_client
+        self, llm_strategy: LLMExtractionStrategy, mock_llm_client
     ):
         html = "<html><body>No posts</body></html>"
-        llm_response = MagicMock()
-        llm_response.content = [MagicMock(text="[]")]
-        mock_anthropic_client.messages.create.return_value = llm_response
+        mock_llm_client.complete.return_value = "[]"
 
         respx.get("https://example.com/").mock(return_value=httpx.Response(200, text=html))
 
@@ -174,12 +157,10 @@ class TestLLMExtractionStrategy:
 
     @respx.mock
     async def test_discover_handles_invalid_json(
-        self, llm_strategy: LLMExtractionStrategy, mock_anthropic_client
+        self, llm_strategy: LLMExtractionStrategy, mock_llm_client
     ):
         html = "<html><body>Content</body></html>"
-        llm_response = MagicMock()
-        llm_response.content = [MagicMock(text="This is not JSON")]
-        mock_anthropic_client.messages.create.return_value = llm_response
+        mock_llm_client.complete.return_value = "This is not JSON"
 
         respx.get("https://example.com/").mock(return_value=httpx.Response(200, text=html))
 
@@ -251,7 +232,7 @@ class TestLLMExtractionStrategy:
 
     @respx.mock
     async def test_discover_uses_cache_with_validated_data(
-        self, llm_strategy: LLMExtractionStrategy, mock_repository, mock_anthropic_client
+        self, llm_strategy: LLMExtractionStrategy, mock_repository, mock_llm_client
     ):
         html = "<html><body>Content</body></html>"
         expected_hash = llm_strategy._get_content_hash(html)
@@ -271,11 +252,11 @@ class TestLLMExtractionStrategy:
         assert result is not None
         assert len(result.posts) == 1
         assert result.posts[0].url == "https://example.com/valid"
-        mock_anthropic_client.messages.create.assert_not_called()
+        mock_llm_client.complete.assert_not_called()
 
     @respx.mock
     async def test_discover_filters_empty_urls_from_cache(
-        self, llm_strategy: LLMExtractionStrategy, mock_repository, mock_anthropic_client
+        self, llm_strategy: LLMExtractionStrategy, mock_repository, mock_llm_client
     ):
         html = "<html><body>Content</body></html>"
         expected_hash = llm_strategy._get_content_hash(html)
@@ -298,22 +279,20 @@ class TestLLMExtractionStrategy:
         assert result is not None
         assert len(result.posts) == 1
         assert result.posts[0].url == "https://example.com/valid"
-        mock_anthropic_client.messages.create.assert_not_called()
+        mock_llm_client.complete.assert_not_called()
 
     @respx.mock
     async def test_discover_ignores_invalid_cache_json_and_refreshes(
-        self, llm_strategy: LLMExtractionStrategy, mock_repository, mock_anthropic_client
+        self, llm_strategy: LLMExtractionStrategy, mock_repository, mock_llm_client
     ):
         html = "<html><body>Content</body></html>"
         cached = MagicMock(spec=ExtractionCache)
         cached.content_hash = llm_strategy._get_content_hash(html)
         cached.posts_json = "{not json"
         mock_repository.get_extraction_cache.return_value = cached
-        llm_response = MagicMock()
-        llm_response.content = [
-            MagicMock(text='[{"url": "https://example.com/fresh", "title": "Fresh"}]')
-        ]
-        mock_anthropic_client.messages.create.return_value = llm_response
+        mock_llm_client.complete.return_value = (
+            '[{"url": "https://example.com/fresh", "title": "Fresh"}]'
+        )
         respx.get("https://example.com/").mock(return_value=httpx.Response(200, text=html))
 
         result = await llm_strategy.discover("https://example.com/")
@@ -324,18 +303,16 @@ class TestLLMExtractionStrategy:
 
     @respx.mock
     async def test_discover_ignores_cache_without_valid_posts(
-        self, llm_strategy: LLMExtractionStrategy, mock_repository, mock_anthropic_client
+        self, llm_strategy: LLMExtractionStrategy, mock_repository, mock_llm_client
     ):
         html = "<html><body>Content</body></html>"
         cached = MagicMock(spec=ExtractionCache)
         cached.content_hash = llm_strategy._get_content_hash(html)
         cached.posts_json = json.dumps([{"url": "", "title": "Empty"}])
         mock_repository.get_extraction_cache.return_value = cached
-        llm_response = MagicMock()
-        llm_response.content = [
-            MagicMock(text='[{"url": "https://example.com/fresh", "title": "Fresh"}]')
-        ]
-        mock_anthropic_client.messages.create.return_value = llm_response
+        mock_llm_client.complete.return_value = (
+            '[{"url": "https://example.com/fresh", "title": "Fresh"}]'
+        )
         respx.get("https://example.com/").mock(return_value=httpx.Response(200, text=html))
 
         result = await llm_strategy.discover("https://example.com/")
@@ -345,18 +322,16 @@ class TestLLMExtractionStrategy:
 
     @respx.mock
     async def test_discover_ignores_non_list_cache_and_refreshes(
-        self, llm_strategy: LLMExtractionStrategy, mock_repository, mock_anthropic_client
+        self, llm_strategy: LLMExtractionStrategy, mock_repository, mock_llm_client
     ):
         html = "<html><body>Content</body></html>"
         cached = MagicMock(spec=ExtractionCache)
         cached.content_hash = llm_strategy._get_content_hash(html)
         cached.posts_json = json.dumps({"url": "https://example.com/not-a-list"})
         mock_repository.get_extraction_cache.return_value = cached
-        llm_response = MagicMock()
-        llm_response.content = [
-            MagicMock(text='[{"url": "https://example.com/fresh", "title": "Fresh"}]')
-        ]
-        mock_anthropic_client.messages.create.return_value = llm_response
+        mock_llm_client.complete.return_value = (
+            '[{"url": "https://example.com/fresh", "title": "Fresh"}]'
+        )
         respx.get("https://example.com/").mock(return_value=httpx.Response(200, text=html))
 
         result = await llm_strategy.discover("https://example.com/")
@@ -419,7 +394,7 @@ class TestLLMExtractionStrategy:
             )
         )
         strategy = LLMExtractionStrategy(
-            anthropic_client=MagicMock(),
+            llm_client=MagicMock(),
             repository=mock_repository,
             http_client=client,
         )
@@ -518,39 +493,15 @@ class TestLLMExtractionStrategy:
 
         assert cleaned == "<" + ("x" * 1099)
 
-    async def test_extract_with_llm_ignores_blocks_without_text(
-        self, llm_strategy: LLMExtractionStrategy, mock_anthropic_client
-    ):
-        response = MagicMock()
-        response.content = [
-            object(),
-            MagicMock(text='[{"url": "https://example.com/post", "title": "Post"}]'),
-        ]
-        mock_anthropic_client.messages.create.return_value = response
-
-        posts = await llm_strategy._extract_with_llm(
-            "<html><body>Posts</body></html>",
-            "https://example.com/blog",
-        )
-
-        assert len(posts) == 1
-        assert posts[0].url == "https://example.com/post"
-
     async def test_extract_with_llm_skips_ssrf_blocked_urls(
-        self, llm_strategy: LLMExtractionStrategy, mock_anthropic_client
+        self, llm_strategy: LLMExtractionStrategy, mock_llm_client
     ):
-        response = MagicMock()
-        response.content = [
-            MagicMock(
-                text=json.dumps(
-                    [
-                        {"url": "http://localhost/admin", "title": "Blocked"},
-                        {"url": "/safe", "title": "Safe"},
-                    ]
-                )
-            )
-        ]
-        mock_anthropic_client.messages.create.return_value = response
+        mock_llm_client.complete.return_value = json.dumps(
+            [
+                {"url": "http://localhost/admin", "title": "Blocked"},
+                {"url": "/safe", "title": "Safe"},
+            ]
+        )
 
         posts = await llm_strategy._extract_with_llm(
             "<html><body>Posts</body></html>",
@@ -579,14 +530,9 @@ class TestLLMExtractionStrategy:
         assert result == []
 
     async def test_extract_with_llm_handles_api_error(
-        self, llm_strategy: LLMExtractionStrategy, mock_anthropic_client
+        self, llm_strategy: LLMExtractionStrategy, mock_llm_client
     ):
-        request = httpx.Request("POST", "https://api.anthropic.com/v1/messages")
-        mock_anthropic_client.messages.create.side_effect = anthropic.APIError(
-            "api failed",
-            request,
-            body=None,
-        )
+        mock_llm_client.complete.side_effect = LLMError("api failed")
 
         assert await llm_strategy._extract_with_llm("<html></html>", "https://example.com") == []
 

--- a/tests/test_discord/test_source_management.py
+++ b/tests/test_discord/test_source_management.py
@@ -33,6 +33,8 @@ def mock_bot():
     bot.settings.get_poll_interval = MagicMock(return_value=5)
     bot.settings.youtube_api_key = "test-api-key"
     bot.settings.twitter_bearer_token = "test-twitter-token"
+    bot.settings.llm_provider = "openai"
+    bot.settings.llm_api_key = "test-openai-key"
     return bot
 
 
@@ -403,7 +405,6 @@ class TestSourceManagementAdd:
         assert "already exists" in call_args[0][0]
 
     async def test_add_duplicate_blog_skips_expensive_analysis(self, source_management, mock_bot):
-        mock_bot.settings.anthropic_api_key = "anthropic-key"
         interaction = make_interaction()
         source_type_choice = MagicMock(value="blog", name="Blog")
         existing_source = MagicMock(name="Existing Blog")
@@ -664,8 +665,8 @@ class TestSourceManagementAdd:
         mock_bot.repository.add_source.assert_not_called()
         assert "Invalid source type" in interaction.followup.send.call_args.args[0]
 
-    async def test_add_page_without_anthropic_key(self, source_management, mock_bot):
-        mock_bot.settings.anthropic_api_key = None
+    async def test_add_page_without_llm_key(self, source_management, mock_bot):
+        mock_bot.settings.llm_api_key = None
         interaction = make_interaction()
         source_type_choice = MagicMock()
         source_type_choice.value = "page"
@@ -681,8 +682,8 @@ class TestSourceManagementAdd:
         mock_bot.repository.add_source.assert_not_called()
         assert "not available" in interaction.followup.send.call_args.args[0]
 
-    async def test_add_blog_without_anthropic_key(self, source_management, mock_bot):
-        mock_bot.settings.anthropic_api_key = None
+    async def test_add_blog_without_llm_key(self, source_management, mock_bot):
+        mock_bot.settings.llm_api_key = None
         interaction = make_interaction()
         source_type_choice = MagicMock()
         source_type_choice.value = "blog"
@@ -772,7 +773,6 @@ class TestSourceManagementAdd:
         assert "already exists" in interaction.followup.send.call_args.args[0]
 
     async def test_add_page_stores_analyzed_extraction_profile(self, source_management, mock_bot):
-        mock_bot.settings.anthropic_api_key = "anthropic-key"
         interaction = make_interaction()
         source_type_choice = MagicMock()
         source_type_choice.value = "page"
@@ -802,7 +802,6 @@ class TestSourceManagementAdd:
         assert json.loads(call_kwargs["extraction_profile"]) == {"post_selector": "article"}
 
     async def test_add_page_reports_analysis_error(self, source_management, mock_bot):
-        mock_bot.settings.anthropic_api_key = "anthropic-key"
         interaction = make_interaction()
         source_type_choice = MagicMock()
         source_type_choice.value = "page"
@@ -823,10 +822,8 @@ class TestSourceManagementAdd:
         mock_bot.repository.add_source.assert_not_called()
         assert "Failed to analyze page structure" in interaction.followup.send.call_args.args[0]
 
-    async def test_add_page_rechecks_anthropic_key_before_analysis(
-        self, source_management, mock_bot
-    ):
-        class SettingsWithClearedAnthropicKey:
+    async def test_add_page_rechecks_llm_key_before_analysis(self, source_management, mock_bot):
+        class SettingsWithClearedLLMKey:
             default_poll_interval_minutes = 5
             twitter_bearer_token = "test-twitter-token"
             youtube_api_key = "test-api-key"
@@ -835,11 +832,13 @@ class TestSourceManagementAdd:
                 self.calls = 0
 
             @property
-            def anthropic_api_key(self) -> str | None:
+            def llm_api_key(self) -> str:
                 self.calls += 1
-                return "anthropic-key" if self.calls == 1 else None
+                if self.calls == 1:
+                    return "openai-key"
+                raise ValueError("No API key configured")
 
-        mock_bot.settings = SettingsWithClearedAnthropicKey()
+        mock_bot.settings = SettingsWithClearedLLMKey()
         interaction = make_interaction()
         source_type_choice = MagicMock()
         source_type_choice.value = "page"
@@ -853,10 +852,9 @@ class TestSourceManagementAdd:
         )
 
         mock_bot.repository.add_source.assert_not_called()
-        assert "require ANTHROPIC_API_KEY" in interaction.followup.send.call_args.args[0]
+        assert "require an LLM API key" in interaction.followup.send.call_args.args[0]
 
     async def test_add_blog_uses_discovered_metadata(self, source_management, mock_bot):
-        mock_bot.settings.anthropic_api_key = "anthropic-key"
         interaction = make_interaction()
         source_type_choice = MagicMock()
         source_type_choice.value = "blog"
@@ -876,7 +874,7 @@ class TestSourceManagementAdd:
         mock_bot.repository.add_source = AsyncMock(return_value=mock_source)
 
         with (
-            patch.object(source_management, "_get_anthropic_client", return_value=MagicMock()),
+            patch.object(source_management, "_get_llm_client", return_value=MagicMock()),
             patch(
                 "intelstream.discord.cogs.source_management.async_is_safe_url",
                 return_value=(True, None),
@@ -902,7 +900,6 @@ class TestSourceManagementAdd:
         assert any(field.name == "Discovery Strategy" for field in embed.fields)
 
     async def test_add_blog_reports_analysis_failure(self, source_management, mock_bot):
-        mock_bot.settings.anthropic_api_key = "anthropic-key"
         interaction = make_interaction()
         source_type_choice = MagicMock()
         source_type_choice.value = "blog"
@@ -913,7 +910,7 @@ class TestSourceManagementAdd:
         adapter.analyze_site = AsyncMock(return_value=result)
 
         with (
-            patch.object(source_management, "_get_anthropic_client", return_value=MagicMock()),
+            patch.object(source_management, "_get_llm_client", return_value=MagicMock()),
             patch(
                 "intelstream.discord.cogs.source_management.async_is_safe_url",
                 return_value=(True, None),
@@ -1632,44 +1629,36 @@ class TestSourceAutocomplete:
 
 
 class TestSourceManagementLifecycle:
-    def test_get_anthropic_client_is_cached(self, source_management, mock_bot):
-        mock_bot.settings.anthropic_api_key = "anthropic-key"
-        with patch("intelstream.discord.cogs.source_management.anthropic.AsyncAnthropic") as cls:
-            first = source_management._get_anthropic_client()
-            second = source_management._get_anthropic_client()
+    def test_get_llm_client_is_cached_per_model(self, source_management):
+        with patch("intelstream.discord.cogs.source_management.create_llm_client") as cls:
+            cls.side_effect = [MagicMock(), MagicMock()]
+            first = source_management._get_llm_client("model-a")
+            second = source_management._get_llm_client("model-a")
+            other = source_management._get_llm_client("model-b")
 
         assert first is second
-        cls.assert_called_once_with(api_key="anthropic-key")
+        assert first is not other
+        assert cls.call_count == 2
 
-    async def test_cog_unload_closes_owned_anthropic_client_once(self, source_management, mock_bot):
-        mock_bot.settings.anthropic_api_key = "anthropic-key"
+    async def test_cog_unload_closes_llm_clients_once(self, source_management):
         client = MagicMock()
         client.close = AsyncMock()
 
         with patch(
-            "intelstream.discord.cogs.source_management.anthropic.AsyncAnthropic",
+            "intelstream.discord.cogs.source_management.create_llm_client",
             return_value=client,
         ):
-            source_management._get_anthropic_client()
+            source_management._get_llm_client("model-a")
 
         await source_management.cog_unload()
         await source_management.cog_unload()
 
         client.close.assert_awaited_once()
 
-    async def test_cog_unload_does_not_close_external_anthropic_client(self, source_management):
-        client = MagicMock()
-        client.close = AsyncMock()
-        source_management._anthropic_client = client
-
+    async def test_cog_unload_noops_without_llm_clients(self, source_management):
         await source_management.cog_unload()
 
-        client.close.assert_not_called()
-
-    async def test_cog_unload_noops_without_anthropic_client(self, source_management):
-        await source_management.cog_unload()
-
-        assert source_management._anthropic_client is None
+        assert source_management._llm_clients == {}
 
     async def test_setup_adds_cog(self, mock_bot):
         from intelstream.discord.cogs.source_management import setup

--- a/tests/test_services/test_page_analyzer.py
+++ b/tests/test_services/test_page_analyzer.py
@@ -1,10 +1,10 @@
 import json
 from unittest.mock import AsyncMock, MagicMock, patch
 
-import anthropic
 import httpx
 import pytest
 
+from intelstream.services.llm_client import LLMError
 from intelstream.services.page_analyzer import (
     ExtractionProfile,
     PageAnalysisError,
@@ -67,56 +67,38 @@ def valid_llm_response() -> dict:
     }
 
 
+@pytest.fixture
+def mock_llm_client():
+    client = MagicMock()
+    client.complete = AsyncMock()
+    return client
+
+
 class TestPageAnalyzer:
-    async def test_close_closes_owned_anthropic_client_once(self) -> None:
-        client = MagicMock()
-        client.close = AsyncMock()
-        with patch(
-            "intelstream.services.page_analyzer.anthropic.AsyncAnthropic",
-            return_value=client,
-        ):
-            analyzer = PageAnalyzer(api_key="test-key")
-
-        await analyzer.close()
-        await analyzer.close()
-
-        client.close.assert_awaited_once_with()
-
-    async def test_close_does_not_close_shared_anthropic_client(self) -> None:
-        client = MagicMock()
-        client.close = AsyncMock()
-        analyzer = PageAnalyzer(anthropic_client=client)
-
-        await analyzer.close()
-
-        client.close.assert_not_awaited()
-
-    async def test_analyze_rejects_invalid_url_format(self) -> None:
-        analyzer = PageAnalyzer(api_key="test-key")
+    async def test_analyze_rejects_invalid_url_format(self, mock_llm_client) -> None:
+        analyzer = PageAnalyzer(llm_client=mock_llm_client)
 
         with pytest.raises(PageAnalysisError, match="Invalid URL format"):
             await analyzer.analyze("not-a-valid-url")
 
-    async def test_analyze_rejects_non_http_scheme(self) -> None:
-        analyzer = PageAnalyzer(api_key="test-key")
+    async def test_analyze_rejects_non_http_scheme(self, mock_llm_client) -> None:
+        analyzer = PageAnalyzer(llm_client=mock_llm_client)
 
         with pytest.raises(PageAnalysisError, match="must use http or https"):
             await analyzer.analyze("ftp://example.com/blog")
 
-    async def test_analyze_success(self, sample_html: str, valid_llm_response: dict) -> None:
+    async def test_analyze_success(
+        self, sample_html: str, valid_llm_response: dict, mock_llm_client
+    ) -> None:
         mock_http_client = MagicMock(spec=httpx.AsyncClient)
         mock_response = MagicMock()
         mock_response.text = sample_html
         mock_response.raise_for_status = MagicMock()
         mock_http_client.get = AsyncMock(return_value=mock_response)
 
-        mock_anthropic_response = MagicMock()
-        mock_text_block = MagicMock()
-        mock_text_block.text = json.dumps(valid_llm_response)
-        mock_anthropic_response.content = [mock_text_block]
+        mock_llm_client.complete.return_value = json.dumps(valid_llm_response)
 
-        analyzer = PageAnalyzer(api_key="test-key", http_client=mock_http_client)
-        analyzer._client.messages.create = AsyncMock(return_value=mock_anthropic_response)
+        analyzer = PageAnalyzer(llm_client=mock_llm_client, http_client=mock_http_client)
 
         profile = await analyzer.analyze("https://example.com/blog")
 
@@ -124,7 +106,7 @@ class TestPageAnalyzer:
         assert profile.post_selector == "article.post-card"
         assert profile.title_selector == "h3.post-title"
 
-    async def test_analyze_http_error(self) -> None:
+    async def test_analyze_http_error(self, mock_llm_client) -> None:
         mock_http_client = MagicMock(spec=httpx.AsyncClient)
         mock_response = MagicMock()
         mock_response.status_code = 404
@@ -135,26 +117,28 @@ class TestPageAnalyzer:
         )
         mock_http_client.get = AsyncMock(return_value=mock_response)
 
-        analyzer = PageAnalyzer(api_key="test-key", http_client=mock_http_client)
+        analyzer = PageAnalyzer(llm_client=mock_llm_client, http_client=mock_http_client)
 
         with pytest.raises(PageAnalysisError, match="Failed to fetch page"):
             await analyzer.analyze("https://example.com/blog")
 
-    async def test_fetch_html_wraps_request_error(self) -> None:
+    async def test_fetch_html_wraps_request_error(self, mock_llm_client) -> None:
         mock_http_client = MagicMock(spec=httpx.AsyncClient)
         mock_http_client.get = AsyncMock(side_effect=httpx.ConnectError("network down"))
-        analyzer = PageAnalyzer(api_key="test-key", http_client=mock_http_client)
+        analyzer = PageAnalyzer(llm_client=mock_llm_client, http_client=mock_http_client)
 
         with pytest.raises(PageAnalysisError, match="network down"):
             await analyzer._fetch_html("https://example.com/blog")
 
-    async def test_fetch_html_uses_browser_user_agent_and_follows_redirects(self) -> None:
+    async def test_fetch_html_uses_browser_user_agent_and_follows_redirects(
+        self, mock_llm_client
+    ) -> None:
         mock_http_client = MagicMock(spec=httpx.AsyncClient)
         mock_response = MagicMock()
         mock_response.text = "<html></html>"
         mock_response.raise_for_status = MagicMock()
         mock_http_client.get = AsyncMock(return_value=mock_response)
-        analyzer = PageAnalyzer(api_key="test-key", http_client=mock_http_client)
+        analyzer = PageAnalyzer(llm_client=mock_llm_client, http_client=mock_http_client)
 
         result = await analyzer._fetch_html("https://example.com/blog")
 
@@ -163,43 +147,39 @@ class TestPageAnalyzer:
         assert "Mozilla/5.0" in call_kwargs["headers"]["User-Agent"]
         assert call_kwargs["follow_redirects"] is False
 
-    async def test_analyze_llm_returns_error(self, sample_html: str) -> None:
+    async def test_analyze_llm_returns_error(self, sample_html: str, mock_llm_client) -> None:
         mock_http_client = MagicMock(spec=httpx.AsyncClient)
         mock_response = MagicMock()
         mock_response.text = sample_html
         mock_response.raise_for_status = MagicMock()
         mock_http_client.get = AsyncMock(return_value=mock_response)
 
-        mock_anthropic_response = MagicMock()
-        mock_text_block = MagicMock()
-        mock_text_block.text = json.dumps({"error": "Could not identify post listing pattern"})
-        mock_anthropic_response.content = [mock_text_block]
+        mock_llm_client.complete.return_value = json.dumps(
+            {"error": "Could not identify post listing pattern"}
+        )
 
-        analyzer = PageAnalyzer(api_key="test-key", http_client=mock_http_client)
-        analyzer._client.messages.create = AsyncMock(return_value=mock_anthropic_response)
+        analyzer = PageAnalyzer(llm_client=mock_llm_client, http_client=mock_http_client)
 
         with pytest.raises(PageAnalysisError, match="Could not identify"):
             await analyzer.analyze("https://example.com/blog")
 
-    async def test_analyze_llm_invalid_json(self, sample_html: str) -> None:
+    async def test_analyze_llm_invalid_json(self, sample_html: str, mock_llm_client) -> None:
         mock_http_client = MagicMock(spec=httpx.AsyncClient)
         mock_response = MagicMock()
         mock_response.text = sample_html
         mock_response.raise_for_status = MagicMock()
         mock_http_client.get = AsyncMock(return_value=mock_response)
 
-        mock_anthropic_response = MagicMock()
-        mock_text_block = MagicMock()
-        mock_text_block.text = "This is not valid JSON"
-        mock_anthropic_response.content = [mock_text_block]
+        mock_llm_client.complete.return_value = "This is not valid JSON"
 
-        analyzer = PageAnalyzer(api_key="test-key", http_client=mock_http_client)
-        analyzer._client.messages.create = AsyncMock(return_value=mock_anthropic_response)
+        analyzer = PageAnalyzer(llm_client=mock_llm_client, http_client=mock_http_client)
 
         with pytest.raises(PageAnalysisError, match="invalid JSON"):
             await analyzer.analyze("https://example.com/blog")
 
-    async def test_analyze_llm_missing_required_field(self, sample_html: str) -> None:
+    async def test_analyze_llm_missing_required_field(
+        self, sample_html: str, mock_llm_client
+    ) -> None:
         mock_http_client = MagicMock(spec=httpx.AsyncClient)
         mock_response = MagicMock()
         mock_response.text = sample_html
@@ -210,18 +190,16 @@ class TestPageAnalyzer:
             "site_name": "Test Blog",
             "post_selector": "article.post-card",
         }
-        mock_anthropic_response = MagicMock()
-        mock_text_block = MagicMock()
-        mock_text_block.text = json.dumps(incomplete_response)
-        mock_anthropic_response.content = [mock_text_block]
+        mock_llm_client.complete.return_value = json.dumps(incomplete_response)
 
-        analyzer = PageAnalyzer(api_key="test-key", http_client=mock_http_client)
-        analyzer._client.messages.create = AsyncMock(return_value=mock_anthropic_response)
+        analyzer = PageAnalyzer(llm_client=mock_llm_client, http_client=mock_http_client)
 
         with pytest.raises(PageAnalysisError, match="Missing required field"):
             await analyzer.analyze("https://example.com/blog")
 
-    async def test_analyze_validation_fails_no_posts(self, valid_llm_response: dict) -> None:
+    async def test_analyze_validation_fails_no_posts(
+        self, valid_llm_response: dict, mock_llm_client
+    ) -> None:
         html = "<html><body><div>No matching posts</div></body></html>"
 
         mock_http_client = MagicMock(spec=httpx.AsyncClient)
@@ -230,34 +208,28 @@ class TestPageAnalyzer:
         mock_response.raise_for_status = MagicMock()
         mock_http_client.get = AsyncMock(return_value=mock_response)
 
-        mock_anthropic_response = MagicMock()
-        mock_text_block = MagicMock()
-        mock_text_block.text = json.dumps(valid_llm_response)
-        mock_anthropic_response.content = [mock_text_block]
+        mock_llm_client.complete.return_value = json.dumps(valid_llm_response)
 
-        analyzer = PageAnalyzer(api_key="test-key", http_client=mock_http_client)
-        analyzer._client.messages.create = AsyncMock(return_value=mock_anthropic_response)
+        analyzer = PageAnalyzer(llm_client=mock_llm_client, http_client=mock_http_client)
 
         with pytest.raises(PageAnalysisError, match="Profile validation failed"):
             await analyzer.analyze("https://example.com/blog")
 
-    async def test_analyze_api_error(self, sample_html: str) -> None:
+    async def test_analyze_api_error(self, sample_html: str, mock_llm_client) -> None:
         mock_http_client = MagicMock(spec=httpx.AsyncClient)
         mock_response = MagicMock()
         mock_response.text = sample_html
         mock_response.raise_for_status = MagicMock()
         mock_http_client.get = AsyncMock(return_value=mock_response)
 
-        analyzer = PageAnalyzer(api_key="test-key", http_client=mock_http_client)
-        analyzer._client.messages.create = AsyncMock(
-            side_effect=anthropic.APIError(message="API Error", request=MagicMock(), body=None)
-        )
+        analyzer = PageAnalyzer(llm_client=mock_llm_client, http_client=mock_http_client)
+        mock_llm_client.complete.side_effect = LLMError("API Error")
 
         with pytest.raises(PageAnalysisError, match="LLM API error"):
             await analyzer.analyze("https://example.com/blog")
 
     async def test_analyze_without_http_client(
-        self, sample_html: str, valid_llm_response: dict
+        self, sample_html: str, valid_llm_response: dict, mock_llm_client
     ) -> None:
         with patch("intelstream.services.page_analyzer.httpx.AsyncClient") as mock_client_class:
             mock_client = MagicMock()
@@ -269,18 +241,14 @@ class TestPageAnalyzer:
             mock_client.__aexit__ = AsyncMock(return_value=None)
             mock_client_class.return_value = mock_client
 
-            mock_anthropic_response = MagicMock()
-            mock_text_block = MagicMock()
-            mock_text_block.text = json.dumps(valid_llm_response)
-            mock_anthropic_response.content = [mock_text_block]
+            mock_llm_client.complete.return_value = json.dumps(valid_llm_response)
 
-            analyzer = PageAnalyzer(api_key="test-key")
-            analyzer._client.messages.create = AsyncMock(return_value=mock_anthropic_response)
+            analyzer = PageAnalyzer(llm_client=mock_llm_client)
 
             profile = await analyzer.analyze("https://example.com/blog")
             assert profile.site_name == "Test Blog"
 
-    def test_clean_html_removes_scripts(self) -> None:
+    def test_clean_html_removes_scripts(self, mock_llm_client) -> None:
         html = """
         <html>
         <head><script>alert('xss')</script></head>
@@ -292,14 +260,14 @@ class TestPageAnalyzer:
         </body>
         </html>
         """
-        analyzer = PageAnalyzer(api_key="test-key")
+        analyzer = PageAnalyzer(llm_client=mock_llm_client)
         cleaned = analyzer._clean_html(html)
 
         assert "<script>" not in cleaned
         assert "alert" not in cleaned
         assert "console.log" not in cleaned
 
-    def test_clean_html_removes_styles(self) -> None:
+    def test_clean_html_removes_styles(self, mock_llm_client) -> None:
         html = """
         <html>
         <head><style>.hidden { display: none; }</style></head>
@@ -308,13 +276,13 @@ class TestPageAnalyzer:
         </body>
         </html>
         """
-        analyzer = PageAnalyzer(api_key="test-key")
+        analyzer = PageAnalyzer(llm_client=mock_llm_client)
         cleaned = analyzer._clean_html(html)
 
         assert "<style>" not in cleaned
         assert "display: none" not in cleaned
 
-    def test_clean_html_preserves_important_attributes(self) -> None:
+    def test_clean_html_preserves_important_attributes(self, mock_llm_client) -> None:
         html = """
         <html>
         <body>
@@ -325,7 +293,7 @@ class TestPageAnalyzer:
         </body>
         </html>
         """
-        analyzer = PageAnalyzer(api_key="test-key")
+        analyzer = PageAnalyzer(llm_client=mock_llm_client)
         cleaned = analyzer._clean_html(html)
 
         assert 'class="post"' in cleaned
@@ -334,9 +302,9 @@ class TestPageAnalyzer:
         assert 'datetime="2024-01-15"' in cleaned
         assert "data-tracking" not in cleaned
 
-    def test_clean_html_truncates_long_html(self) -> None:
+    def test_clean_html_truncates_long_html(self, mock_llm_client) -> None:
         html = "<html><body>" + ("x" * 200) + "</body></html>"
-        analyzer = PageAnalyzer(api_key="test-key")
+        analyzer = PageAnalyzer(llm_client=mock_llm_client)
         settings = MagicMock()
         settings.max_html_length = 50
 
@@ -345,7 +313,7 @@ class TestPageAnalyzer:
 
         assert len(cleaned) == 50
 
-    def test_validate_profile_valid(self, sample_html: str) -> None:
+    def test_validate_profile_valid(self, sample_html: str, mock_llm_client) -> None:
         profile = ExtractionProfile(
             site_name="Test",
             post_selector="article.post-card",
@@ -353,13 +321,13 @@ class TestPageAnalyzer:
             url_selector="a.post-link",
             url_attribute="href",
         )
-        analyzer = PageAnalyzer(api_key="test-key")
+        analyzer = PageAnalyzer(llm_client=mock_llm_client)
         result = analyzer._validate_profile(sample_html, profile)
 
         assert result["valid"] is True
         assert result["post_count"] == 2
 
-    def test_validate_profile_no_matching_posts(self, sample_html: str) -> None:
+    def test_validate_profile_no_matching_posts(self, sample_html: str, mock_llm_client) -> None:
         profile = ExtractionProfile(
             site_name="Test",
             post_selector="div.nonexistent",
@@ -367,13 +335,13 @@ class TestPageAnalyzer:
             url_selector="a",
             url_attribute="href",
         )
-        analyzer = PageAnalyzer(api_key="test-key")
+        analyzer = PageAnalyzer(llm_client=mock_llm_client)
         result = analyzer._validate_profile(sample_html, profile)
 
         assert result["valid"] is False
         assert "No elements found" in result["reason"]
 
-    def test_validate_profile_cannot_extract_data(self) -> None:
+    def test_validate_profile_cannot_extract_data(self, mock_llm_client) -> None:
         html = """
         <html>
         <body>
@@ -390,14 +358,14 @@ class TestPageAnalyzer:
             url_selector="a.link",
             url_attribute="href",
         )
-        analyzer = PageAnalyzer(api_key="test-key")
+        analyzer = PageAnalyzer(llm_client=mock_llm_client)
         result = analyzer._validate_profile(html, profile)
 
         assert result["valid"] is False
         assert "Could not extract" in result["reason"]
 
     async def test_analyze_extracts_json_from_markdown(
-        self, sample_html: str, valid_llm_response: dict
+        self, sample_html: str, valid_llm_response: dict, mock_llm_client
     ) -> None:
         mock_http_client = MagicMock(spec=httpx.AsyncClient)
         mock_response = MagicMock()
@@ -405,61 +373,34 @@ class TestPageAnalyzer:
         mock_response.raise_for_status = MagicMock()
         mock_http_client.get = AsyncMock(return_value=mock_response)
 
-        mock_anthropic_response = MagicMock()
-        mock_text_block = MagicMock()
-        mock_text_block.text = f"```json\n{json.dumps(valid_llm_response)}\n```"
-        mock_anthropic_response.content = [mock_text_block]
+        mock_llm_client.complete.return_value = f"```json\n{json.dumps(valid_llm_response)}\n```"
 
-        analyzer = PageAnalyzer(api_key="test-key", http_client=mock_http_client)
-        analyzer._client.messages.create = AsyncMock(return_value=mock_anthropic_response)
+        analyzer = PageAnalyzer(llm_client=mock_llm_client, http_client=mock_http_client)
 
         profile = await analyzer.analyze("https://example.com/blog")
 
         assert profile.site_name == "Test Blog"
 
-    async def test_extract_profile_ignores_content_blocks_without_text(
-        self, valid_llm_response: dict
-    ) -> None:
-        class EmptyBlock:
-            pass
-
-        mock_anthropic_response = MagicMock()
-        mock_text_block = MagicMock()
-        mock_text_block.text = json.dumps(valid_llm_response)
-        mock_anthropic_response.content = [EmptyBlock(), mock_text_block]
-
-        analyzer = PageAnalyzer(api_key="test-key")
-        analyzer._client.messages.create = AsyncMock(return_value=mock_anthropic_response)
-
-        result = await analyzer._extract_profile_with_llm(
-            "https://example.com/blog",
-            "<html></html>",
-        )
-
-        assert result["site_name"] == "Test Blog"
-
     async def test_extract_profile_sanitizes_control_characters_from_url(
-        self, valid_llm_response: dict
+        self, valid_llm_response: dict, mock_llm_client
     ) -> None:
-        mock_anthropic_response = MagicMock()
-        mock_text_block = MagicMock()
-        mock_text_block.text = json.dumps(valid_llm_response)
-        mock_anthropic_response.content = [mock_text_block]
+        mock_llm_client.complete.return_value = json.dumps(valid_llm_response)
 
-        analyzer = PageAnalyzer(api_key="test-key")
-        analyzer._client.messages.create = AsyncMock(return_value=mock_anthropic_response)
+        analyzer = PageAnalyzer(llm_client=mock_llm_client)
 
         await analyzer._extract_profile_with_llm(
             "https://example.com/\x00blog\x7f",
             "<html></html>",
         )
 
-        user_prompt = analyzer._client.messages.create.await_args.kwargs["messages"][0]["content"]
+        user_prompt = mock_llm_client.complete.await_args.kwargs["user_message"]
         assert "URL: https://example.com/blog" in user_prompt
         assert "\x00" not in user_prompt
         assert "\x7f" not in user_prompt
 
-    def test_validate_profile_invalid_post_selector(self, sample_html: str) -> None:
+    def test_validate_profile_invalid_post_selector(
+        self, sample_html: str, mock_llm_client
+    ) -> None:
         profile = ExtractionProfile(
             site_name="Test",
             post_selector="[invalid selector syntax",
@@ -467,13 +408,15 @@ class TestPageAnalyzer:
             url_selector="a",
             url_attribute="href",
         )
-        analyzer = PageAnalyzer(api_key="test-key")
+        analyzer = PageAnalyzer(llm_client=mock_llm_client)
         result = analyzer._validate_profile(sample_html, profile)
 
         assert result["valid"] is False
         assert "Invalid CSS selector" in result["reason"]
 
-    def test_validate_profile_rejects_posts_with_links_missing_url_attribute(self) -> None:
+    def test_validate_profile_rejects_posts_with_links_missing_url_attribute(
+        self, mock_llm_client
+    ) -> None:
         html = """
         <html>
         <body>
@@ -491,14 +434,16 @@ class TestPageAnalyzer:
             url_selector="a.post-link",
             url_attribute="href",
         )
-        analyzer = PageAnalyzer(api_key="test-key")
+        analyzer = PageAnalyzer(llm_client=mock_llm_client)
 
         result = analyzer._validate_profile(html, profile)
 
         assert result["valid"] is False
         assert "Could not extract" in result["reason"]
 
-    def test_validate_profile_invalid_title_selector(self, sample_html: str) -> None:
+    def test_validate_profile_invalid_title_selector(
+        self, sample_html: str, mock_llm_client
+    ) -> None:
         profile = ExtractionProfile(
             site_name="Test",
             post_selector="article.post-card",
@@ -506,7 +451,7 @@ class TestPageAnalyzer:
             url_selector="a.post-link",
             url_attribute="href",
         )
-        analyzer = PageAnalyzer(api_key="test-key")
+        analyzer = PageAnalyzer(llm_client=mock_llm_client)
         result = analyzer._validate_profile(sample_html, profile)
 
         assert result["valid"] is False

--- a/tests/test_services/test_pipeline.py
+++ b/tests/test_services/test_pipeline.py
@@ -16,7 +16,9 @@ from intelstream.services.summarizer import SummarizationError, SummarizationSer
 def mock_settings():
     settings = MagicMock(spec=Settings)
     settings.youtube_api_key = "test-youtube-key"
-    settings.anthropic_api_key = "test-anthropic-key"
+    settings.llm_provider = "openai"
+    settings.llm_api_key = "test-openai-key"
+    settings.summary_model = "gpt-5.6-luna"
     settings.twitter_bearer_token = None
     settings.http_timeout_seconds = 30.0
     settings.summarization_delay_seconds = 0.5
@@ -131,7 +133,9 @@ class TestContentPipelineInitialization:
     async def test_initialize_without_youtube_key(self, mock_repository, mock_summarizer):
         settings = MagicMock(spec=Settings)
         settings.youtube_api_key = None
-        settings.anthropic_api_key = "test-anthropic-key"
+        settings.llm_provider = "openai"
+        settings.llm_api_key = "test-openai-key"
+        settings.summary_model = "gpt-5.6-luna"
         settings.twitter_bearer_token = None
         settings.http_timeout_seconds = 30.0
         settings.summarization_delay_seconds = 0.5
@@ -152,7 +156,9 @@ class TestContentPipelineInitialization:
     async def test_initialize_creates_twitter_adapter(self, mock_repository, mock_summarizer):
         settings = MagicMock(spec=Settings)
         settings.youtube_api_key = "test-key"
-        settings.anthropic_api_key = "test-key"
+        settings.llm_provider = "openai"
+        settings.llm_api_key = "test-openai-key"
+        settings.summary_model = "gpt-5.6-luna"
         settings.twitter_bearer_token = "test-twitter-key"
         settings.http_timeout_seconds = 30.0
         settings.summarization_delay_seconds = 0.5
@@ -170,7 +176,9 @@ class TestContentPipelineInitialization:
     async def test_initialize_without_twitter_key(self, mock_repository, mock_summarizer):
         settings = MagicMock(spec=Settings)
         settings.youtube_api_key = "test-key"
-        settings.anthropic_api_key = "test-key"
+        settings.llm_provider = "openai"
+        settings.llm_api_key = "test-openai-key"
+        settings.summary_model = "gpt-5.6-luna"
         settings.twitter_bearer_token = None
         settings.http_timeout_seconds = 30.0
         settings.summarization_delay_seconds = 0.5
@@ -205,32 +213,33 @@ class TestContentPipelineInitialization:
         for adapter in adapters:
             adapter.close.assert_awaited_once()
 
-    async def test_close_closes_owned_anthropic_client_once(
+    async def test_close_closes_owned_llm_client_once(
         self,
         pipeline: ContentPipeline,
     ):
-        anthropic_client = MagicMock()
-        anthropic_client.close = AsyncMock()
+        llm_client = MagicMock()
+        llm_client.close = AsyncMock()
 
         with patch(
-            "intelstream.services.pipeline.anthropic.AsyncAnthropic",
-            return_value=anthropic_client,
+            "intelstream.services.pipeline.create_llm_client",
+            return_value=llm_client,
         ):
             await pipeline.initialize()
 
         await pipeline.close()
         await pipeline.close()
 
-        anthropic_client.close.assert_awaited_once()
+        llm_client.close.assert_awaited_once()
 
-    async def test_close_does_not_create_anthropic_client_when_absent(
+    async def test_close_does_not_create_llm_client_when_unconfigured(
         self,
         mock_repository,
         mock_summarizer,
     ):
         settings = MagicMock(spec=Settings)
         settings.youtube_api_key = "test-key"
-        settings.anthropic_api_key = None
+        settings.llm_provider = "openai"
+        settings.llm_api_key = None
         settings.twitter_bearer_token = None
         settings.http_timeout_seconds = 30.0
         settings.summarization_delay_seconds = 0.5
@@ -240,18 +249,21 @@ class TestContentPipelineInitialization:
             settings=settings, repository=mock_repository, summarizer=mock_summarizer
         )
 
-        with patch("intelstream.services.pipeline.anthropic.AsyncAnthropic") as cls:
+        with patch("intelstream.services.pipeline.create_llm_client") as cls:
             await pipeline.initialize()
+
+            assert SourceType.BLOG not in pipeline._adapters
             await pipeline.close()
 
         cls.assert_not_called()
 
 
-class TestCreateAdaptersWithoutAnthropicKey:
-    async def test_no_blog_adapter_without_anthropic_key(self, mock_repository, mock_summarizer):
+class TestCreateAdaptersWithoutLLMKey:
+    async def test_no_blog_adapter_without_llm_key(self, mock_repository, mock_summarizer):
         settings = MagicMock(spec=Settings)
         settings.youtube_api_key = "test-key"
-        settings.anthropic_api_key = None
+        settings.llm_provider = "openai"
+        settings.llm_api_key = None
         settings.twitter_bearer_token = None
         settings.http_timeout_seconds = 30.0
         settings.summarization_delay_seconds = 0.5
@@ -267,10 +279,11 @@ class TestCreateAdaptersWithoutAnthropicKey:
 
         await pipeline.close()
 
-    async def test_no_blog_adapter_with_empty_anthropic_key(self, mock_repository, mock_summarizer):
+    async def test_no_blog_adapter_with_empty_llm_key(self, mock_repository, mock_summarizer):
         settings = MagicMock(spec=Settings)
         settings.youtube_api_key = "test-key"
-        settings.anthropic_api_key = "  "
+        settings.llm_provider = "openai"
+        settings.llm_api_key = ""
         settings.twitter_bearer_token = None
         settings.http_timeout_seconds = 30.0
         settings.summarization_delay_seconds = 0.5
@@ -517,7 +530,9 @@ class TestFetchAllSources:
         """Verify that fetch_delay_seconds is applied between source fetches."""
         settings = MagicMock(spec=Settings)
         settings.youtube_api_key = "test-key"
-        settings.anthropic_api_key = "test-key"
+        settings.llm_provider = "openai"
+        settings.llm_api_key = "test-openai-key"
+        settings.summary_model = "gpt-5.6-luna"
         settings.twitter_bearer_token = None
         settings.http_timeout_seconds = 30.0
         settings.summarization_delay_seconds = 0.5


### PR DESCRIPTION
## Why

Blog and page sources were hardwired to Anthropic: `SmartBlogAdapter`, `LLMExtractionStrategy`, `PageAnalyzer`, the pipeline's BLOG adapter wiring, and the `/source add` guards all required `ANTHROPIC_API_KEY` specifically. With no Anthropic account in play (and the bot otherwise running on the configurable `llm_provider` setting), these 7 sources were dead unless Anthropic was configured.

## What changed

- `SmartBlogAdapter`, `LLMExtractionStrategy`, `PageAnalyzer` now take the unified `LLMClient` (`services/llm_client.py`) instead of `anthropic.AsyncAnthropic`. Anthropic stays supported as one provider among four (anthropic/openai/gemini/kimi); nothing here is Anthropic-specific anymore.
- `ContentPipeline` builds the extraction client from the configured provider (`llm_provider` + `llm_api_key` + `summary_model`) and owns its lifecycle, same as the old Anthropic client.
- `SourceManagement` cog caches per-model `LLMClient`s and closes them on unload: blog site analysis uses `summary_model` (was hardcoded haiku), page analysis uses `summary_model_interactive` (was hardcoded sonnet) — same cheap/smart tier split as before.
- Key-availability guards in `/source add` are now provider-agnostic ("No LLM API key configured") and cover missing/empty keys.
- Rate-limit retry and error mapping now go through `LLMRateLimitError`/`LLMError` with identical semantics to the old Anthropic exception handling.

## Testing

- Updated the affected test files to mock `LLMClient.complete` (plain string return — simpler than the old content-block mocks); removed tests that covered deleted behavior (content-block filtering, client-ownership close).
- `ruff check`, `ruff format --check`, `mypy src/` clean; full suite: **1884 passed**.

## Notes

- No config changes required; Anthropic remains an option via `LLM_PROVIDER=anthropic`.
- Operational follow-ups (tracked separately in planning notes): re-enabling the bot with an OpenAI key needs a backlog flush first (~60k unsummarized items would flood), and gpt-5.6-luna being a reasoning model may warrant a reasoning-effort parameter in `OpenAILLMClient` later.